### PR TITLE
fix(web): send empty object for POST/PATCH/PUT without body

### DIFF
--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -113,21 +113,24 @@ export class ApiClient {
   async post<T>(path: string, body?: unknown): Promise<T> {
     return this.request<T>(path, {
       method: 'POST',
-      body: body ? JSON.stringify(body) : undefined,
+      // Always send a body for POST to avoid Fastify "empty body" errors
+      body: JSON.stringify(body ?? {}),
     });
   }
 
   async patch<T>(path: string, body?: unknown): Promise<T> {
     return this.request<T>(path, {
       method: 'PATCH',
-      body: body ? JSON.stringify(body) : undefined,
+      // Always send a body for PATCH to avoid Fastify "empty body" errors
+      body: JSON.stringify(body ?? {}),
     });
   }
 
   async put<T>(path: string, body?: unknown): Promise<T> {
     return this.request<T>(path, {
       method: 'PUT',
-      body: body ? JSON.stringify(body) : undefined,
+      // Always send a body for PUT to avoid Fastify "empty body" errors
+      body: JSON.stringify(body ?? {}),
     });
   }
 


### PR DESCRIPTION
## Summary
- Fix Fastify "empty body" error when making POST/PATCH/PUT requests without a body
- The API client always sets `Content-Type: application/json`, but Fastify rejects empty JSON bodies
- Now sends `{}` as default body when none is provided

## Root Cause
The `/auth/guest` endpoint was returning 500 because:
1. `apiClient.post('/auth/guest')` was called without a body parameter
2. The client sent `Content-Type: application/json` header but no body
3. Fastify's JSON parser threw: "Body cannot be empty when content-type is set to 'application/json'"

## Changes
- `post()`: `body: JSON.stringify(body ?? {})`
- `patch()`: `body: JSON.stringify(body ?? {})`
- `put()`: `body: JSON.stringify(body ?? {})`

## Test plan
- [ ] Try Demo button on login page should work (calls `/auth/guest`)
- [ ] Other POST endpoints should continue working

🤖 Generated with [Claude Code](https://claude.com/claude-code)