### PR TITLE
fix(web): correct Recharts XAxis and YAxis props in budget analytics

### DIFF
--- a/apps/web/src/components/budgets/budget-analytics.tsx
+++ b/apps/web/src/components/budgets/budget-analytics.tsx
@@ -155,8 +155,8 @@ export function BudgetAnalytics({ spaceId, budgetId, currency }: BudgetAnalytics
                   margin={{ top: 20, right: 30, left: 20, bottom: 5 }}
                 >
                   <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="name" fontSize={12} angle={-45} textAnchor="end" height={80} />
-                  <YAxis fontSize={12} />
+                  <XAxis dataKey="name" tick={{ fontSize: 12, angle: -45, textAnchor: 'end' }} height={80} />
+                  <YAxis tick={{ fontSize: 12 }} />
                   <Tooltip
                     formatter={(value: number) => [formatCurrency(value, currency), '']}
                     labelStyle={{ color: '#000' }}
@@ -213,8 +213,8 @@ export function BudgetAnalytics({ spaceId, budgetId, currency }: BudgetAnalytics
                   margin={{ top: 20, right: 30, left: 20, bottom: 5 }}
                 >
                   <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="week" fontSize={12} />
-                  <YAxis fontSize={12} />
+                  <XAxis dataKey="week" tick={{ fontSize: 12 }} />
+                  <YAxis tick={{ fontSize: 12 }} />
                   <Tooltip
                     formatter={(value: number) => [formatCurrency(value, currency), '']}
                     labelStyle={{ color: '#000' }}


### PR DESCRIPTION
Fix TypeScript compilation error by using the correct Recharts API. The fontSize, angle, and textAnchor props need to be passed through the tick prop object instead of as direct props on XAxis/YAxis.

This resolves the Vercel build failure where the build was failing with "Property 'fontSize' does not exist" errors.