### PR TITLE
test(t5): unskip 5 form validation tests, swap fireEvent to userEvent [AUDIT T5]

### DIFF
--- a/apps/web/src/components/forms/login-form.test.tsx
+++ b/apps/web/src/components/forms/login-form.test.tsx
@@ -114,14 +114,14 @@ describe('LoginForm', () => {
     expect(toggleButton).toHaveAttribute('aria-label', 'Show password');
   });
 
-  it.skip('should show validation errors for empty fields on submit', async () => {
-    // Import fireEvent locally to avoid conflict if not imported at top
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { fireEvent } = require('@testing-library/react');
+  // AUDIT-2026-04-23 T5 resolved: un-skipped, swapped to userEvent.click
+  // which goes through jsdom's synthetic event path (fireEvent.click
+  // did not propagate through react-hook-form's async resolver here).
+  it('should show validation errors for empty fields on submit [AUDIT-T5]', async () => {
+    const user = userEvent.setup();
     render(<LoginForm onSubmit={mockOnSubmit} />);
 
-    // Use fireEvent.click instead of user.click to avoid jsdom/react interaction bug
-    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+    await user.click(screen.getByRole('button', { name: 'Sign in' }));
 
     await waitFor(() => {
       expect(screen.getByText('Invalid email address')).toBeInTheDocument();

--- a/apps/web/src/components/forms/register-form.test.tsx
+++ b/apps/web/src/components/forms/register-form.test.tsx
@@ -121,9 +121,9 @@ describe('RegisterForm', () => {
     expect(eyeIcons).toHaveLength(2);
 
     // Both toggle buttons should have "Show password" aria-label initially
-    const toggleButtons = screen.getAllByRole('button').filter((btn) =>
-      btn.getAttribute('aria-label')?.includes('password')
-    );
+    const toggleButtons = screen
+      .getAllByRole('button')
+      .filter((btn) => btn.getAttribute('aria-label')?.includes('password'));
     expect(toggleButtons).toHaveLength(2);
     toggleButtons.forEach((btn) => {
       expect(btn).toHaveAttribute('aria-label', 'Show password');
@@ -155,7 +155,11 @@ describe('RegisterForm', () => {
     expect(toggleAgain).toHaveAttribute('aria-label', 'Show password');
   });
 
-  it.skip('should show validation errors for empty fields on submit', async () => {
+  // AUDIT-2026-04-23 / finding T5: registration form validation skipped.
+  // 4 tests below (empty fields, invalid email, weak password, missing uppercase) cover
+  // user-facing error messaging on the signup form. Un-skip after fixing jsdom/react interaction.
+  // See /Users/aldoruizluna/labspace/claudedocs/ECOSYSTEM_AUDIT_2026-04-23.md
+  it('should show validation errors for empty fields on submit [AUDIT-T5]', async () => {
     const user = userEvent.setup();
     render(<RegisterForm onSubmit={mockOnSubmit} />);
 
@@ -169,7 +173,7 @@ describe('RegisterForm', () => {
     expect(mockOnSubmit).not.toHaveBeenCalled();
   });
 
-  it.skip('should show validation error for invalid email', async () => {
+  it('should show validation error for invalid email [AUDIT-T5]', async () => {
     const user = userEvent.setup();
     render(<RegisterForm onSubmit={mockOnSubmit} />);
 
@@ -184,7 +188,7 @@ describe('RegisterForm', () => {
     });
   });
 
-  it.skip('should show validation error for weak password', async () => {
+  it('should show validation error for weak password [AUDIT-T5]', async () => {
     const user = userEvent.setup();
     render(<RegisterForm onSubmit={mockOnSubmit} />);
 
@@ -198,7 +202,7 @@ describe('RegisterForm', () => {
     });
   });
 
-  it.skip('should show error when password missing uppercase letter', async () => {
+  it('should show error when password missing uppercase letter [AUDIT-T5]', async () => {
     const user = userEvent.setup();
     render(<RegisterForm onSubmit={mockOnSubmit} />);
 


### PR DESCRIPTION
Audit 2026-04-23 finding T5. 5 form-validation tests were skipped
with `un-skip after fixing jsdom/react fireEvent interaction`:

- `apps/web/src/components/forms/login-form.test.tsx:119`
- `apps/web/src/components/forms/register-form.test.tsx:162, 176, 191, 205`

The register-form tests already used `userEvent`; only the skip
markers were blocking them. The login-form test used
`fireEvent.click`, which doesn't propagate through react-hook-form's
async resolver in the current jsdom setup — swapped to
`userEvent.click` (same pattern as the passing sibling tests in the
same file).

Skipped tests that were **not** in audit scope (register-form.test.tsx:221
"missing number" and :269 "without accepting terms") left as-is
pending separate triage.

Investigation report + per-finding rationale:
`claudedocs/SKIPPED_TESTS_AUDIT_2026-04-23.md`.

## Test plan
- [ ] CI green on the branch.
- [ ] Review the audit file-line anchors in `claudedocs/ECOSYSTEM_AUDIT_2026-04-23.md`.

Full audit: `claudedocs/ECOSYSTEM_AUDIT_2026-04-23.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
