### PR TITLE
fix(migration): remove CONCURRENTLY from fulltext search indexes

### DIFF
--- a/apps/api/prisma/migrations/20260315000001_add_fulltext_search/migration.sql
+++ b/apps/api/prisma/migrations/20260315000001_add_fulltext_search/migration.sql
@@ -2,9 +2,9 @@
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
 -- GIN trigram index on transaction description for fuzzy search
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_txn_description_trgm
+CREATE INDEX IF NOT EXISTS idx_txn_description_trgm
   ON transactions USING GIN (description gin_trgm_ops);
 
 -- GIN trigram index on transaction merchant for fuzzy search
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_txn_merchant_trgm
+CREATE INDEX IF NOT EXISTS idx_txn_merchant_trgm
   ON transactions USING GIN (merchant gin_trgm_ops);


### PR DESCRIPTION
## Summary

- Remove `CONCURRENTLY` from both `CREATE INDEX` statements in migration `20260315000001_add_fulltext_search`
- `CREATE INDEX CONCURRENTLY` cannot run inside a PostgreSQL transaction — Prisma wraps all migrations in transactions by default, causing P3009 failure
- This blocks all deployments: init container runs `prisma migrate deploy`, hits the failed migration, and crashes → `Init:CrashLoopBackOff`

## Fix

Normal `CREATE INDEX` (without `CONCURRENTLY`) works inside transactions. Brief table lock during index creation is acceptable — old pods continue serving traffic.

## Deployment steps

After merging:
1. **Before CI deploys**: mark the failed migration as rolled back on the cluster:
   ```bash
   kubectl exec -n dhanam <running-pod> -- npx prisma migrate resolve --rolled-back 20260315000001_add_fulltext_search --schema=prisma/schema.prisma
   ```
2. CI builds new image → pushes digest → ArgoCD syncs → init container re-runs migration successfully
3. Verify: all pods Running, `api.dhan.am/health` → 200, indexes exist on `transactions` table

## Test plan

- [x] Migration SQL valid (no `CONCURRENTLY` keyword)
- [ ] `prisma migrate resolve --rolled-back` executed on cluster
- [ ] ArgoCD shows `Synced Healthy` after deploy
- [ ] All dhanam-api pods Running (no CrashLoopBackOff)
- [ ] `api.dhan.am/health` → 200
- [ ] pg_trgm indexes exist on transactions table

🤖 Generated with [Claude Code](https://claude.com/claude-code)