### PR TITLE
fix(web): resolve Zustand hydration race condition

### DIFF
--- a/apps/web/src/app/(dashboard)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/layout.tsx
@@ -29,7 +29,7 @@ function DashboardSkeleton() {
 }
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, _hasHydrated } = useAuth();
   const router = useRouter();
   // Track if client has hydrated - prevents SSR/client mismatch
   const [hasMounted, setHasMounted] = useState(false);
@@ -39,16 +39,21 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
     setHasMounted(true);
   }, []);
 
-  // Redirect unauthenticated users after mount
+  // Redirect unauthenticated users after Zustand hydration is complete
   useEffect(() => {
-    if (hasMounted && !isAuthenticated) {
+    if (hasMounted && _hasHydrated && !isAuthenticated) {
       router.push('/login');
     }
-  }, [hasMounted, isAuthenticated, router]);
+  }, [hasMounted, _hasHydrated, isAuthenticated, router]);
 
   // Show skeleton during SSR and initial hydration
   // This ensures server and client render the same content initially
   if (!hasMounted) {
+    return <DashboardSkeleton />;
+  }
+
+  // Wait for Zustand to hydrate from localStorage before deciding
+  if (!_hasHydrated) {
     return <DashboardSkeleton />;
   }
 

--- a/apps/web/src/lib/hooks/use-auth.ts
+++ b/apps/web/src/lib/hooks/use-auth.ts
@@ -10,6 +10,7 @@ interface AuthState {
   token: string | null;
   isAuthenticated: boolean;
   isLoading: boolean;
+  _hasHydrated: boolean;
 
   setAuth: (user: UserProfile, tokens: AuthTokens) => void;
   clearAuth: () => void;
@@ -17,6 +18,7 @@ interface AuthState {
   refreshTokens: () => Promise<void>;
   refreshUser: () => Promise<void>;
   getToken: () => Promise<string | null>;
+  setHasHydrated: (state: boolean) => void;
 }
 
 export const useAuth = create<AuthState>()(
@@ -27,6 +29,11 @@ export const useAuth = create<AuthState>()(
       token: null,
       isAuthenticated: false,
       isLoading: false,
+      _hasHydrated: false,
+
+      setHasHydrated: (state) => {
+        set({ _hasHydrated: state });
+      },
 
       setAuth: (user, tokens) => {
         apiClient.setTokens(tokens);
@@ -98,6 +105,8 @@ export const useAuth = create<AuthState>()(
         if (state?.tokens) {
           apiClient.setTokens(state.tokens);
         }
+        // Mark hydration as complete
+        useAuth.getState().setHasHydrated(true);
       },
     }
   )


### PR DESCRIPTION
## Summary
- Add `_hasHydrated` state tracking to auth store
- Wait for Zustand localStorage rehydration before checking auth status
- Fixes dashboard showing skeleton indefinitely for authenticated users

## Problem
The dashboard layout was checking `isAuthenticated` from Zustand store before the store had finished rehydrating from localStorage. This caused authenticated users to see a permanent skeleton because:
1. Server renders skeleton (no localStorage on server)
2. Client mounts with skeleton (SSR match)
3. `isAuthenticated` check runs before Zustand rehydrates → returns `false`
4. Dashboard stays in skeleton state forever

## Solution
Track hydration completion with `_hasHydrated` state that's set to `true` in the `onRehydrateStorage` callback, and wait for this before making auth decisions.

## Test plan
- [x] Login via Janua SSO
- [ ] Dashboard should show actual content after redirect (not skeleton)
- [ ] Unauthenticated users should still redirect to login

🤖 Generated with [Claude Code](https://claude.com/claude-code)