### PR TITLE
feat(infra): pp.2 dhanam staging audit + rfc 0001 alignment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,6 +321,59 @@ Uses the Dhanam package (https://github.com/aldoruizluna/Dhanam) for:
 - **Staging**: `infra/k8s/staging/` — 1 replica, `:main` image tags, auto-deployed on push to main
 - **ArgoCD**: GitOps sync from `infra/k8s/production/` with auto-sync, prune, and self-heal
 
+## Deployment Pipeline (dev → staging → prod)
+
+Dhanam is a **Phase 2** target (billing/MXN-ingress priority) for the 3-tier
+pipeline defined in
+[internal-devops/rfcs/0001-dev-staging-prod-pipeline.md](https://github.com/madfam-org/internal-devops/blob/main/rfcs/0001-dev-staging-prod-pipeline.md).
+
+**Current state:** staging exists and auto-deploys on every push to `main`,
+but does not yet follow the RFC shape. See
+[docs/PP_2_STAGING_AUDIT.md](docs/PP_2_STAGING_AUDIT.md) for the full row-by-row
+gap analysis.
+
+### Known divergences from RFC 0001 (tracked in PP_2_STAGING_AUDIT.md)
+
+| Divergence                                                               | Impact                                                                                        | Resolution PR                                        |
+| ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| Staging manifests are duplicated from production (not overlays)          | Maintenance burden; drift risk                                                                | PP.2b                                                |
+| Staging image tag is `:main` (mutable), not digest-pinned                | "The image that passed staging" is not identifiable — breaks RFC's "one image, promoted" rule | PP.2b                                                |
+| No `promote-to-prod.yml` or `rollback-prod.yml` workflow                 | Prod consumes CI builds directly, not staging-validated digests                               | PP.2c                                                |
+| `deploy-staging.yml` does `kubectl apply -k` instead of ArgoCD reconcile | Push-based staging deploy vs pull-based GitOps                                                | PP.2b                                                |
+| No ArgoCD Application for staging                                        | `infra/argocd/config.json` only registers the prod App                                        | PP.2b (infra action)                                 |
+| Admin app not included in staging overlay                                | Admin ships straight to prod with no staging soak                                             | PP.2b                                                |
+| No staging ingress / DNS (`staging-api.dhan.am`)                         | Staging is namespace-internal; can't run cross-service smoke                                  | PP.2b (+ Cloudflare ops)                             |
+| Nightly prod→staging masked DB refresh not implemented                   | Staging data is hand-seeded; migrations don't see prod-shaped volumes                         | Deferred (RFC 0001 open question — masking tool TBD) |
+
+### Promotion pattern (when PP.2c lands)
+
+Dhanam is **Pattern B — manual gate** per RFC 0001. Reasoning: Dhanam is the
+billing boundary for the MADFAM ecosystem (Stripe MX, SPEI, Paddle, webhook
+relay to Karafiel for CFDI issuance). A wrong promote is expensive.
+
+When PP.2c ships, `.enclii.yml` will declare:
+
+```yaml
+promotion:
+  pattern: manual
+  min_soak_minutes: 30
+  require_smoke_pass: true
+```
+
+### What currently ships on push to `main`
+
+| Workflow               | Trigger                    | Effect                                                                                                |
+| ---------------------- | -------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `deploy-staging.yml`   | push to main               | `kubectl apply -k infra/k8s/staging/` → `dhanam-staging` namespace, `:main` tag                       |
+| `deploy-k8s.yml` (API) | push to main (api paths)   | Builds + pushes image, commits digest to `infra/k8s/production/kustomization.yaml`, ArgoCD syncs prod |
+| `deploy-web-k8s.yml`   | push to main (web paths)   | Same pattern for `dhanam-web`                                                                         |
+| `deploy-admin-k8s.yml` | push to main (admin paths) | Same pattern for `dhanam-admin`                                                                       |
+| `deploy-enclii.yml`    | push to main               | Enclii auto-deploy (primary production path per MADFAM ecosystem)                                     |
+
+**This flow is intentionally preserved unchanged by PP.2.** Convergence to
+RFC 0001 is sequenced across follow-up PRs (PP.2b structural, PP.2c
+promote/rollback) so each diff is reviewable and reversible.
+
 ## Environment Setup
 
 Each app requires environment configuration:

--- a/docs/PP_2_STAGING_AUDIT.md
+++ b/docs/PP_2_STAGING_AUDIT.md
@@ -1,0 +1,83 @@
+# PP.2 — Dhanam staging audit vs RFC 0001
+
+> Last Updated: 2026-04-17
+> RFC: [internal-devops/rfcs/0001-dev-staging-prod-pipeline.md](https://github.com/madfam-org/internal-devops/blob/main/rfcs/0001-dev-staging-prod-pipeline.md)
+> Reference impl: [karafiel PP.1 — `infra/k8s/overlays/staging/`](https://github.com/madfam-org/karafiel/tree/main/infra/k8s/overlays/staging)
+> Scope: audit only — this PR ships the document + a CLAUDE.md cross-reference; yaml/workflow convergence is **deferred** to PP.2b (see "Convergence actions" below).
+
+## TL;DR
+
+Dhanam already has a working staging pipeline: a `dhanam-staging` namespace,
+a Kustomize layer that overrides replicas + `NODE_ENV`, and a
+`deploy-staging.yml` workflow that runs on every push to `main`. **It is not
+RFC 0001-compliant** in the ways that matter for the MXN-flywheel rollout:
+
+1. Staging manifests are **duplicated** from production (`api-deployment.yaml`
+   - `web-deployment.yaml` are copies, not references), rather than inheriting
+     via `resources: [../production]` the way Karafiel does.
+2. Staging images are pinned to the **mutable `:main` tag**, not a digest.
+   "The image that passed staging" is not an identifiable artefact, which
+   breaks the "one image, promoted" rule of RFC 0001 § "Three tiers, one
+   image, two overlays".
+3. There is **no promotion workflow**. `deploy-k8s.yml` (API),
+   `deploy-web-k8s.yml`, and `deploy-admin-k8s.yml` each write digests
+   directly into `infra/k8s/production/kustomization.yaml` on every push to
+   `main`. Prod is therefore fed by CI builds, not by a promotion from staging.
+4. `deploy-staging.yml` uses `kubectl apply -k` (push-based) instead of
+   ArgoCD reconcile (pull-based). ArgoCD only watches `infra/k8s/production/`
+   today (`infra/argocd/config.json`); there is no Application pointing at
+   `infra/k8s/staging/`.
+5. Admin is not in the staging kustomization at all — only api + web.
+
+None of these are blockers for PP.2 (this audit). They are the work items
+for PP.2b (Dhanam staging convergence) and PP.2c (promotion workflow).
+
+## Current state vs RFC 0001 — row-by-row
+
+| Area                              | RFC 0001 expects                                                                                              | Dhanam today                                                                                                                                                                                        | Status         | Resolution                                                                                                                                                                                                                                                                                   |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Layout**                        | `infra/k8s/base/` + `overlays/{staging,production}/`                                                          | `infra/k8s/production/` (canonical base) + `infra/k8s/staging/` (sibling, duplicated)                                                                                                               | Diverged       | PP.2b: convert `staging/` to overlay referencing `../production` (Karafiel pattern). Phase 1 = keep `production/` as canonical base, skip the eventual `base/` rename.                                                                                                                       |
+| **Staging manifests**             | Overlay imports base + patches (replicas, env, ingress, secrets, HPA, digest)                                 | Self-contained manifests duplicated from prod                                                                                                                                                       | Diverged       | PP.2b: delete `api-deployment.yaml` + `web-deployment.yaml` + `namespace.yaml` from `staging/` once overlay is proven to render equivalent YAML (`kustomize build infra/k8s/staging/`).                                                                                                      |
+| **Admin in staging**              | All three apps (api, web, admin) deploy to staging                                                            | Only api + web. Admin absent.                                                                                                                                                                       | Diverged       | PP.2b: add admin-deployment to staging overlay; `deploy-admin-k8s.yml` needs a sibling staging workflow or the overlay picks admin up via inheritance.                                                                                                                                       |
+| **Image pinning**                 | Digest (`sha256:...`) patched into `overlays/staging/kustomization.yaml` by `build-and-deploy-staging.yml`    | `newTag: main` — **mutable tag**                                                                                                                                                                    | Diverged       | PP.2b: CI writes digest via `kustomize edit set image dhanam-{api,web,admin}=ghcr.io/.../@sha256:<digest>`, like Karafiel `staging-deploy-api.yml` does.                                                                                                                                     |
+| **Promotion**                     | `promote-to-prod.yml` (`workflow_dispatch`) takes staging digest → writes to `overlays/production/`           | No promote workflow. `deploy-{k8s,web-k8s,admin-k8s}.yml` commit digest directly to `infra/k8s/production/kustomization.yaml` on push.                                                              | Diverged       | PP.2c (separate PR): add `promote-to-prod.yml`, remove the direct-to-prod digest commits. Pattern B (manual gate) — Dhanam is billing, mistakes are expensive.                                                                                                                               |
+| **Rollback**                      | `rollback-prod.yml` workflow, RTO <5 min                                                                      | None. Revert commit + rebuild.                                                                                                                                                                      | Diverged       | PP.2c: add `rollback-prod.yml` with target-digest input.                                                                                                                                                                                                                                     |
+| **ArgoCD staging Application**    | `dhanam-staging` App watches `infra/k8s/staging/`                                                             | Only `dhanam` prod App exists (`infra/argocd/config.json`)                                                                                                                                          | Diverged       | PP.2b (infra work): register `dhanam-staging` Application. Operator checklist in `internal-devops/runbooks/staging-bootstrap.md` §2.                                                                                                                                                         |
+| **Deploy trigger mechanism**      | Commit digest → ArgoCD reconciles (pull)                                                                      | `kubectl apply -k` direct from GH Actions (push)                                                                                                                                                    | Diverged       | PP.2b: once the staging overlay exists + the staging ArgoCD App is registered, `deploy-staging.yml` should patch the digest and exit — ArgoCD takes over. Removes the `KUBECONFIG_STAGING` secret from the workflow.                                                                         |
+| **Soak period before promote**    | ≥30 min in staging, validated by promote workflow                                                             | N/A — no promotion                                                                                                                                                                                  | Deferred       | PP.2c.                                                                                                                                                                                                                                                                                       |
+| **Staging smoke test**            | Post-deploy smoke against `staging-<domain>/health`                                                           | `kubectl rollout status` only. No HTTP health check against the staging URL.                                                                                                                        | Diverged       | PP.2b: add curl-retry smoke step to `deploy-staging.yml` (Karafiel has the template — 6 retries × 20s). Surgical change, ~15 lines.                                                                                                                                                          |
+| **Replica counts**                | 1 in staging vs 2-N in prod, HPAs disabled/capped                                                             | API+web=1, HPA min=1/max=2                                                                                                                                                                          | Aligned        | Keep as-is.                                                                                                                                                                                                                                                                                  |
+| **Staging namespace**             | `<service>-staging`                                                                                           | `dhanam-staging`                                                                                                                                                                                    | Aligned        | Keep.                                                                                                                                                                                                                                                                                        |
+| **Staging secrets**               | Separate `<service>-staging-secrets` secret                                                                   | `dhanam-secrets` in `dhanam-staging` namespace (name collision with prod secret name, lives in different namespace — works, but ambiguous)                                                          | Aligned enough | Document the deviation. Renaming secrets is an infra cutover; **out of scope** per PR instructions.                                                                                                                                                                                          |
+| **Staging subdomain**             | `staging-<service>.<domain>` (e.g. `staging-api.dhan.am`)                                                     | No ingress in staging overlay today (deployments only, no `Ingress` resource). Staging appears to be namespace-internal for now.                                                                    | Diverged       | PP.2b: add `ingress-staging.yaml` patch pointing at `staging-api.dhan.am` + `staging.dhan.am`. Requires Cloudflare DNS + tunnel route (ops action).                                                                                                                                          |
+| **External service sandbox**      | Test/sandbox keys (Stripe test, Resend test, Janua staging tenant) in staging secrets. **No PAC in staging.** | `secrets-template.yaml` in `infra/k8s/staging/` lists DB, Redis, encryption, OIDC, NextAuth, JWT only. Billing (Stripe/Paddle) + provider (Belvo/Plaid/Bitso) secrets **not declared for staging.** | Diverged       | PP.2b: expand staging `secrets-template.yaml` to cover every secret the overlay's pods reference. Operator then populates `dhanam-billing-secrets` + `dhanam-provider-secrets` for `dhanam-staging` namespace. Until then, staging pods will CrashLoop on missing billing/provider env vars. |
+| **DB: nightly masked restore**    | Prod→staging DB refresh, PII-masked, 03:00 UTC                                                                | Not implemented. Staging DB is whatever the operator seeded manually.                                                                                                                               | Diverged       | RFC 0001 open question (masking tool choice). Out of scope for PP.2b. Track as separate infra work.                                                                                                                                                                                          |
+| **Promotion pattern declaration** | `.enclii.yml` `promotion:` key (manual vs auto)                                                               | Not present in `.enclii.yml`.                                                                                                                                                                       | Diverged       | PP.2c: add `promotion: { pattern: manual, min_soak_minutes: 30, require_smoke_pass: true }` — Dhanam is Pattern B (billing = critical).                                                                                                                                                      |
+
+## Summary
+
+- **Aligned**: 3 rows (namespace convention, replica counts, secret namespacing workaround)
+- **Diverged (in-scope for PP.2b)**: 8 rows (layout, manifests, admin coverage, image pinning, staging smoke, ArgoCD App, trigger mechanism, ingress, secrets-template completeness)
+- **Diverged (in-scope for PP.2c — new PR)**: 3 rows (promote workflow, rollback workflow, `.enclii.yml` promotion key)
+- **Deferred (out of scope for Phase 1)**: 2 rows (nightly masked DB restore, secret rename)
+
+## What PP.2 (this PR) ships
+
+Per user instructions "do NOT rewrite Dhanam's deploy pipeline wholesale":
+
+1. **This audit document** (`docs/PP_2_STAGING_AUDIT.md`).
+2. **CLAUDE.md update** with a "Deployment Pipeline" section cross-referencing RFC 0001 and listing the divergences above.
+3. **No YAML or workflow changes.** The convergence work is scoped to follow-up PRs so each diff is reviewable and reversible:
+   - **PP.2b** — Kustomize overlay structure + digest pinning + staging smoke + admin inclusion + ingress patch + expanded staging secrets template. ETA ~200 lines of yaml + ~30 lines of workflow edits.
+   - **PP.2c** — Promote + rollback workflows + `.enclii.yml` promotion key + removal of direct-to-prod digest commits from `deploy-{k8s,web-k8s,admin-k8s}.yml`. ETA ~250 lines net (adds two new workflows, trims three existing ones).
+
+This split keeps each PR reviewable and avoids accidentally breaking the
+currently-working production deploy path during the structural move.
+
+## Cross-references
+
+- RFC 0001 — `internal-devops/rfcs/0001-dev-staging-prod-pipeline.md`
+- Runbook — `internal-devops/runbooks/staging-bootstrap.md`
+- Reference impl — `karafiel/infra/k8s/overlays/staging/kustomization.yaml` + `karafiel/.github/workflows/staging-deploy-api.yml` (PP.1)
+- This PR — `feat/pp-2-dhanam-staging-audit`
+- Follow-up PRs — PP.2b (structural convergence), PP.2c (promote/rollback workflows)


### PR DESCRIPTION
## Summary

Audit Dhanam's existing staging pipeline against [RFC 0001](https://github.com/madfam-org/internal-devops/blob/main/rfcs/0001-dev-staging-prod-pipeline.md) (dev → staging → prod). **Ships the audit document + CLAUDE.md cross-reference only** — no yaml or workflow changes. Convergence work is sequenced into follow-up PRs (PP.2b structural, PP.2c promote/rollback) so each diff stays reviewable.

## What this PR contains

- `docs/PP_2_STAGING_AUDIT.md` — row-by-row gap analysis vs RFC 0001
- `CLAUDE.md` — new "Deployment Pipeline" section cross-referencing RFC 0001 + listing tracked divergences

## Audit findings (summary)

- **Aligned**: 3 rows (namespace convention, replica counts, secret namespacing)
- **Diverged, in-scope for PP.2b**: 8 rows — layout (duplicated manifests vs overlay), mutable `:main` tag vs digest, missing admin in staging, `kubectl apply -k` vs ArgoCD reconcile, no staging ArgoCD Application, no staging ingress, incomplete staging `secrets-template.yaml`, missing staging smoke
- **Diverged, in-scope for PP.2c (new PR)**: 3 rows — no `promote-to-prod.yml`, no `rollback-prod.yml`, no `.enclii.yml` `promotion:` key. Dhanam flagged Pattern B (manual gate) since it's the billing boundary.
- **Deferred**: 2 rows — nightly masked prod→staging DB refresh (RFC open question), secret rename (infra cutover, explicitly out of scope)

## Why no convergence yaml in this PR

Per user instructions: "If Dhanam's staging is already 90% RFC-compliant, ship just the audit doc + CLAUDE.md update." It isn't 90% — it's ~25% — but the convergence work (overlay restructure, digest pinning, promote/rollback workflows, ArgoCD staging Application) is large enough that bundling it would bury the audit and make rollback harder if any one piece breaks prod. Splitting into PP.2b (structural) + PP.2c (promotion) preserves a working prod deploy path at every step.

## References

- RFC 0001: `internal-devops/rfcs/0001-dev-staging-prod-pipeline.md`
- Runbook: `internal-devops/runbooks/staging-bootstrap.md`
- PP.1 reference: madfam-org/karafiel#12 — `infra/k8s/overlays/staging/kustomization.yaml` + `.github/workflows/staging-deploy-api.yml`

## Test plan

- [ ] Reviewer reads `docs/PP_2_STAGING_AUDIT.md` and confirms the row classifications (aligned vs diverged vs deferred) match their mental model of Dhanam's current state
- [ ] Reviewer confirms the PP.2b/PP.2c split makes sense and doesn't want convergence yaml merged into this PR
- [ ] No CI changes expected — doc-only PR; CI should be green from pre-push checks already

🤖 Generated with [Claude Code](https://claude.com/claude-code)