### PR TITLE
feat(preview): per-PR preview environments — P1.7 pilot service

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,232 @@
+# P1.7 — Dhanam per-PR preview deploy.
+#
+# On PR open/synchronize (new commits pushed to PR branch):
+#   1. Build the API image (api-only; web/admin stay on staging-latest per
+#      infra/k8s/overlays/preview/kustomization.yaml rationale).
+#   2. Push to ghcr.io/madfam-org/dhanam/api:pr-<N>-<sha> (tagged so the
+#      image is discoverable from the PR page) AND capture the digest.
+#   3. Patch infra/k8s/overlays/preview/kustomization.yaml on the PR's
+#      own branch (NOT main) with the new digest. ArgoCD's ApplicationSet
+#      pullRequest generator watches this file at the PR's `head` ref, so
+#      committing on the PR branch is how the digest reaches the cluster.
+#
+# Teardown is handled by the ApplicationSet finalizer on PR close/merge —
+# this workflow intentionally does NOT have a `pull_request: types: closed`
+# job.
+#
+# Skip conditions:
+#   - Fork PRs: no preview (credential + resource leak risk). GitHub's
+#     default `GITHUB_TOKEN` can't write to the fork anyway.
+#   - `no-preview` label: operator escape hatch (e.g., docs-only PR,
+#     known-broken build, cost containment).
+
+name: Preview Deploy (per-PR)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+concurrency:
+  # One build per PR at a time; cancel superseded runs on new commits.
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  API_IMAGE: madfam-org/dhanam/api
+
+jobs:
+  guard:
+    # Single gate job — other jobs depend on its output. Keeps the
+    # fork/label logic in one place.
+    name: Guard (fork + label checks)
+    runs-on: ubuntu-latest
+    outputs:
+      should_deploy: ${{ steps.decide.outputs.should_deploy }}
+      reason: ${{ steps.decide.outputs.reason }}
+    steps:
+      - id: decide
+        env:
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -euo pipefail
+          if [ "$IS_FORK" = "true" ]; then
+            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+            echo "reason=fork" >> "$GITHUB_OUTPUT"
+            echo "::notice::Preview skipped — PR is from a fork (security policy)."
+            exit 0
+          fi
+          if echo "$LABELS" | grep -q '"no-preview"'; then
+            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+            echo "reason=no-preview-label" >> "$GITHUB_OUTPUT"
+            echo "::notice::Preview skipped — 'no-preview' label present."
+            exit 0
+          fi
+          echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+          echo "reason=ok" >> "$GITHUB_OUTPUT"
+
+  build-api:
+    name: Build API preview image
+    needs: guard
+    if: needs.guard.outputs.should_deploy == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
+      short: ${{ steps.sha.outputs.short }}
+      pr: ${{ github.event.pull_request.number }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: sha
+        run: echo "short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/api/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.API_IMAGE }}:pr-${{ github.event.pull_request.number }}-${{ steps.sha.outputs.short }}
+            ${{ env.REGISTRY }}/${{ env.API_IMAGE }}:pr-${{ github.event.pull_request.number }}-latest
+          cache-from: |
+            type=gha,scope=api-preview-${{ github.event.pull_request.number }}
+            type=gha,scope=api
+          cache-to: type=gha,scope=api-preview-${{ github.event.pull_request.number }},mode=max
+
+  update-preview-overlay:
+    name: Patch preview overlay digest on PR branch
+    needs: [guard, build-api]
+    if: needs.guard.outputs.should_deploy == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          # Need write access to push back to the PR branch. Default
+          # GITHUB_TOKEN is insufficient for fork-guarded workflows only;
+          # same-repo PRs work fine with the default token.
+          token: ${{ secrets.MADFAM_BOT_PAT || secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Patch preview overlay api digest
+        env:
+          API_DIGEST: ${{ needs.build-api.outputs.digest }}
+          SHORT: ${{ needs.build-api.outputs.short }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          FILE="infra/k8s/overlays/preview/kustomization.yaml"
+          python3 <<PY
+          import os, re, pathlib
+          path = pathlib.Path("$FILE")
+          text = path.read_text()
+
+          # Only the api digest gets rewritten on every PR push; web/admin
+          # keep whatever digest is currently in the file (points at the
+          # most recent staging-latest captured when the preview overlay
+          # was last manually refreshed — see README in infra/k8s/overlays/preview/).
+          pattern = (
+              r'(name:\s+ghcr\.io/madfam-org/dhanam/api\n\s+digest:\s+)'
+              r'sha256:[a-f0-9]+'
+          )
+          text = re.sub(pattern, lambda m: m.group(1) + os.environ["API_DIGEST"], text)
+          path.write_text(text)
+          PY
+
+          if git diff --quiet -- "$FILE"; then
+            echo "No digest change (duplicate build?) — skipping commit."
+            exit 0
+          fi
+
+          git config user.name "madfam-deploy-bot"
+          git config user.email "deploy-bot@madfam.io"
+          git add "$FILE"
+          git commit -m "deploy(preview): pr-$PR api digest -> $SHORT"
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+
+  smoke:
+    name: Preview smoke test
+    needs: [guard, update-preview-overlay]
+    if: needs.guard.outputs.should_deploy == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Wait for ArgoCD reconcile
+        # ApplicationSet regen cadence (~30s) + ArgoCD sync + pod warmup.
+        # Larger than staging smoke because preview namespaces cold-start.
+        run: sleep 240
+
+      - name: API health check (6x retry x 20s)
+        env:
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          URL="https://pr-${PR}.api.preview.dhan.am"
+          for i in 1 2 3 4 5 6; do
+            if curl -fsS --max-time 10 "$URL/health" > /dev/null; then
+              echo "Preview API healthy on attempt $i ($URL/health)"
+              exit 0
+            fi
+            echo "attempt $i unhealthy, retrying"
+            sleep 20
+          done
+          echo "::error::Preview failed health check after 6 attempts ($URL/health)"
+          echo "::error::Check ArgoCD (\`argocd app get dhanam-pr-${PR}\`) and namespace events (\`kubectl -n dhanam-pr-${PR} get events\`)."
+          exit 1
+
+      - name: Comment preview URL on PR
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          PR: ${{ github.event.pull_request.number }}
+        with:
+          script: |
+            const pr = process.env.PR;
+            const body = [
+              `### Preview environment`,
+              ``,
+              `- API: https://pr-${pr}.api.preview.dhan.am`,
+              `- Web: https://pr-${pr}.web.preview.dhan.am`,
+              `- Admin: https://pr-${pr}.admin.preview.dhan.am`,
+              ``,
+              `Build: \`pr-${pr}-${{ needs.build-api.outputs.short }}\`.`,
+              `Teardown on PR close/merge is automatic.`,
+              `Add label \`no-preview\` to skip future builds.`
+            ].join('\n');
+            // Upsert: one preview comment per PR, find-by-marker + update/create.
+            const marker = '### Preview environment';
+            const {data: comments} = await github.rest.issues.listComments({
+              ...context.repo, issue_number: Number(pr)
+            });
+            const existing = comments.find(c =>
+              c.user.login === 'github-actions[bot]' && c.body.startsWith(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo, comment_id: existing.id, body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: Number(pr), body
+              });
+            }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -480,6 +480,88 @@ for the transform implementation and
 for the 22-test suite covering signature, transforms, idempotency,
 currency guard, and feature-flag gate.
 
+## Preview Environments (P1.7 — Enclii ephemeral per-PR envs)
+
+Dhanam is the first participating service for Enclii's preview-environment
+feature (see
+[internal-devops/roadmaps/2026-04-enclii-remediation-plan.md](https://github.com/madfam-org/internal-devops/blob/main/roadmaps/2026-04-enclii-remediation-plan.md)
+P1.7). Every non-fork PR to `main` auto-spawns a per-PR environment:
+
+| Surface | URL |
+|---------|-----|
+| API | `https://pr-<N>.api.preview.dhan.am` |
+| Web | `https://pr-<N>.web.preview.dhan.am` |
+| Admin | `https://pr-<N>.admin.preview.dhan.am` |
+
+### How it works
+
+1. `preview-deploy.yml` (on PR open/synchronize) builds the API image,
+   pushes it to `ghcr.io/madfam-org/dhanam/api:pr-<N>-<sha>`, and patches
+   `infra/k8s/overlays/preview/kustomization.yaml` **on the PR branch**
+   with the new digest.
+2. ArgoCD's `dhanam-preview` ApplicationSet (in
+   [internal-devops/infra/argocd/appsets/dhanam-preview.yaml](https://github.com/madfam-org/internal-devops/blob/main/infra/argocd/appsets/dhanam-preview.yaml))
+   watches `madfam-org/dhanam` for open PRs. For each PR it generates an
+   Application `dhanam-pr-<N>` that deploys this overlay to namespace
+   `dhanam-pr-<N>`.
+3. On PR close/merge, ArgoCD drops the Application. The
+   `resources-finalizer.argocd.argoproj.io` finalizer deletes every
+   resource in the namespace, including the namespace itself.
+4. The smoke job polls `pr-<N>.api.preview.dhan.am/health` and comments
+   the URLs on the PR.
+
+### Guardrails
+
+- **Fork PRs are skipped** (no preview build) — prevents credential +
+  resource leakage to untrusted contributors.
+- **`no-preview` label skips** builds — escape hatch for docs-only PRs,
+  known-broken branches, or cost containment.
+- **Sandbox-only credentials** — `dhanam-secrets-preview`,
+  `dhanam-billing-secrets-preview`, `dhanam-provider-secrets-preview`,
+  `dhanam-janua-secrets-preview` are provisioned from
+  `infra/k8s/overlays/preview/secrets-template.yaml` with test/sandbox
+  keys only. `FEATURE_STRIPE_MXN_LIVE=false` is pinned in
+  `env-patch-api.yaml` regardless of secret content.
+- **Per-namespace quota** — `quota.yaml` caps the preview at cpu 1 /
+  mem 2Gi / 8 pods, so a runaway preview cannot exhaust the cluster.
+- **14-day reap** — a CronJob in `internal-devops/infra/k8s/`
+  (`preview-reaper-cronjob.yaml`) deletes any `dhanam-pr-*` namespace
+  older than 14 days regardless of PR state, as a safety net if
+  ApplicationSet fails to reap.
+- **API-only rebuild** — web/admin use the most-recent staging digests
+  pinned in `overlays/preview/kustomization.yaml`. Rebuilding all three
+  per PR costs too much; web/admin changes ship through staging on
+  merge like always.
+
+### Files
+
+| Purpose | Location |
+|---------|----------|
+| Overlay | `infra/k8s/overlays/preview/kustomization.yaml` |
+| API env patch | `infra/k8s/overlays/preview/env-patch-api.yaml` |
+| Web env patch | `infra/k8s/overlays/preview/env-patch-web.yaml` |
+| Admin env patch | `infra/k8s/overlays/preview/env-patch-admin.yaml` |
+| Secrets retarget | `infra/k8s/overlays/preview/secrets-patch.yaml` |
+| HPA disable | `infra/k8s/overlays/preview/hpa-disable-patch.yaml` |
+| Resource quota | `infra/k8s/overlays/preview/quota.yaml` |
+| Secrets template | `infra/k8s/overlays/preview/secrets-template.yaml` |
+| CI workflow | `.github/workflows/preview-deploy.yml` |
+| Smoke script | `scripts/preview-smoke.sh <pr-number>` |
+
+### Troubleshooting
+
+- **Preview not appearing after PR open**: check the `Preview Deploy
+  (per-PR)` workflow run. If skipped, look for the `fork` /
+  `no-preview-label` reason in the guard step.
+- **Build succeeds but pod CrashLoop**: missing
+  `dhanam-secrets-preview` in the namespace. Operator must apply
+  `secrets-template.yaml` with `__NAMESPACE__` substituted.
+- **Health check 6x fail**: run `./scripts/preview-smoke.sh <PR>`; check
+  ArgoCD (`argocd app get dhanam-pr-<PR>`) and namespace events.
+- **Stale preview after merge**: reap runs within 14 days. For
+  immediate cleanup, `kubectl delete application dhanam-pr-<PR> -n
+  argocd` and the finalizer takes care of the namespace.
+
 ## Known Local Dev Issues
 
 - **Janua SDK**: Using `@janua/react-sdk@0.1.4`. PKCE exports and `useMFA`/`MFAChallenge` are now available. Auth state fix: `signIn()` parses JWT for immediate user state instead of blocking on `getCurrentUser()`. SSR safety: components loaded via `next/dynamic` + `JanuaErrorBoundary`; `SSRSafeJanuaProvider` in `providers.tsx` handles the dynamic import.

--- a/infra/k8s/overlays/preview/env-patch-admin.yaml
+++ b/infra/k8s/overlays/preview/env-patch-admin.yaml
@@ -1,0 +1,20 @@
+# Preview env overrides for the admin (Next.js standalone) deployment.
+# Same templating pattern as web — ApplicationSet substitutes __PR_NUMBER__.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dhanam-admin
+spec:
+  template:
+    spec:
+      containers:
+        - name: admin
+          env:
+            - name: NODE_ENV
+              value: "staging"
+            - name: NEXT_PUBLIC_API_URL
+              value: "https://pr-__PR_NUMBER__.api.preview.dhan.am/v1"
+            - name: NEXT_PUBLIC_APP_URL
+              value: "https://pr-__PR_NUMBER__.admin.preview.dhan.am"
+            - name: SENTRY_ENVIRONMENT
+              value: "preview"

--- a/infra/k8s/overlays/preview/env-patch-api.yaml
+++ b/infra/k8s/overlays/preview/env-patch-api.yaml
@@ -1,0 +1,42 @@
+# Preview-specific env overrides for the API.
+#
+# Keys differ from staging on:
+#   - ENVIRONMENT / SENTRY_ENVIRONMENT = "preview" (segregate preview noise
+#     from staging dashboards + alerting rules)
+#   - CORS_ORIGINS = wildcard under *.preview.dhan.am (every preview web/admin
+#     origin must be accepted; individual PR URLs are templated by the
+#     ApplicationSet at Application creation time)
+#
+# Safety: billing stays test-mode (same as staging). If a preview ever
+# processed a live Stripe event it would be a material compliance break.
+# FEATURE_STRIPE_MXN_LIVE=false is enforced here even if the preview-secret
+# accidentally leaked a live key.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dhanam-api
+spec:
+  template:
+    spec:
+      containers:
+        - name: api
+          env:
+            - name: NODE_ENV
+              value: "staging"
+            - name: ENVIRONMENT
+              value: "preview"
+            - name: SENTRY_ENVIRONMENT
+              value: "preview"
+            - name: SENTRY_RELEASE
+              value: "dhanam-api@preview"
+            - name: FEATURE_STRIPE_MXN_LIVE
+              value: "false"
+            - name: PADDLE_ENVIRONMENT
+              value: "sandbox"
+            # CORS: wildcard across all preview hosts. Pair with preview-only
+            # JWT secret so a leaked preview token cannot be used in prod.
+            - name: CORS_ORIGINS
+              value: "https://*.preview.dhan.am"
+            # Fan-out disabled in preview (no downstream webhook consumers).
+            - name: PRODUCT_WEBHOOK_URLS
+              value: ""

--- a/infra/k8s/overlays/preview/env-patch-web.yaml
+++ b/infra/k8s/overlays/preview/env-patch-web.yaml
@@ -1,0 +1,26 @@
+# Preview env overrides for the web (Next.js) deployment.
+#
+# Web needs to know the *specific* PR's API host. The `__PR_NUMBER__`
+# placeholder is substituted by the ApplicationSet template at sync time
+# (pullRequest generator exposes {{.number}}) so each preview's browser
+# client talks to its own isolated API.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dhanam-web
+spec:
+  template:
+    spec:
+      containers:
+        - name: dhanam-web
+          env:
+            - name: NODE_ENV
+              value: "staging"
+            - name: NEXT_PUBLIC_API_URL
+              value: "https://pr-__PR_NUMBER__.api.preview.dhan.am/v1"
+            - name: NEXT_PUBLIC_BASE_URL
+              value: "https://pr-__PR_NUMBER__.web.preview.dhan.am"
+            - name: SENTRY_ENVIRONMENT
+              value: "preview"
+            - name: SENTRY_RELEASE
+              value: "dhanam-web@preview"

--- a/infra/k8s/overlays/preview/hpa-disable-patch.yaml
+++ b/infra/k8s/overlays/preview/hpa-disable-patch.yaml
@@ -1,0 +1,8 @@
+# Same mechanism as staging: pin min=max=1 on HPAs. Pairs with the
+# `replicas:` block in kustomization.yaml.
+- op: replace
+  path: /spec/minReplicas
+  value: 1
+- op: replace
+  path: /spec/maxReplicas
+  value: 1

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -1,0 +1,119 @@
+# Preview overlay — ephemeral per-PR environments (RFC 0001 / Enclii P1.7).
+#
+# Architecture (end-to-end):
+#
+#   GitHub PR opened ─▶ preview-deploy.yml builds API image, pushes to GHCR
+#                         with tag  `pr-<PR>-<sha>`, then commits this file
+#                         on the PR branch with the new digest pinned below.
+#
+#   ArgoCD ApplicationSet (`internal-devops/infra/argocd/appsets/dhanam-preview.yaml`)
+#   watches madfam-org/dhanam for open PRs. For each PR it generates an
+#   Application that deploys this overlay to namespace `dhanam-pr-<n>`,
+#   substituting the namespace and hostnames via the ApplicationSet
+#   template.
+#
+#   When the PR closes or merges, ArgoCD drops the Application, its
+#   `resources-finalizer.argocd.argoproj.io` deletes every resource in the
+#   namespace, and a separate CronJob (`infra/k8s/preview-reaper-cronjob.yaml`
+#   in internal-devops) sweeps any `dhanam-pr-*` namespace older than 14 days
+#   as a safety net.
+#
+# What preview differs from prod on:
+#   - namespace: dhanam-pr-<n>     (templated by ApplicationSet)
+#   - replicas: 1 everywhere (no HPA; preview is cost-capped)
+#   - images: ONLY the api is rebuilt per PR; web/admin use the current
+#     staging-latest digests (most product changes are API-first; rebuilding
+#     three images per push costs too much for a preview). Web/admin can be
+#     promoted to per-PR later if demand justifies it.
+#   - hostnames: pr-<n>.api.preview.dhan.am (resolved by Cloudflare wildcard
+#     tunnel route `*.api.preview.dhan.am` — operator configures once)
+#   - secrets: dhanam-secrets-preview, dhanam-billing-secrets-preview,
+#     dhanam-provider-secrets-preview, dhanam-janua-secrets-preview — all
+#     sandbox/test credentials, operator-provisioned once, reused across
+#     every pr-<n> namespace via Kustomize-level secret ref names. ReplicaSet
+#     will fail scheduling if missing; see secrets-template.yaml.
+#   - feature flags: mirror staging (FEATURE_STRIPE_MXN_LIVE=false, sandbox
+#     Paddle, sandbox Belvo/Plaid/Bitso). ENVIRONMENT=preview tags logs.
+#   - resource quota: cpu 1 / mem 2Gi per namespace (see quota.yaml).
+#
+# Security guardrails:
+#   - Preview NEVER receives prod secrets (enforced by distinct K8s secret names).
+#   - PRs from forks are skipped by the ApplicationSet generator (credential
+#     + resource leak prevention).
+#   - Per-namespace ResourceQuota prevents a runaway preview from eating the
+#     cluster.
+#   - Namespace is isolated; no NetworkPolicy egress to prod databases.
+#     (Preview DB_URL points at the dedicated staging-preview Postgres
+#     instance, populated with synthetic fixtures only.)
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Namespace: placeholder; ApplicationSet replaces via `namespace:` override.
+# Kustomize requires *some* value here so the overlay builds standalone for
+# `kubectl kustomize` smoke tests.
+namespace: dhanam-pr-0
+
+resources:
+  - ../../production
+  - quota.yaml
+
+# Preview replicas: 1 everywhere. HPAs are pinned min=max=1 via patch.
+replicas:
+  - name: dhanam-api
+    count: 1
+  - name: dhanam-web
+    count: 1
+  - name: dhanam-admin
+    count: 1
+
+# Image digests for the preview overlay. `preview-deploy.yml` patches the
+# api digest on every PR push; web/admin stay on staging-latest and are
+# only refreshed when staging's own pipeline runs (intentional — preview
+# is API-focused).
+images:
+  - name: ghcr.io/madfam-org/dhanam/api
+    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+  - name: ghcr.io/madfam-org/dhanam/web
+    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+  - name: ghcr.io/madfam-org/dhanam/admin
+    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+
+patches:
+  # PATCH ORDERING MATTERS: secrets-patch.yaml is a JSON-patch `replace` on
+  # the container env array, so it must run FIRST. The env-patch-*.yaml
+  # files are strategic-merge patches keyed on env-entry `name`, so they
+  # merge additional env vars (ENVIRONMENT, CORS_ORIGINS, …) on top of
+  # the already-rewritten-to-preview secret refs.
+  #
+  # Re-point every deployment's secretRefs at the -preview secret set.
+  # (Runs first — replaces the entire env array on api/web/admin.)
+  - path: secrets-patch.yaml
+    target:
+      kind: Deployment
+
+  # Preview-specific env vars on the API (ENVIRONMENT=preview, forced-test
+  # billing, sandbox integrations, preview CORS wildcard). Strategic-merge
+  # appends these to the container's env (merged by `name`).
+  - path: env-patch-api.yaml
+    target:
+      kind: Deployment
+      name: dhanam-api
+
+  # Preview env on web (NODE_ENV=staging to reuse staging bundles; API URL
+  # points at the PR's own api host).
+  - path: env-patch-web.yaml
+    target:
+      kind: Deployment
+      name: dhanam-web
+
+  # Preview env on admin.
+  - path: env-patch-admin.yaml
+    target:
+      kind: Deployment
+      name: dhanam-admin
+
+  # Disable HPAs in preview (same mechanism as staging).
+  - path: hpa-disable-patch.yaml
+    target:
+      kind: HorizontalPodAutoscaler

--- a/infra/k8s/overlays/preview/quota.yaml
+++ b/infra/k8s/overlays/preview/quota.yaml
@@ -1,0 +1,22 @@
+# ResourceQuota for preview namespaces.
+#
+# Per RFC 0001 / Enclii P1.7 guardrails: a preview env is cost-capped so
+# that an arbitrary PR (or a leaked fork PR, if the fork filter ever fails)
+# cannot exhaust cluster capacity. Values intentionally conservative;
+# scale up if legitimate preview runs hit the limit.
+#
+# Quota targets ~1 small workload (api pod at ~400Mi request) per ns.
+# Web/admin already run the staging-latest digest at 1 replica.
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: dhanam-preview-quota
+spec:
+  hard:
+    requests.cpu: "1"
+    requests.memory: "2Gi"
+    limits.cpu: "2"
+    limits.memory: "4Gi"
+    pods: "8"
+    persistentvolumeclaims: "0"  # preview uses shared staging-preview PG
+    services.loadbalancers: "0"  # ingress handled by Cloudflare tunnel

--- a/infra/k8s/overlays/preview/secrets-patch.yaml
+++ b/infra/k8s/overlays/preview/secrets-patch.yaml
@@ -1,0 +1,177 @@
+# Re-point every Deployment's env.valueFrom.secretKeyRef at the -preview
+# secret set (dhanam-secrets-preview / dhanam-billing-secrets-preview /
+# dhanam-provider-secrets-preview / dhanam-janua-secrets-preview).
+#
+# Why JSON-patch and not strategic merge: strategic merge on env arrays
+# by name is brittle (secret refs come from the base deployment's many env
+# entries). A bounded set of `replace` ops keeps this explicit.
+#
+# Keys listed here mirror api-deployment.yaml's secretKeyRef usages. If
+# you add a new secretKeyRef to a Deployment in production/, add a
+# matching `replace` op here or the preview will fall back to the
+# non-existent-in-preview-ns prod secret and CrashLoop.
+- op: replace
+  path: /spec/template/spec/containers/0/env
+  value:
+    # Copy the base env array but retarget every secret ref to -preview.
+    # NOTE: this JSON patch replaces the container env entirely. The
+    # env-patch-api.yaml / env-patch-web.yaml / env-patch-admin.yaml
+    # merges (via `patches:` with `target.kind/name`) run AFTER this one
+    # and re-inject the preview-specific literal env vars.
+    - name: NODE_ENV
+      value: "staging"
+    - name: DATABASE_URL
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-secrets-preview
+          key: DATABASE_URL
+    - name: REDIS_URL
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-secrets-preview
+          key: REDIS_URL
+    - name: ENCRYPTION_KEY
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-secrets-preview
+          key: ENCRYPTION_KEY
+    - name: JWT_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-secrets-preview
+          key: JWT_SECRET
+    - name: JWT_REFRESH_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-secrets-preview
+          key: JWT_REFRESH_SECRET
+    - name: BANXICO_API_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-secrets-preview
+          key: BANXICO_API_TOKEN
+    - name: DHANAM_WEBHOOK_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-secrets-preview
+          key: DHANAM_WEBHOOK_SECRET
+    - name: COTIZA_WEBHOOK_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-secrets-preview
+          key: COTIZA_WEBHOOK_SECRET
+    - name: METAMAP_CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-secrets-preview
+          key: METAMAP_CLIENT_ID
+    - name: METAMAP_CLIENT_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-secrets-preview
+          key: METAMAP_CLIENT_SECRET
+    - name: METAMAP_WEBHOOK_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-secrets-preview
+          key: METAMAP_WEBHOOK_SECRET
+    - name: FEDERATION_API_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-secrets-preview
+          key: FEDERATION_API_TOKEN
+    - name: STRIPE_MX_SECRET_KEY
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-billing-secrets-preview
+          key: STRIPE_MX_SECRET_KEY
+    - name: STRIPE_MX_WEBHOOK_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-billing-secrets-preview
+          key: STRIPE_MX_WEBHOOK_SECRET
+    - name: PADDLE_VENDOR_ID
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-billing-secrets-preview
+          key: PADDLE_VENDOR_ID
+    - name: PADDLE_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-billing-secrets-preview
+          key: PADDLE_API_KEY
+    - name: PADDLE_CLIENT_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-billing-secrets-preview
+          key: PADDLE_CLIENT_TOKEN
+    - name: PADDLE_WEBHOOK_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-billing-secrets-preview
+          key: PADDLE_WEBHOOK_SECRET
+    - name: JANUA_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-janua-secrets-preview
+          key: JANUA_API_KEY
+    - name: JANUA_ADMIN_KEY
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-janua-secrets-preview
+          key: JANUA_ADMIN_KEY
+    - name: JANUA_API_URL
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-janua-secrets-preview
+          key: JANUA_API_URL
+    - name: JANUA_WEBHOOK_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-janua-secrets-preview
+          key: JANUA_WEBHOOK_SECRET
+    - name: BELVO_SECRET_KEY_ID
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-provider-secrets-preview
+          key: BELVO_SECRET_KEY_ID
+    - name: BELVO_SECRET_KEY_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-provider-secrets-preview
+          key: BELVO_SECRET_KEY_PASSWORD
+    - name: BELVO_WEBHOOK_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-provider-secrets-preview
+          key: BELVO_WEBHOOK_SECRET
+    - name: PLAID_CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-provider-secrets-preview
+          key: PLAID_CLIENT_ID
+    - name: PLAID_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-provider-secrets-preview
+          key: PLAID_SECRET
+    - name: PLAID_WEBHOOK_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-provider-secrets-preview
+          key: PLAID_WEBHOOK_SECRET
+    - name: BITSO_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-provider-secrets-preview
+          key: BITSO_API_KEY
+    - name: BITSO_API_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-provider-secrets-preview
+          key: BITSO_API_SECRET
+    - name: ZAPPER_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: dhanam-provider-secrets-preview
+          key: ZAPPER_API_KEY

--- a/infra/k8s/overlays/preview/secrets-template.yaml
+++ b/infra/k8s/overlays/preview/secrets-template.yaml
@@ -1,0 +1,145 @@
+# =============================================================================
+# Dhanam Preview Secrets Template (P1.7 — Enclii preview environments)
+# =============================================================================
+# Operator workflow (run ONCE per namespace after ArgoCD creates it, or
+# pre-provision for common PRs):
+#
+#   1. cp infra/k8s/overlays/preview/secrets-template.yaml /tmp/dhanam-preview-secrets.yaml
+#   2. sed -i '' "s/__NAMESPACE__/dhanam-pr-<PR>/g" /tmp/dhanam-preview-secrets.yaml
+#   3. Fill every <placeholder> with a SANDBOX credential. NEVER copy prod or
+#      even staging-live values. Every external key MUST be test/sandbox:
+#        - Stripe: sk_test_... (MX test mode, separate from staging if
+#          policy requires; otherwise reuse staging test key)
+#        - Paddle: sandbox vendor
+#        - Belvo: sandbox institutions only (never OFX/real bank links)
+#        - Plaid: sandbox
+#        - Bitso: stage env API keys
+#        - Janua: staging tenant client (jnc_stg_...)
+#        - MetaMap: sandbox merchant
+#   4. kubectl apply -f /tmp/dhanam-preview-secrets.yaml
+#   5. rm /tmp/dhanam-preview-secrets.yaml
+#   6. DO NOT commit the filled file. This template stays in git; the
+#      secrets themselves never do.
+#
+# Reuse strategy: the same set of sandbox credentials may be applied to
+# every `dhanam-pr-*` namespace (there's no tenant isolation concern in
+# preview because every preview runs on synthetic fixtures). The operator
+# can automate this by running a seeding job on namespace-create (future
+# work; for v1 a manual `kubectl apply` per new PR is acceptable since
+# ArgoCD's ApplicationSet creates the namespace but not the secret).
+#
+# Security properties:
+#   - Distinct K8s secret names (-preview suffix) guarantee no accidental
+#     cross-env secret mount.
+#   - dhanam-preview-quota caps pods to 8 / cpu 1, so a secret leak cannot
+#     be amplified by a runaway workload.
+# =============================================================================
+
+---
+# Core API secrets.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dhanam-secrets-preview
+  namespace: __NAMESPACE__
+  labels:
+    app: dhanam
+    environment: preview
+type: Opaque
+stringData:
+  # Dedicated preview Postgres (synthetic fixtures only; never prod/staging data).
+  DATABASE_URL: "<postgresql://preview:PASS@preview-pg/dhanam_preview>"
+  REDIS_URL: "<redis://preview-redis:6379/0>"
+
+  # Preview-only encryption key. Generate per preview namespace OR share one
+  # preview-only key (data is synthetic so blast radius is minimal).
+  ENCRYPTION_KEY: "<exactly-32-ascii-chars-preview-key>"
+
+  # JWT secrets — preview-only; token leakage cannot authenticate against prod/staging.
+  JWT_SECRET: "<openssl rand -base64 48>"
+  JWT_REFRESH_SECRET: "<openssl rand -base64 48>"
+
+  # Email: Mailhog or Resend test domain. Never live SMTP.
+  SMTP_HOST: "<smtp-preview-host>"
+  SMTP_PORT: "587"
+  SMTP_USER: "<smtp-test-user>"
+  SMTP_PASSWORD: "<smtp-test-pass>"
+  EMAIL_FROM: "preview-noreply@dhan.am"
+
+  BANXICO_API_TOKEN: "<banxico-api-token>"
+
+  DHANAM_WEBHOOK_SECRET: "<openssl rand -hex 32>"
+  MADFAM_EVENTS_WEBHOOK_SECRET: "<openssl rand -hex 32>"
+  COTIZA_WEBHOOK_SECRET: "<openssl rand -hex 32>"
+
+  # No downstream fan-out in preview — set empty.
+  PRODUCT_WEBHOOK_URLS: ""
+
+  SENTRY_DSN: "<sentry-preview-dsn>"
+  FEDERATION_API_TOKEN: "<openssl rand -hex 32>"
+
+  METAMAP_CLIENT_ID: "<metamap-sandbox-client-id>"
+  METAMAP_CLIENT_SECRET: "<metamap-sandbox-client-secret>"
+  METAMAP_WEBHOOK_SECRET: "<openssl rand -hex 32>"
+
+  OPENAI_API_KEY: "<openai-preview-key-low-limit>"
+
+---
+# Billing (Stripe + Paddle — sandbox).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dhanam-billing-secrets-preview
+  namespace: __NAMESPACE__
+  labels:
+    app: dhanam
+    environment: preview
+type: Opaque
+stringData:
+  STRIPE_MX_SECRET_KEY: "<sk_test_...>"
+  STRIPE_MX_WEBHOOK_SECRET: "<whsec_test_...>"
+  STRIPE_MX_PUBLISHABLE_KEY: "<pk_test_...>"
+  PADDLE_VENDOR_ID: "<sandbox-vendor-id>"
+  PADDLE_API_KEY: "<sandbox-api-key>"
+  PADDLE_CLIENT_TOKEN: "<sandbox-client-token>"
+  PADDLE_WEBHOOK_SECRET: "<sandbox-webhook-secret>"
+
+---
+# Provider secrets (all sandbox).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dhanam-provider-secrets-preview
+  namespace: __NAMESPACE__
+  labels:
+    app: dhanam
+    environment: preview
+type: Opaque
+stringData:
+  BELVO_SECRET_KEY_ID: "<belvo-sandbox-key-id>"
+  BELVO_SECRET_KEY_PASSWORD: "<belvo-sandbox-password>"
+  BELVO_WEBHOOK_SECRET: "<openssl rand -hex 32>"
+  PLAID_CLIENT_ID: "<plaid-sandbox-client-id>"
+  PLAID_SECRET: "<plaid-sandbox-secret>"
+  PLAID_WEBHOOK_SECRET: "<openssl rand -hex 32>"
+  BITSO_API_KEY: "<bitso-stage-key>"
+  BITSO_API_SECRET: "<bitso-stage-secret>"
+  ZAPPER_API_KEY: "<zapper-preview-key>"
+
+---
+# Janua server-side keys (staging tenant — reuse staging, no preview tenant).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dhanam-janua-secrets-preview
+  namespace: __NAMESPACE__
+  labels:
+    app: dhanam
+    environment: preview
+type: Opaque
+stringData:
+  JANUA_API_KEY: "<janua-staging-service-key>"
+  JANUA_ADMIN_KEY: "<janua-staging-admin-key>"
+  JANUA_API_URL: "https://api.janua.dev"
+  JANUA_WEBHOOK_SECRET: "<janua-staging-webhook-secret>"
+  DHANAM_WEBHOOK_SECRET: "<must match dhanam-secrets-preview DHANAM_WEBHOOK_SECRET>"

--- a/scripts/preview-smoke.sh
+++ b/scripts/preview-smoke.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# P1.7 preview smoke test — hit a per-PR preview URL with the same
+# 6x20s retry cadence used by staging. Usable from a developer laptop
+# to probe a suspect preview, or from `enclii` CLI wrappers.
+#
+# Usage:
+#   ./scripts/preview-smoke.sh <pr-number>
+#   ./scripts/preview-smoke.sh 123
+#
+# Exits 0 on success, 1 on failure after 6 attempts. Echoes the URL
+# being probed for clarity.
+set -euo pipefail
+
+PR="${1:-}"
+if [[ -z "$PR" ]]; then
+  echo "usage: $0 <pr-number>" >&2
+  exit 2
+fi
+if ! [[ "$PR" =~ ^[0-9]+$ ]]; then
+  echo "error: pr-number must be numeric, got '$PR'" >&2
+  exit 2
+fi
+
+URL="https://pr-${PR}.api.preview.dhan.am"
+echo "Probing $URL/health (6x retry, 20s apart)"
+for i in 1 2 3 4 5 6; do
+  if curl -fsS --max-time 10 "$URL/health" >/dev/null; then
+    echo "OK (attempt $i)"
+    exit 0
+  fi
+  echo "attempt $i unhealthy, retrying in 20s"
+  sleep 20
+done
+echo "FAIL: $URL/health unhealthy after 6 attempts" >&2
+echo "  - check ArgoCD:   argocd app get dhanam-pr-${PR}" >&2
+echo "  - check ns:       kubectl -n dhanam-pr-${PR} get pods,events" >&2
+echo "  - check ingress:  kubectl -n cloudflared logs -l app=cloudflared --tail=50 | grep pr-${PR}" >&2
+exit 1


### PR DESCRIPTION
## Summary

- Delivers the service-side of Enclii's per-PR preview environment feature (P1.7 in the [enclii remediation plan](https://github.com/madfam-org/internal-devops/blob/main/roadmaps/2026-04-enclii-remediation-plan.md)).
- Dhanam is the pilot service. Every non-fork PR labeled `preview` spins up `pr-<N>.{api,web,admin}.preview.dhan.am` via ArgoCD ApplicationSet, torn down on PR close.
- API-only rebuild per PR; web/admin ride staging-latest (cost tradeoff).

## What's in this PR

- `infra/k8s/overlays/preview/` — Kustomize overlay scoped to `dhanam-pr-<N>` namespace: preview secret refs, sandbox billing flags, CORS wildcard, per-ns ResourceQuota (cpu 1 / mem 2Gi / 8 pods).
- `.github/workflows/preview-deploy.yml` — PR-triggered build + digest commit to PR branch. Skips forks (security) and PRs with `no-preview` label (escape hatch).
- `scripts/preview-smoke.sh` — 6x20s health check helper.
- `CLAUDE.md` — new "Preview Environments" section with URLs, guardrails, troubleshooting.

Companion PR in [internal-devops](https://github.com/madfam-org/internal-devops) adds the ArgoCD ApplicationSet + reaper CronJob + operator runbook.

## Test plan

- [x] `kubectl kustomize infra/k8s/overlays/preview/` builds clean (25 resources: Namespace, ResourceQuota, 3 Deployments, 3 Services, 3 SAs, 3 HPAs, 3 PDBs, 8 NetworkPolicies).
- [x] Secret refs retarget to `*-preview` variants (verified in built manifests).
- [x] HPAs pinned min=max=1 via `hpa-disable-patch.yaml`.
- [x] `preview-deploy.yml` YAML parses; guard job correctly skips forks + `no-preview` label via `if:` expressions on downstream jobs.
- [ ] End-to-end smoke after operator completes bootstrap (GitHub PAT, Cloudflare wildcard, TLS cert, secrets seed) — blocker on cluster-side setup, not this PR.

## Operator actions required before first preview

1. Provision GitHub PAT `argocd-github-pat` in `argocd` namespace (scope: repo + PRs).
2. Cloudflare wildcard tunnel route `*.{api,web,admin}.preview.dhan.am` + wildcard TLS cert.
3. `kubectl apply` of `secrets-template.yaml` (with `__NAMESPACE__` substituted) for each new preview namespace — or automate via ExternalSecret cloner (follow-up).

See companion internal-devops PR's runbook for full bootstrap.

## Risk

- **Credential leakage**: mitigated by fork skip + distinct `-preview` secret names + wildcard sandbox-only credentials.
- **Resource exhaustion**: mitigated by per-ns ResourceQuota + 14-day reaper CronJob (in internal-devops PR).
- **DNS wildcard**: Cloudflare for SaaS covers first 100 hostnames free; the wildcard cert is DNS-01 via cert-manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)