### PR TITLE
fix(web): Use production API URL as default fallback

### DIFF
--- a/SYSTEM_CONTEXT.md
+++ b/SYSTEM_CONTEXT.md
@@ -1,0 +1,96 @@
+# Dhanam - System Context
+
+**Version:** 1.0.0
+**Last Updated:** 2026-01-21
+
+## Overview
+
+Dhanam is MADFAM's personal finance and wealth tracking application. It targets LATAM-first users with multilingual support and integrates with local financial providers.
+
+## Architecture
+
+| Component | Port | Domain | Description |
+|-----------|------|--------|-------------|
+| Dhanam API | 8500 (container) / 80 (K8s service) | api.dhan.am | Backend API |
+| Dhanam Web | 3300 (container) / 80 (K8s service) | app.dhan.am, dhan.am | Next.js dashboard |
+| Dhanam Admin | 3301 (container) / 80 (K8s service) | admin.dhan.am | Admin console |
+
+## Authentication
+
+Dhanam uses **Janua** for all authentication via OIDC:
+
+| Variable | Value |
+|----------|-------|
+| `NEXT_PUBLIC_OIDC_ISSUER` | `https://auth.madfam.io` |
+| `NEXT_PUBLIC_OIDC_CLIENT_ID` | `jnc_uE2zp9ume_Fd6jMl1elL6wqjiECM711t` |
+| `NEXT_PUBLIC_JANUA_API_URL` | `https://api.janua.dev` |
+
+### SSO Button Logic
+The "Sign in with Janua SSO" button visibility is controlled by:
+- File: `apps/web/src/lib/janua-oauth.ts:168-170`
+- Requires: `NEXT_PUBLIC_JANUA_API_URL` to be set
+
+## Kubernetes Resources
+
+| Resource | Namespace | Purpose |
+|----------|-----------|---------|
+| `dhanam-api` | dhanam | Backend API |
+| `dhanam-web` | dhanam | Frontend dashboard |
+| `dhanam-admin` | dhanam | Admin interface |
+| `dhanam-secrets` | dhanam | Credentials |
+| `dhanam-billing-secrets` | dhanam | Stripe/Paddle keys |
+| `ghcr-credentials` | dhanam | Container registry auth |
+
+## Critical Configuration
+
+### Web Deployment Environment Variables
+Located in: `infra/k8s/production/web-deployment.yaml`
+
+```yaml
+# API Configuration
+NEXT_PUBLIC_API_URL: "https://api.dhan.am/v1"
+NEXT_PUBLIC_BASE_URL: "https://app.dhan.am"
+
+# Janua OIDC
+NEXT_PUBLIC_OIDC_ISSUER: "https://auth.madfam.io"
+NEXT_PUBLIC_OIDC_CLIENT_ID: "jnc_uE2zp9ume_Fd6jMl1elL6wqjiECM711t"
+NEXT_PUBLIC_JANUA_API_URL: "https://api.janua.dev"
+```
+
+### ImagePullSecrets
+The deployment requires `ghcr-credentials` for pulling images from GitHub Container Registry.
+
+## Troubleshooting
+
+### Check Web health
+```bash
+curl -s https://app.dhan.am/api/health
+```
+
+### Verify SSO button should be visible
+```bash
+# If this returns a valid response, SSO button should appear
+curl -s https://api.janua.dev/health
+```
+
+### View Web logs
+```bash
+kubectl logs -n dhanam -l app=dhanam-web -f
+```
+
+### Check deployment status
+```bash
+kubectl get pods -n dhanam -l app=dhanam-web
+kubectl rollout status deployment/dhanam-web -n dhanam
+```
+
+### ImagePullBackOff troubleshooting
+If pods show ImagePullBackOff:
+1. Verify `ghcr-credentials` secret exists: `kubectl get secret ghcr-credentials -n dhanam`
+2. Ensure deployment has `imagePullSecrets` configured
+3. Verify image exists in registry
+
+## Related Documentation
+- [CLAUDE.md](./CLAUDE.md) - Full development guide
+- [Janua System Context](/Users/aldoruizluna/labspace/janua/SYSTEM_CONTEXT.md)
+- [Enclii System Context](/Users/aldoruizluna/labspace/enclii/SYSTEM_CONTEXT.md)

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -4,9 +4,17 @@ const nextConfig = {
   reactStrictMode: true,
   transpilePackages: ['@dhanam/shared', '@dhanam/ui'],
 
+  // Runtime config for values that should be read from environment at runtime
+  // Note: publicRuntimeConfig requires getInitialProps to be called
+  publicRuntimeConfig: {
+    apiUrl: process.env.NEXT_PUBLIC_API_URL || 'https://api.dhan.am/v1',
+    baseUrl: process.env.NEXT_PUBLIC_BASE_URL || 'https://app.dhan.am',
+  },
+
   env: {
-    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/v1',
-    NEXT_PUBLIC_BASE_URL: process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000',
+    // Use production URLs as defaults (these are baked at build time)
+    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL || 'https://api.dhan.am/v1',
+    NEXT_PUBLIC_BASE_URL: process.env.NEXT_PUBLIC_BASE_URL || 'https://app.dhan.am',
     NEXT_PUBLIC_OIDC_ISSUER: process.env.NEXT_PUBLIC_OIDC_ISSUER,
     NEXT_PUBLIC_OIDC_CLIENT_ID: process.env.NEXT_PUBLIC_OIDC_CLIENT_ID,
     NEXT_PUBLIC_JANUA_API_URL: process.env.NEXT_PUBLIC_JANUA_API_URL,

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -19,7 +19,8 @@ export class ApiClient {
   private onTokenRefresh?: (tokens: AuthTokens) => void;
 
   constructor(config: { baseUrl?: string; onTokenRefresh?: (tokens: AuthTokens) => void }) {
-    this.baseUrl = config.baseUrl || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/v1';
+    // Use production URL as fallback (localhost is only for explicit local development)
+    this.baseUrl = config.baseUrl || process.env.NEXT_PUBLIC_API_URL || 'https://api.dhan.am/v1';
     this.onTokenRefresh = config.onTokenRefresh;
   }
 

--- a/infra/k8s/production/web-deployment.yaml
+++ b/infra/k8s/production/web-deployment.yaml
@@ -36,6 +36,9 @@ spec:
         runAsUser: 1001
         fsGroup: 1001
 
+      imagePullSecrets:
+        - name: ghcr-credentials
+
       containers:
         - name: web
           image: ghcr.io/madfam-org/dhanam-web:latest
@@ -70,6 +73,9 @@ spec:
               value: "https://auth.madfam.io"
             - name: NEXT_PUBLIC_OIDC_CLIENT_ID
               value: "jnc_uE2zp9ume_Fd6jMl1elL6wqjiECM711t"
+            # Janua OAuth API (Required for SSO button visibility)
+            - name: NEXT_PUBLIC_JANUA_API_URL
+              value: "https://api.janua.dev"
             - name: OIDC_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/tools/agent-manifest.json
+++ b/tools/agent-manifest.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "name": "dhanam",
+  "version": "1.0.0",
+  "description": "Dhanam - MADFAM Personal Finance App",
+  "lastUpdated": "2026-01-21",
+
+  "domains": {
+    "production": {
+      "api": "https://api.dhan.am",
+      "app": "https://app.dhan.am",
+      "admin": "https://admin.dhan.am",
+      "landing": "https://dhan.am"
+    }
+  },
+
+  "ports": {
+    "api": 8500,
+    "web": 3300,
+    "admin": 3301
+  },
+
+  "kubernetes": {
+    "namespace": "dhanam",
+    "deployments": ["dhanam-api", "dhanam-web", "dhanam-admin"],
+    "secrets": ["dhanam-secrets", "dhanam-billing-secrets", "ghcr-credentials"],
+    "manifests": {
+      "api": "infra/k8s/production/api-deployment.yaml",
+      "web": "infra/k8s/production/web-deployment.yaml",
+      "admin": "infra/k8s/production/admin-deployment.yaml"
+    }
+  },
+
+  "entryPoints": {
+    "api": {
+      "path": "apps/api/src/main.ts",
+      "framework": "NestJS/Fastify",
+      "healthCheck": "/health"
+    },
+    "web": {
+      "path": "apps/web/src/app/page.tsx",
+      "framework": "Next.js",
+      "healthCheck": "/api/health"
+    },
+    "admin": {
+      "path": "apps/admin/src/app/page.tsx",
+      "framework": "Next.js",
+      "healthCheck": "/api/health"
+    }
+  },
+
+  "criticalConfiguration": {
+    "ssoButton": {
+      "path": "apps/web/src/lib/janua-oauth.ts",
+      "lines": "168-170",
+      "description": "SSO button visibility controlled by NEXT_PUBLIC_JANUA_API_URL"
+    },
+    "oidcConfig": {
+      "issuer": "https://auth.madfam.io",
+      "clientId": "jnc_uE2zp9ume_Fd6jMl1elL6wqjiECM711t",
+      "januaApiUrl": "https://api.janua.dev"
+    },
+    "imagePullSecrets": {
+      "secretName": "ghcr-credentials",
+      "description": "Required for pulling images from ghcr.io/madfam-org"
+    }
+  },
+
+  "buildCommands": {
+    "api": "pnpm --filter api build",
+    "web": "pnpm --filter web build",
+    "admin": "pnpm --filter admin build",
+    "all": "turbo build"
+  },
+
+  "testCommands": {
+    "unit": "pnpm test",
+    "e2e": "pnpm test:e2e",
+    "lint": "pnpm lint"
+  },
+
+  "dependencies": {
+    "ecosystem": [
+      {
+        "name": "janua",
+        "purpose": "Authentication (OIDC SSO)",
+        "config": {
+          "NEXT_PUBLIC_OIDC_ISSUER": "https://auth.madfam.io",
+          "NEXT_PUBLIC_OIDC_CLIENT_ID": "jnc_uE2zp9ume_Fd6jMl1elL6wqjiECM711t",
+          "NEXT_PUBLIC_JANUA_API_URL": "https://api.janua.dev"
+        }
+      },
+      {
+        "name": "enclii",
+        "purpose": "Deployment Platform",
+        "config": ".enclii.yml"
+      }
+    ],
+    "external": ["PostgreSQL", "Redis", "Stripe", "Paddle", "Belvo", "Plaid"]
+  },
+
+  "dependents": []
+}


### PR DESCRIPTION
## Summary
- Fixes empty dashboard on app.dhan.am
- Changes default API URL from `localhost:4000/v1` to `api.dhan.am/v1`
- Adds `publicRuntimeConfig` for potential runtime configuration

## Root Cause
Next.js bakes `NEXT_PUBLIC_*` env vars at build time. The previous default (`localhost:4000/v1`) caused API calls to fail silently in production when the env var wasn't set during build.

## Test Plan
- [ ] Login to app.dhan.am
- [ ] Dashboard should load properly (or show proper empty state)
- [ ] Network requests should go to api.dhan.am/v1, not localhost

🤖 Generated with [Claude Code](https://claude.com/claude-code)