### PR TITLE
fix(web): resolve dashboard hydration mismatch and i18n namespace bug

### DIFF
--- a/packages/shared/src/hooks/useTranslation.ts
+++ b/packages/shared/src/hooks/useTranslation.ts
@@ -11,7 +11,7 @@ import { useContext } from 'react';
 import { I18nContext } from '../contexts/I18nContext';
 import type { TranslationNamespace } from '../i18n';
 
-export function useTranslation(_namespace?: TranslationNamespace) {
+export function useTranslation(namespace?: TranslationNamespace) {
   const context = useContext(I18nContext);
 
   if (!context) {
@@ -22,19 +22,25 @@ export function useTranslation(_namespace?: TranslationNamespace) {
 
   /**
    * Translate a key
-   * @param key - Translation key in dot notation (e.g., "common.save")
+   * @param key - Translation key in dot notation (e.g., "save" or "common.save")
    * @param params - Optional parameters for interpolation
+   *
+   * If a namespace was provided to useTranslation, keys without dots will be
+   * prefixed with the namespace (e.g., "loginTitle" becomes "auth.loginTitle").
+   * Keys with dots are used as-is for full path access.
    */
   const t = (key: string, params?: Record<string, string | number>): string => {
-    const keys = key.split('.');
+    // If namespace provided and key doesn't contain a dot, prepend namespace
+    const fullKey = namespace && !key.includes('.') ? `${namespace}.${key}` : key;
+    const keys = fullKey.split('.');
     let value: any = translations[locale];
 
     // Navigate through the nested object
     for (const k of keys) {
       value = value?.[k];
       if (value === undefined) {
-        console.warn(`Translation key not found: ${key} for locale: ${locale}`);
-        return key;
+        console.warn(`Translation key not found: ${fullKey} for locale: ${locale}`);
+        return key; // Return original key (without namespace) for display
       }
     }
 


### PR DESCRIPTION
## Summary
- Add `hasMounted` state pattern to prevent SSR/client hydration mismatch in dashboard layout
- Show loading skeleton during initial render (same content on server and client)
- Only check auth state after client hydration completes
- Fix `useTranslation` hook to properly use namespace parameter

## Root Cause
The dashboard layout was returning `null` when `!isAuthenticated`. During SSR, there's no localStorage, so `isAuthenticated` is always false. The server rendered nothing, but the client expected to render the dashboard after hydrating Zustand from localStorage. This mismatch caused React Error #418 (hydration mismatch) and the entire page failed to render.

## Changes
1. **Dashboard layout** (`apps/web/src/app/(dashboard)/layout.tsx`):
   - Added `DashboardSkeleton` component for loading state
   - Added `hasMounted` state to track client hydration
   - Render skeleton during SSR and initial hydration (prevents mismatch)
   - Only check auth and redirect after mount

2. **useTranslation hook** (`packages/shared/src/hooks/useTranslation.ts`):
   - Fixed namespace parameter which was previously ignored
   - `useTranslation('auth')` + `t('loginTitle')` now correctly looks up `auth.loginTitle`

## Test plan
- [ ] Login via Janua SSO at app.dhan.am/login
- [ ] After callback, dashboard should render (not blank)
- [ ] Translation keys should show proper text, not raw keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)