### PR TITLE
fix: add missing build:packages script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "dev": "turbo dev",
     "build": "turbo build",
+    "build:packages": "turbo build --filter='./packages/*'",
     "test": "turbo test",
     "lint": "turbo lint",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",


### PR DESCRIPTION
Added build:packages script to root package.json to build only packages in the monorepo using Turborepo's filter feature. This resolves the Type Check task error where the command was not found.

The script uses `turbo build --filter='./packages/*'` to build all workspace packages without building apps.