### PR TITLE
docs: dependabot sweep decisions — 2026-04-18

### DIFF
--- a/docs/dependabot-sweeps/2026-04-18.md
+++ b/docs/dependabot-sweeps/2026-04-18.md
@@ -1,0 +1,71 @@
+# Dhanam Dependabot Sweep — 2026-04-18
+
+## Summary
+
+- **Merged**: 6 PRs (low/medium risk, validated green against baseline)
+- **Held with comment**: 12 PRs (migration-bound, require dedicated work)
+- **Closed as duplicate**: 1 PR (#262)
+
+## Baseline on `main` @ `aaf0c5d`
+
+Established before touching any PR branches; "green" = matches this baseline.
+
+**apps/api** (jest, via `DATABASE_URL=dummy pnpm exec jest`):
+- Test Suites: **6 failed**, 2 skipped, **169 passed** (175 of 177 total)
+- Tests: **55 failed**, 35 skipped, **4304 passed** (4394 total)
+- Pre-existing failing suites (unrelated to deps): `migration/lunchmoney-mapper`, `kyc/kyc.service`, `billing/cotiza-webhook`, `billing/webhook-processor`, `billing/billing.service`, `billing/billing.controller`
+- Typecheck: **56 errors** pre-existing (providers/orchestrator, transaction-execution, users.service)
+
+**apps/web**:
+- Test Suites: 1 skipped, **71 passed** (71 of 72 total); Tests: 15 skipped, **522 passed** (537 total)
+- Typecheck: **2 errors** pre-existing in `billing/usage-alerts/page.tsx`
+- `next build` fails on prettier/prettier rules in same file — **pre-existing on main**, not introduced here
+
+**apps/mobile**:
+- Test Suites: **6 passed** (6 total); Tests: **52 passed** (52 total)
+- Typecheck: **0 errors**
+
+### Lockfile drift
+
+`main`'s `pnpm-lock.yaml` was out of sync with `apps/web/package.json` (framer-motion 12.36→12.37 and @tanstack/react-virtual 3.13.22→3.13.23 had landed in package.json but lockfile was not updated). Each PR branch naturally regenerated the lockfile during `pnpm install`. None of the merged PRs required a manual lockfile fix-up beyond what dependabot already did.
+
+## Decision log
+
+| PR # | Bump | Decision | Reason |
+|---|---|---|---|
+| **285** | @types/supertest 6.0.3 → 7.2.0 (api, dev) | ✅ merged | Types-only; api tests match baseline (6 failed/169 passed suites); typecheck 56 errors (baseline). |
+| **284** | prisma 7.3.0 → 7.5.0 (api, dev) | ✅ merged | Minor within v7; api tests green vs baseline; prisma generate succeeds. |
+| **280** | @nestjs/core 11.1.16 → 11.1.17 (api) | ✅ merged | Patch bump; tests match baseline. |
+| **279** | @types/node 20.19.37 → 25.5.0 (api, dev) | ✅ merged | Types-only; api tests + typecheck match baseline. No Buffer/globals regressions. |
+| **281** | @types/node 20.19.37 → 25.5.0 (web, dev) | ✅ merged | Types-only; web tests 71 passed (baseline); typecheck 2 errors (baseline). |
+| **271** | @types/react 18.3.28 → 19.2.14 (mobile, dev) | ✅ merged | Types-only; mobile typecheck 0 errors; all 52 mobile tests pass. |
+| **268** | @testing-library/react-native 12.9.0 → 13.3.3 (mobile, dev) | ✅ merged | Major bump but dev-only, tests all pass; no breakage in the test helpers used by our 6 suites. |
+| **262** | @types/supertest grouped (dup of #285) | 🚫 closed | Duplicate; same underlying bump merged via #285. |
+| **267** | @sentry/nextjs 9.47.1 → 10.43.0 (web, admin) | ⏸ hold | **Major**. Tests pass, but Next build emits Sentry migration notice: `Could not find onRequestError hook in instrumentation file. Use Sentry.captureRequestError` — silently degrades error visibility in prod. Needs deliberate `instrumentation.ts` update. Also peer-dep warning (wants next@16, we're on 15). Owner-review required. |
+| **272** | tailwindcss 3.4.17 → 4.2.1 (web, dev) | ⏸ hold | **v4 migration**. CSS-first config, removal of `tailwind.config.js`, class generation changes. Needs dedicated 1-day migration + visual regression. |
+| **274** | eslint 8.57.1 → 10.0.3 (api, dev) | ⏸ hold | Flat config migration. `.eslintrc.json` incompatible with ESLint 9+. Deferred ecosystem-wide. |
+| **283** | eslint 8.57.1 → 10.0.3 (web, dev) | ⏸ hold | Same as #274. |
+| **273** | babel-preset-expo 54.0.10 → 55.0.11 (mobile, dev) | ⏸ hold | Expo SDK 55 bundle. App is on Expo SDK 54. |
+| **275** | expo-auth-session 5.5.2 → 55.0.8 (mobile) | ⏸ hold | Expo SDK 55 bundle. |
+| **276** | expo-font 14.0.11 → 55.0.4 (mobile) | ⏸ hold | Expo SDK 55 bundle. |
+| **269** | expo-local-authentication 17.0.8 → 55.0.8 (root) | ⏸ hold | Expo SDK 55 bundle. Major native-module API jump. |
+| **278** | @react-native-async-storage/async-storage 2.2.0 → 3.0.1 (mobile) | ⏸ hold | Native module breaking change; bundled with Expo SDK 55 migration since next regression pass. |
+| **266** | async-storage 2.2.0 → 3.0.1 (root, dup of #278) | ⏸ hold | Duplicate of #278. |
+| **265** | babel-preset-expo 54 → 55 (root, dup of #273) | ⏸ hold | Duplicate of #273. |
+| **264** | expo-status-bar 3.0.9 → 55.0.4 (mobile) | ⏸ hold | Expo SDK 55 bundle (version pinned to SDK major). |
+
+## Surprises / notes
+
+1. **`prisma` 7.3→7.5 was trivially safe** — despite prisma being a database-layer tool with a history of breaking changes, this minor bump installed + generated cleanly + tests stayed at baseline. Merging these low-risk prisma bumps promptly avoids accumulating db-tier drift.
+2. **`@types/react` 18→19 in mobile was a non-event** — types-only, no mobile test/typecheck regression. Next candidate to try in web/api (if dependabot opens those) with the same expectation, but React 19 in runtime (not just types) will need a separate evaluation.
+3. **`@types/node` 20→25 jump** — large-looking bump but mostly additive; no regressions in api or web. @types/node releases track Node minors liberally, not actual runtime changes.
+4. **Sentry 10 was the surprise hazard** — it looks routine but silently breaks error visibility in Next.js 15 unless `instrumentation.ts` is updated per the migration guide. Worth calling out to whoever owns observability.
+5. **Lockfile drift on main**: an earlier sweep merged `apps/web/package.json` version bumps without updating `pnpm-lock.yaml`. Non-blocking for this sweep (each PR's install regenerated), but `pnpm install --frozen-lockfile` would fail in CI on main. Worth fixing in a follow-up.
+
+## Recommended follow-ups
+
+1. **Expo SDK 54→55 migration** — bundles 6 held PRs (#264/265/266/269/273/275/276/278). Mobile-team-owned, schedule after next mobile release.
+2. **ESLint 9/10 flat-config migration** — ecosystem-wide (#274/#283 here + similar deferred PRs in other repos).
+3. **Tailwind v4 migration** — dedicated 1-day web-team PR (#272).
+4. **Sentry 10 migration** — update `instrumentation.ts` + validate onRequestError hook (#267).
+5. **Lockfile sync on main** — run `pnpm install` and commit `pnpm-lock.yaml` so `--frozen-lockfile` passes in CI.


### PR DESCRIPTION
## Summary

Decision log for the 2026-04-18 dependabot sweep of dhanam.

- **Merged (6):** #268, #271, #279, #280, #281, #284, #285
- **Held with comment (10):** #264, #265, #266, #267, #269, #272, #273, #274, #275, #276, #278, #283 — tracked behind Expo SDK 55 migration, ESLint flat-config migration, Tailwind v4 migration, and Sentry 10 instrumentation update.
- **Closed duplicate (1):** #262 (grouped duplicate of #285).

Full baseline, per-PR decision rationale, and follow-up recommendations in `docs/dependabot-sweeps/2026-04-18.md`.

## Test plan

- [ ] Review the decision log for any PR whose hold reason doesn't match your expectations
- [ ] Confirm the Expo SDK 55 migration bundle ownership (mobile team)
- [ ] Schedule the Sentry 10 instrumentation update (#267) before next production deploy that relies on error tracking
- [ ] Fix lockfile drift on `main` (`pnpm install && commit pnpm-lock.yaml`)

Generated as part of the dependabot triage session.