### PR TITLE
fix(billing-sdk): bump version 0.2.0 -> 0.3.0 (PR #337 follow-up)

### DIFF
--- a/packages/billing-sdk/package.json
+++ b/packages/billing-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dhanam/billing-sdk",
-  "version": "0.2.0",
-  "description": "Dhanam billing SDK — checkout, subscriptions, and webhook verification",
+  "version": "0.3.0",
+  "description": "Dhanam billing SDK — subscriptions, marketplace (Connect), and webhook verification",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
PR #337's commit was supposed to bump `packages/billing-sdk/package.json` to v0.3.0 but the change didn't land in the staged diff. The merged main shows 0.2.0; the publish workflow's version-vs-tag check rightly rejected.

This bumps it now so the publish workflow can re-run cleanly.

After this merges:
1. Re-trigger the Publish Package workflow against tag `@dhanam/billing-sdk@0.3.0` (already pushed) — either delete + repush the tag, or run with workflow_dispatch + dry_run=false.
2. Verify the SDK lands on `npm.madfam.io`.
3. forj's queued CI will then succeed on its dependency-install step.