### PR TITLE
fix(publish): --ignore-scripts so SDK publish isn't blocked by apps/api postinstall

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -88,7 +88,11 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        # --ignore-scripts so workspace postinstall hooks (e.g. apps/api's
+        # Prisma config loader that needs DATABASE_URL) don't block SDK
+        # publishing. The published packages (billing-sdk, shared, esg,
+        # simulations) have no lifecycle scripts of their own.
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Authenticate to npm.madfam.io
         run: |


### PR DESCRIPTION
## Summary

`@dhanam/billing-sdk@0.2.0` has **never successfully published** to npm.madfam.io since 2026-03-14. Every tagged publish + workflow_dispatch attempt in \`publish-packages.yml\` fails at \`pnpm install --frozen-lockfile\` because \`apps/api/postinstall\` runs the Prisma config loader, which needs \`DATABASE_URL\` — but the publish job doesn't (and shouldn't) provision a DB.

Downstream effect: **karafiel main CI** and **forgesight main CI** have been failing for weeks because they try to resolve \`@dhanam/billing-sdk\` from npm.madfam.io — the registry returns \`401\` on the missing tarball, surfaces as \`npm error code E401 Unable to authenticate\`. Looked like a token rotation issue; wasn't.

### Fix

Add \`--ignore-scripts\` to the \`pnpm install\` step in \`publish-packages.yml\`. The four publishable packages (billing-sdk, shared, esg, simulations) have no lifecycle scripts of their own — the workspace-wide postinstall chain is only needed for app development, not for publishing.

## Test plan

- [ ] CI green on this PR (proves the install step now succeeds)
- [ ] After merge, **manually dispatch** \`publish-packages.yml\` with \`package=@dhanam/billing-sdk\` and \`dry_run=true\` — confirm it reaches the \`pnpm publish --dry-run\` step without the Prisma postinstall error
- [ ] Then dispatch again with \`dry_run=false\` to actually publish 0.2.0 to npm.madfam.io
- [ ] Verify: \`curl -sI https://npm.madfam.io/@dhanam%2Fbilling-sdk/-/billing-sdk-0.2.0.tgz\` returns 200 (currently 401)
- [ ] Re-run karafiel and forgesight main CI — install step should now succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)