### PR TITLE
fix(web): document NEXT_PUBLIC invariant on .env.production + guard script [AUDIT H13]

### DIFF
--- a/apps/web/.env.production
+++ b/apps/web/.env.production
@@ -1,5 +1,15 @@
 # Production environment configuration
-# These values are baked into the Next.js bundle at build time
+# These values are baked into the Next.js bundle at build time.
+#
+# INVARIANT: this file must only contain NEXT_PUBLIC_* keys. Secrets of any
+# kind (API tokens, DB passwords, signing keys) MUST live in K8s secrets or
+# Enclii's secret store, never in this file. The audit 2026-04-23 H13 scan
+# flagged generic ".env* committed" as a broad ecosystem concern; keeping
+# this file tracked is intentional because Next.js build-time
+# NEXT_PUBLIC_* constants are public by design (they reach every browser
+# loading the app). Adding any non-NEXT_PUBLIC_ key here is a security
+# incident — the guard `scripts/verify-env-production.sh` exits non-zero
+# when it finds one.
 
 # API Configuration - MUST include /v1 prefix
 NEXT_PUBLIC_API_URL=https://api.dhan.am/v1

--- a/scripts/verify-env-production.sh
+++ b/scripts/verify-env-production.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Guard: apps/web/.env.production must only contain NEXT_PUBLIC_* keys.
+# Exit non-zero if any non-NEXT_PUBLIC key is present.
+set -euo pipefail
+FILE="${1:-apps/web/.env.production}"
+if [ ! -f "$FILE" ]; then
+  echo "OK (file missing): $FILE"
+  exit 0
+fi
+bad=$(grep -vE '^\s*(#|$)' "$FILE" | grep -vE '^\s*NEXT_PUBLIC_' || true)
+if [ -n "$bad" ]; then
+  echo "::error::$FILE contains non-NEXT_PUBLIC keys:"
+  echo "$bad"
+  exit 1
+fi
+echo "OK: $FILE contains only NEXT_PUBLIC_* keys."


### PR DESCRIPTION
Audit 2026-04-23 H13. The audit flagged any committed `.env*` file
as a broad ecosystem concern, but `apps/web/.env.production` is
intentionally tracked — it contains only `NEXT_PUBLIC_*` constants
that Next.js bakes into the browser bundle at build time. These
values reach every user on first page load; they are public by
design and removing them from git would force every CI pipeline to
stage a synthetic `.env` file.

Changes:
- Header comment on `apps/web/.env.production` documents the
  invariant and points at the guard script + incident response.
- `scripts/verify-env-production.sh` exits non-zero when a
  non-`NEXT_PUBLIC_` key sneaks in. Run manually or wire into a CI
  job; not gated as mandatory yet because the `security-first.yml`
  workflow doesn't exist here.

Sibling repos with real leaked credentials (social-sentiment-monitor)
are being scrubbed in their own PRs with rotation checklists.

## Test plan
- [ ] CI green on the branch.
- [ ] Review the audit file-line anchors in `claudedocs/ECOSYSTEM_AUDIT_2026-04-23.md`.

Full audit: `claudedocs/ECOSYSTEM_AUDIT_2026-04-23.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
