### PR TITLE
fix(publish): filter install + build to target package only

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -88,11 +88,13 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        # --ignore-scripts so workspace postinstall hooks (e.g. apps/api's
-        # Prisma config loader that needs DATABASE_URL) don't block SDK
-        # publishing. The published packages (billing-sdk, shared, esg,
-        # simulations) have no lifecycle scripts of their own.
-        run: pnpm install --frozen-lockfile --ignore-scripts
+        # Filter to just the package being published (+ its workspace deps).
+        # Avoids two problems:
+        #   1. apps/api postinstall needs DATABASE_URL (not available here)
+        #   2. apps/mobile lockfile drift blocks the entire workspace
+        # Also --ignore-scripts for belt-and-braces. The publishable packages
+        # (billing-sdk, shared, esg, simulations) have no lifecycle scripts.
+        run: pnpm install --frozen-lockfile --ignore-scripts --filter '${{ needs.resolve.outputs.package_name }}...'
 
       - name: Authenticate to npm.madfam.io
         run: |
@@ -100,8 +102,8 @@ jobs:
         env:
           NPM_MADFAM_TOKEN: ${{ secrets.NPM_MADFAM_TOKEN }}
 
-      - name: Build all packages
-        run: pnpm build:packages
+      - name: Build target package (and its workspace deps)
+        run: pnpm --filter '${{ needs.resolve.outputs.package_name }}...' build
 
       - name: Typecheck target package
         run: pnpm --filter '${{ needs.resolve.outputs.package_name }}' typecheck


### PR DESCRIPTION
## Summary

Follow-up to [#333](https://github.com/madfam-org/dhanam/pull/333). The \`--ignore-scripts\` fix cleared the Prisma postinstall blocker, but the publish dry-run still failed at install time because **\`apps/mobile/package.json\` has Expo dep version specifiers that don't match the lockfile** (e.g. \`expo-auth-session: ~55.0.14\` in package.json vs \`~5.5.2\` in lockfile).

The publish job only needs the **target package plus its workspace dependencies** — there's no reason to validate or install the entire workspace. Filter the install + build accordingly.

### Changes

\`pnpm install\`: add \`--filter '<package>...'\` so only the target package and its transitive workspace deps are resolved. billing-sdk only depends on @dhanam/config; the other publishable packages are similarly narrow.

\`pnpm build\`: swap \`build:packages\` (builds all of them) for \`--filter '<package>...' build\` (builds just the target + its deps).

## Test plan

- [ ] Merge this PR
- [ ] Dispatch \`publish-packages.yml\` with \`package=@dhanam/billing-sdk\`, \`dry_run=true\`
- [ ] Verify the workflow reaches \`pnpm publish --dry-run\` and passes
- [ ] Dispatch again with \`dry_run=false\` to publish 0.2.0 for real
- [ ] Confirm \`https://npm.madfam.io/@dhanam/billing-sdk/-/billing-sdk-0.2.0.tgz\` returns 200
- [ ] Re-run karafiel + forgesight main CI to confirm install succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)