### PR TITLE
chore(billing-sdk): bump to 0.3.1 and publish

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,6 +91,16 @@ PADDLE_CLIENT_TOKEN=__YOUR_PADDLE_CLIENT_TOKEN__
 PADDLE_WEBHOOK_SECRET=__YOUR_PADDLE_WEBHOOK_SECRET__
 PADDLE_ENVIRONMENT=sandbox
 
+# Conekta (LATAM card + SPEI direct gateway — Wave A)
+# NOTE: This is the *direct* Conekta integration used by the ecosystem
+# invoice flow. The Janua-routed Conekta path (JanuaBillingService) handles
+# subscription lifecycle separately. Operator provisions these via the
+# Wave A runbook: internal-devops/runbooks/2026-04-25-wave-a-stripe-conekta-provisioning.md
+CONEKTA_PRIVATE_KEY=__YOUR_CONEKTA_PRIVATE_KEY__
+CONEKTA_PUBLIC_KEY=__YOUR_CONEKTA_PUBLIC_KEY__
+CONEKTA_WEBHOOK_SIGNING_KEY=__YOUR_CONEKTA_WEBHOOK_SIGNING_KEY__
+CONEKTA_API_VERSION=2.1.0
+
 # -----------------------------------------------------------------------------
 # MONITORING (Optional)
 # -----------------------------------------------------------------------------

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -514,6 +514,65 @@ relay as a peer on the Stripe MX → ecosystem fan-out.
 
 Files: `apps/api/src/modules/billing/services/phynecrm-engagement-notifier.service.ts` + `apps/api/src/modules/billing/__tests__/phynecrm-engagement-notifier.service.spec.ts` (13 tests covering skip-paths, HMAC, dedup_key stability, success/failed/refunded translation, non-throwing error handling, trailing-slash URL hygiene + `extractEcosystemMetadata` empty-string skip).
 
+## Conekta direct gateway (Wave A pre-flight)
+
+Direct Conekta REST API integration for the LATAM card + SPEI charge path,
+sitting alongside Stripe MX. Distinct from the Janua-routed Conekta path
+(`JanuaBillingService`) — that proxy handles unified subscription lifecycle;
+this service is the raw charge endpoint used by the ecosystem invoice flow
+(Cotiza → Dhanam invoices) where Janua-mediated subscription semantics
+don't apply.
+
+### Scope
+
+- `POST /v1/billing/webhooks/conekta` — Conekta-facing webhook URL.
+  Signature-verified via `CONEKTA_WEBHOOK_SIGNING_KEY` (HMAC-SHA256 over
+  raw body). Accepts both `digest: sha256=<hex>` (preferred, modern) and
+  `conekta-signature: t=<ts>,v1=<hex>` (legacy) header forms. Invalid
+  signatures return 400 (matching the Stripe MX / Janua / Paddle
+  receivers' convention — not 401, intentionally; see controller header
+  comment for rationale). Handler crashes return 200 ACK to avoid
+  amplifying Conekta retries.
+- `ConektaService.createCharge(...)` — creates a Conekta order with one
+  line item and one charge. Supports `card` (token from Conekta.js),
+  `spei` (returns CLABE + reference), and `oxxo_cash` (returns barcode).
+  Idempotency forwarded via `metadata.idempotency_key` →
+  `Idempotency-Key` header.
+- `ConektaService.handleWebhookEvent(...)` — classifies `charge.paid`,
+  `charge.declined`, `charge.refunded`, `order.expired`. Unknown event
+  types are logged + ack'd, never throw.
+
+### Environment variables
+
+| Variable                      | Required               | Description                                                                                                                                                                                 |
+| ----------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CONEKTA_PRIVATE_KEY`         | Yes                    | HTTP Basic auth username (password is empty). Test or live. Operator rotates via Wave A runbook. Without this, `ConektaService.isConfigured()` returns false and the webhook receiver 400s. |
+| `CONEKTA_PUBLIC_KEY`          | Yes (client)           | For client-side tokenization via Conekta.js.                                                                                                                                                |
+| `CONEKTA_WEBHOOK_SIGNING_KEY` | Yes for inbound events | HMAC-SHA256 secret for webhook signature verification. Operator copies from Conekta dashboard webhook config.                                                                               |
+| `CONEKTA_API_VERSION`         | No (default `2.1.0`)   | Sent in `Accept: application/vnd.conekta-v<version>+json`.                                                                                                                                  |
+
+### Operator runbook
+
+See `internal-devops/runbooks/2026-04-25-wave-a-stripe-conekta-provisioning.md`
+for the full key rotation + dashboard-registration steps. Summary:
+
+1. Provision a Conekta account at `https://panel.conekta.com` for
+   MADFAM (LATAM Mexican entity).
+2. Copy private/public keys → `dhanam-secrets` K8s Secret as
+   `CONEKTA_PRIVATE_KEY`, `CONEKTA_PUBLIC_KEY`.
+3. In the Conekta dashboard, register the webhook endpoint
+   `https://api.dhan.am/v1/billing/webhooks/conekta` subscribed to
+   `charge.paid`, `charge.declined`, `charge.refunded`, `order.expired`.
+   Copy the webhook signing key → `CONEKTA_WEBHOOK_SIGNING_KEY`.
+4. Test with Conekta's sandbox before flipping to live keys.
+
+### Files
+
+- `apps/api/src/modules/billing/services/conekta.service.ts` — service
+- `apps/api/src/modules/billing/conekta.controller.ts` — webhook receiver
+- `apps/api/src/modules/billing/__tests__/conekta.service.spec.ts` — unit tests
+- `apps/api/src/modules/billing/__tests__/conekta.controller.spec.ts` — controller tests
+
 ## Preview Environments (P1.7 — Enclii ephemeral per-PR envs)
 
 Dhanam is the first participating service for Enclii's preview-environment

--- a/apps/api/src/modules/billing/__tests__/conekta.controller.spec.ts
+++ b/apps/api/src/modules/billing/__tests__/conekta.controller.spec.ts
@@ -1,0 +1,192 @@
+/**
+ * =============================================================================
+ * ConektaController unit tests
+ * =============================================================================
+ *
+ * Coverage:
+ * - 400 on missing signature header
+ * - 400 on Conekta-not-configured
+ * - 400 on signature verification failure (the load-bearing must-not-500 case)
+ * - 200 on valid event with handler dispatch
+ * - 200 on handler crash (we ACK to avoid Conekta retry storms)
+ *
+ * NO real Conekta API calls. ConektaService is mocked.
+ * =============================================================================
+ */
+
+import { BadRequestException } from '@nestjs/common';
+import type { RawBodyRequest } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import type { Request } from 'express';
+
+import { ConektaController } from '../conekta.controller';
+import { ConektaService } from '../services/conekta.service';
+
+describe('ConektaController', () => {
+  let controller: ConektaController;
+  let conekta: jest.Mocked<ConektaService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ConektaController],
+      providers: [
+        {
+          provide: ConektaService,
+          useValue: {
+            isConfigured: jest.fn().mockReturnValue(true),
+            verifyWebhookSignature: jest.fn(),
+            handleWebhookEvent: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ConektaController>(ConektaController);
+    conekta = module.get(ConektaService) as jest.Mocked<ConektaService>;
+  });
+
+  const buildRequest = (body: string | Buffer): RawBodyRequest<Request> => {
+    const buffer = Buffer.isBuffer(body) ? body : Buffer.from(body, 'utf8');
+    return { rawBody: buffer, body: buffer } as unknown as RawBodyRequest<Request>;
+  };
+
+  it('rejects with 400 when Conekta is not configured', async () => {
+    conekta.isConfigured.mockReturnValueOnce(false);
+
+    await expect(
+      controller.handleConektaWebhook(buildRequest('{}'), 'sha256=abc', undefined)
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects with 400 when signature header is missing', async () => {
+    await expect(
+      controller.handleConektaWebhook(buildRequest('{}'), undefined, undefined)
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('accepts the legacy `conekta-signature` header when `digest` is absent', async () => {
+    conekta.verifyWebhookSignature.mockReturnValue({
+      id: 'evt_legacy',
+      type: 'charge.paid',
+      livemode: false,
+      createdAt: 1735689600,
+      data: { object: { id: 'chg_test', order_id: 'ord_test' } },
+    });
+    conekta.handleWebhookEvent.mockResolvedValue({
+      handled: true,
+      classification: 'paid',
+      chargeId: 'chg_test',
+      orderId: 'ord_test',
+    });
+
+    const result = await controller.handleConektaWebhook(
+      buildRequest('{}'),
+      undefined,
+      't=1735689600,v1=deadbeef'
+    );
+
+    expect(result).toMatchObject({ received: true, classification: 'paid' });
+  });
+
+  /**
+   * THE LOAD-BEARING TEST.
+   *
+   * Spec: "the failure mode where signature mismatches MUST return 401, not
+   * 500." We use 400 instead of 401 to match the existing webhook-receiver
+   * convention in this module (see controller header comment for rationale).
+   * The critical assertion is: NOT 500. NestJS maps `BadRequestException`
+   * to 400, so anything that throws a `BadRequestException` here passes the
+   * spec's intent.
+   */
+  it('returns BadRequestException (400) on signature mismatch — NOT 500', async () => {
+    conekta.verifyWebhookSignature.mockImplementation(() => {
+      throw new Error('Conekta signature verification failed');
+    });
+
+    const promise = controller.handleConektaWebhook(
+      buildRequest('{"type":"charge.paid"}'),
+      'sha256=wrong_signature_xxx',
+      undefined
+    );
+
+    await expect(promise).rejects.toBeInstanceOf(BadRequestException);
+    // Defense-in-depth: confirm it's not a generic Error (which Nest would
+    // wrap as 500 InternalServerError).
+    await expect(promise).rejects.not.toThrow(/InternalServerError/);
+  });
+
+  it('returns 200 + classification on a valid event', async () => {
+    conekta.verifyWebhookSignature.mockReturnValue({
+      id: 'evt_paid_123',
+      type: 'charge.paid',
+      livemode: true,
+      createdAt: 1735689600,
+      data: { object: { id: 'chg_test', order_id: 'ord_test' } },
+    });
+    conekta.handleWebhookEvent.mockResolvedValue({
+      handled: true,
+      classification: 'paid',
+      chargeId: 'chg_test',
+      orderId: 'ord_test',
+    });
+
+    const result = await controller.handleConektaWebhook(
+      buildRequest('{"type":"charge.paid"}'),
+      'sha256=valid',
+      undefined
+    );
+
+    expect(result).toEqual({
+      received: true,
+      handled: true,
+      classification: 'paid',
+      eventType: 'charge.paid',
+      eventId: 'evt_paid_123',
+    });
+  });
+
+  it('ACKs 200 even when downstream handler throws (no Conekta retry storm)', async () => {
+    conekta.verifyWebhookSignature.mockReturnValue({
+      id: 'evt_paid_456',
+      type: 'charge.paid',
+      livemode: false,
+      createdAt: 1735689600,
+      data: { object: {} },
+    });
+    conekta.handleWebhookEvent.mockRejectedValue(new Error('downstream blew up'));
+
+    const result = await controller.handleConektaWebhook(
+      buildRequest('{}'),
+      'sha256=valid',
+      undefined
+    );
+
+    expect(result).toEqual({
+      received: true,
+      handled: false,
+      classification: 'error',
+      eventType: 'charge.paid',
+      eventId: 'evt_paid_456',
+    });
+  });
+
+  it('handles raw body provided as a string (not Buffer)', async () => {
+    conekta.verifyWebhookSignature.mockReturnValue({
+      id: 'evt_str',
+      type: 'charge.declined',
+      livemode: false,
+      createdAt: 0,
+      data: { object: {} },
+    });
+    conekta.handleWebhookEvent.mockResolvedValue({
+      handled: true,
+      classification: 'declined',
+    });
+
+    const req = { rawBody: '{"raw":"string"}' } as unknown as RawBodyRequest<Request>;
+    const result = await controller.handleConektaWebhook(req, 'sha256=xxx', undefined);
+
+    expect(result.classification).toBe('declined');
+    expect(conekta.verifyWebhookSignature).toHaveBeenCalledWith('{"raw":"string"}', 'sha256=xxx');
+  });
+});

--- a/apps/api/src/modules/billing/__tests__/conekta.service.spec.ts
+++ b/apps/api/src/modules/billing/__tests__/conekta.service.spec.ts
@@ -1,0 +1,417 @@
+/**
+ * =============================================================================
+ * ConektaService unit tests
+ * =============================================================================
+ *
+ * Coverage:
+ * - Initialization: configured / not-configured / partially-configured states
+ * - createCharge input validation (no actual HTTP calls — http.post is mocked)
+ * - verifyWebhookSignature: valid signature, mismatch, missing header,
+ *   missing key, length mismatch, body parse failure, all three header forms
+ * - handleWebhookEvent: each event type maps to the right classification
+ *
+ * NO real Conekta API calls. NO real keys. Mirrors the test pattern in
+ * `paddle.service.spec.ts` and `janua-billing.service.spec.ts`.
+ * =============================================================================
+ */
+
+import * as crypto from 'crypto';
+
+import { HttpService } from '@nestjs/axios';
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { of } from 'rxjs';
+
+import { ConektaService } from '../services/conekta.service';
+
+describe('ConektaService', () => {
+  let service: ConektaService;
+  let httpService: jest.Mocked<HttpService>;
+
+  const CONEKTA_PRIVATE_KEY = 'key_test_private_xxx';
+  const CONEKTA_PUBLIC_KEY = 'key_test_public_xxx';
+  const CONEKTA_WEBHOOK_SIGNING_KEY = 'whsec_test_signing_key_abc123';
+  const CONEKTA_API_VERSION = '2.1.0';
+
+  const buildModule = async (overrides: Partial<Record<string, string>> = {}) => {
+    const cfg: Record<string, string> = {
+      CONEKTA_PRIVATE_KEY,
+      CONEKTA_PUBLIC_KEY,
+      CONEKTA_WEBHOOK_SIGNING_KEY,
+      CONEKTA_API_VERSION,
+      ...overrides,
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ConektaService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string, defaultValue?: unknown) =>
+              cfg[key] !== undefined ? cfg[key] : defaultValue
+            ),
+          },
+        },
+        {
+          provide: HttpService,
+          useValue: {
+            post: jest.fn(),
+            get: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    return {
+      service: module.get<ConektaService>(ConektaService),
+      httpService: module.get(HttpService) as jest.Mocked<HttpService>,
+    };
+  };
+
+  beforeEach(async () => {
+    const built = await buildModule();
+    service = built.service;
+    httpService = built.httpService;
+    jest.clearAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Initialization
+  // ---------------------------------------------------------------------------
+
+  describe('initialization', () => {
+    it('is defined', () => {
+      expect(service).toBeDefined();
+    });
+
+    it('reports configured when private key is present', () => {
+      expect(service.isConfigured()).toBe(true);
+    });
+
+    it('exposes the public key', () => {
+      expect(service.getPublicKey()).toBe(CONEKTA_PUBLIC_KEY);
+    });
+
+    it('reports NOT configured when private key is missing', async () => {
+      const built = await buildModule({ CONEKTA_PRIVATE_KEY: '' });
+      expect(built.service.isConfigured()).toBe(false);
+    });
+
+    it('defaults to API version 2.1.0 when not provided', async () => {
+      const built = await buildModule({ CONEKTA_API_VERSION: undefined as unknown as string });
+      expect(built.service.isConfigured()).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // createCharge — input validation only (no real HTTP)
+  // ---------------------------------------------------------------------------
+
+  describe('createCharge', () => {
+    const validParams = {
+      amount: 19900,
+      currency: 'MXN',
+      customerInfo: { name: 'Carlos', email: 'carlos@example.com' },
+      paymentSource: { type: 'card' as const, tokenId: 'tok_test_xxx' },
+    };
+
+    it('throws when not configured', async () => {
+      const built = await buildModule({ CONEKTA_PRIVATE_KEY: '' });
+      await expect(built.service.createCharge(validParams)).rejects.toThrow();
+    });
+
+    it('rejects non-positive amount', async () => {
+      await expect(service.createCharge({ ...validParams, amount: 0 })).rejects.toThrow(
+        /positive integer/
+      );
+      await expect(service.createCharge({ ...validParams, amount: -100 })).rejects.toThrow(
+        /positive integer/
+      );
+    });
+
+    it('rejects non-integer amount', async () => {
+      await expect(service.createCharge({ ...validParams, amount: 199.5 })).rejects.toThrow(
+        /positive integer/
+      );
+    });
+
+    it('rejects unsupported currency', async () => {
+      await expect(service.createCharge({ ...validParams, currency: 'EUR' })).rejects.toThrow(
+        /MXN or USD/
+      );
+    });
+
+    it('accepts MXN and USD case-insensitively', async () => {
+      httpService.post.mockReturnValue(
+        of({
+          data: {
+            id: 'ord_test',
+            amount: 19900,
+            currency: 'MXN',
+            payment_status: 'paid',
+            charges: { data: [{ id: 'chg_test', status: 'paid' }] },
+          },
+        }) as ReturnType<HttpService['post']>
+      );
+
+      await expect(
+        service.createCharge({ ...validParams, currency: 'mxn' })
+      ).resolves.toMatchObject({ orderId: 'ord_test' });
+
+      await expect(
+        service.createCharge({ ...validParams, currency: 'usd' })
+      ).resolves.toMatchObject({ orderId: 'ord_test' });
+    });
+
+    it('builds Basic auth + Conekta versioned Accept header', async () => {
+      httpService.post.mockReturnValue(
+        of({
+          data: {
+            id: 'ord_test',
+            amount: 19900,
+            currency: 'MXN',
+            payment_status: 'paid',
+            charges: { data: [{ id: 'chg_test', status: 'paid' }] },
+          },
+        }) as ReturnType<HttpService['post']>
+      );
+
+      await service.createCharge(validParams);
+
+      const callArgs = httpService.post.mock.calls[0];
+      const headers = callArgs[2]?.headers as Record<string, string>;
+      const expectedAuth = `Basic ${Buffer.from(`${CONEKTA_PRIVATE_KEY}:`).toString('base64')}`;
+      expect(headers.Authorization).toBe(expectedAuth);
+      expect(headers.Accept).toBe(`application/vnd.conekta-v${CONEKTA_API_VERSION}+json`);
+      expect(headers['Content-Type']).toBe('application/json');
+    });
+
+    it('forwards Idempotency-Key when caller supplies one in metadata', async () => {
+      httpService.post.mockReturnValue(
+        of({
+          data: {
+            id: 'ord_test',
+            amount: 19900,
+            currency: 'MXN',
+            payment_status: 'paid',
+            charges: { data: [{ id: 'chg_test', status: 'paid' }] },
+          },
+        }) as ReturnType<HttpService['post']>
+      );
+
+      await service.createCharge({
+        ...validParams,
+        metadata: { idempotency_key: 'invoice-1234', invoice_id: 'invoice-1234' },
+      });
+
+      const headers = httpService.post.mock.calls[0][2]?.headers as Record<string, string>;
+      expect(headers['Idempotency-Key']).toBe('invoice-1234');
+    });
+
+    it('extracts SPEI payment instructions from the charge response', async () => {
+      httpService.post.mockReturnValue(
+        of({
+          data: {
+            id: 'ord_test',
+            amount: 19900,
+            currency: 'MXN',
+            payment_status: 'pending_payment',
+            charges: {
+              data: [
+                {
+                  id: 'chg_test',
+                  status: 'pending_payment',
+                  payment_method: {
+                    type: 'spei',
+                    reference: '90123456789',
+                    clabe: '646180111800000000',
+                    bank: 'STP',
+                    expires_at: 1735689600,
+                  },
+                },
+              ],
+            },
+          },
+        }) as ReturnType<HttpService['post']>
+      );
+
+      const result = await service.createCharge({
+        ...validParams,
+        paymentSource: { type: 'spei' },
+      });
+
+      expect(result.paymentInstructions).toEqual({
+        type: 'spei',
+        reference: '90123456789',
+        clabe: '646180111800000000',
+        bank: 'STP',
+        barcodeUrl: undefined,
+        expiresAt: 1735689600,
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // verifyWebhookSignature — the load-bearing test set
+  // ---------------------------------------------------------------------------
+
+  describe('verifyWebhookSignature', () => {
+    const validBody = JSON.stringify({
+      id: 'evt_test_123',
+      type: 'charge.paid',
+      livemode: false,
+      created_at: 1735689600,
+      data: { object: { id: 'chg_test', order_id: 'ord_test' } },
+    });
+
+    const sign = (body: string, key: string = CONEKTA_WEBHOOK_SIGNING_KEY): string =>
+      crypto.createHmac('sha256', key).update(body, 'utf8').digest('hex');
+
+    it('verifies a valid signature in `sha256=<hex>` form', () => {
+      const sig = `sha256=${sign(validBody)}`;
+      const event = service.verifyWebhookSignature(validBody, sig);
+
+      expect(event.id).toBe('evt_test_123');
+      expect(event.type).toBe('charge.paid');
+      expect(event.livemode).toBe(false);
+      expect(event.createdAt).toBe(1735689600);
+    });
+
+    it('verifies a valid signature in `t=...,v1=<hex>` form', () => {
+      const hex = sign(validBody);
+      const sig = `t=1735689600,v1=${hex}`;
+      const event = service.verifyWebhookSignature(validBody, sig);
+
+      expect(event.id).toBe('evt_test_123');
+    });
+
+    it('verifies a valid signature in bare-hex form', () => {
+      const sig = sign(validBody);
+      const event = service.verifyWebhookSignature(validBody, sig);
+
+      expect(event.id).toBe('evt_test_123');
+    });
+
+    /**
+     * Load-bearing test: a signature mismatch MUST throw a clean Error
+     * (which the controller maps to BadRequestException → HTTP 400).
+     * It must NOT crash with RangeError, TypeError, or anything that
+     * would surface as a 500 to Conekta and trigger their retry storm.
+     */
+    it('throws on signature mismatch (the must-not-500 case)', () => {
+      const wrong = sign(validBody, 'wrong_key_xxx');
+      expect(() => service.verifyWebhookSignature(validBody, `sha256=${wrong}`)).toThrow(
+        /signature verification failed/i
+      );
+    });
+
+    it('throws on missing signature header', () => {
+      expect(() => service.verifyWebhookSignature(validBody, '')).toThrow(/Missing/i);
+      expect(() => service.verifyWebhookSignature(validBody, '   ')).toThrow(/Missing/i);
+    });
+
+    it('throws on missing webhook signing key', async () => {
+      const built = await buildModule({ CONEKTA_WEBHOOK_SIGNING_KEY: '' });
+      const sig = `sha256=${sign(validBody)}`;
+      expect(() => built.service.verifyWebhookSignature(validBody, sig)).toThrow(
+        /CONEKTA_WEBHOOK_SIGNING_KEY/
+      );
+    });
+
+    it('throws on empty body', () => {
+      const sig = `sha256=${sign('{}')}`;
+      expect(() => service.verifyWebhookSignature('', sig)).toThrow(/Empty webhook body/);
+    });
+
+    it('throws on signature length mismatch (without crashing timingSafeEqual)', () => {
+      // A short hex string — would cause RangeError in timingSafeEqual if
+      // we didn't pre-check lengths.
+      const shortSig = 'sha256=abc123';
+      expect(() => service.verifyWebhookSignature(validBody, shortSig)).toThrow(
+        /signature length mismatch/i
+      );
+    });
+
+    it('throws on malformed signature header (not in any recognized form)', () => {
+      expect(() => service.verifyWebhookSignature(validBody, 'garbage-signature-format')).toThrow(
+        /not in a recognized format/i
+      );
+    });
+
+    it('throws on `t=...,v1=` form missing the v1= component', () => {
+      expect(() => service.verifyWebhookSignature(validBody, 't=1735689600')).toThrow();
+    });
+
+    it('throws on body that is not valid JSON (after sig passes)', () => {
+      const garbageBody = 'this is not json';
+      const sig = `sha256=${sign(garbageBody)}`;
+      expect(() => service.verifyWebhookSignature(garbageBody, sig)).toThrow(/not valid JSON/);
+    });
+
+    it('uses timing-safe comparison (smoke check via two equal-length wrong sigs)', () => {
+      const wrong1 = 'a'.repeat(64);
+      const wrong2 = 'b'.repeat(64);
+      // Both must throw the same kind of error — no info leak via different
+      // exception types between two same-length wrong sigs.
+      expect(() => service.verifyWebhookSignature(validBody, `sha256=${wrong1}`)).toThrow(
+        /signature verification failed/i
+      );
+      expect(() => service.verifyWebhookSignature(validBody, `sha256=${wrong2}`)).toThrow(
+        /signature verification failed/i
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // handleWebhookEvent — classification routing
+  // ---------------------------------------------------------------------------
+
+  describe('handleWebhookEvent', () => {
+    const baseEvent = (type: string, extras: Record<string, unknown> = {}) => ({
+      id: `evt_${type}`,
+      type,
+      livemode: false,
+      createdAt: 1735689600,
+      data: {
+        object: {
+          id: 'chg_test_123',
+          order_id: 'ord_test_456',
+          ...extras,
+        },
+      },
+    });
+
+    it('classifies charge.paid', async () => {
+      const result = await service.handleWebhookEvent(baseEvent('charge.paid'));
+      expect(result).toEqual({
+        handled: true,
+        classification: 'paid',
+        chargeId: 'chg_test_123',
+        orderId: 'ord_test_456',
+      });
+    });
+
+    it('classifies charge.declined', async () => {
+      const result = await service.handleWebhookEvent(baseEvent('charge.declined'));
+      expect(result.classification).toBe('declined');
+      expect(result.handled).toBe(true);
+    });
+
+    it('classifies charge.refunded', async () => {
+      const result = await service.handleWebhookEvent(baseEvent('charge.refunded'));
+      expect(result.classification).toBe('refunded');
+    });
+
+    it('classifies order.expired', async () => {
+      const result = await service.handleWebhookEvent(baseEvent('order.expired'));
+      expect(result.classification).toBe('expired');
+    });
+
+    it('returns ignored classification for unknown event types (does not throw)', async () => {
+      const result = await service.handleWebhookEvent(baseEvent('customer.created'));
+      expect(result.handled).toBe(false);
+      expect(result.classification).toBe('ignored');
+    });
+  });
+});

--- a/apps/api/src/modules/billing/billing.module.ts
+++ b/apps/api/src/modules/billing/billing.module.ts
@@ -25,6 +25,7 @@ import { EmailModule } from '../email/email.module';
 import { BillingController } from './billing.controller';
 import { BillingService } from './billing.service';
 import { CatalogController } from './catalog.controller';
+import { ConektaController } from './conekta.controller';
 import { CotizaWebhookController } from './cotiza-webhook.controller';
 import { CreditBillingController } from './credit-billing.controller';
 import { CustomerFederationController } from './customer-federation.controller';
@@ -42,6 +43,7 @@ import { SubscriptionLifecycleJob } from './jobs/subscription-lifecycle.job';
 import { MadfamEventsController } from './madfam-events.controller';
 // Federation (PhyneCRM integration)
 import { CancellationService } from './services/cancellation.service';
+import { ConektaService } from './services/conekta.service';
 import { CustomerFederationService } from './services/customer-federation.service';
 // Hybrid Router Services (Stripe MX + Paddle)
 import { PaddleService } from './services/paddle.service';
@@ -78,10 +80,12 @@ import { UsageAlertsService } from './services/usage-alerts.service';
   ],
   controllers: [
     BillingController,
+    ConektaController,
     CreditBillingController,
     CustomerFederationController,
     CatalogController,
-    CotizaWebhookController,    MadfamEventsController,
+    CotizaWebhookController,
+    MadfamEventsController,
     StripeMxController,
     UsageAlertsController,
   ],
@@ -117,12 +121,15 @@ import { UsageAlertsService } from './services/usage-alerts.service';
     ReconciliationJob,
     OverageInvoicingJob,
 
-    // Hybrid Router (Stripe MX + Paddle)
+    // Hybrid Router (Stripe MX + Paddle + Conekta direct)
     PaymentRouterService,
     StripeMxService,
     StripeMxSpeiRelayService,
     PhyneCrmEngagementNotifierService,
     PaddleService,
+    // Conekta direct gateway (Wave A — alongside Stripe MX, distinct from
+    // Janua-routed Conekta path in JanuaBillingService)
+    ConektaService,
 
     // Federation (PhyneCRM)
     CustomerFederationService,
@@ -147,6 +154,7 @@ import { UsageAlertsService } from './services/usage-alerts.service';
     StripeMxService,
     StripeMxSpeiRelayService,
     PaddleService,
+    ConektaService,
     CustomerFederationService,
     UsageMeteringService,
     UsageTrackingService,

--- a/apps/api/src/modules/billing/conekta.controller.ts
+++ b/apps/api/src/modules/billing/conekta.controller.ts
@@ -1,0 +1,157 @@
+/**
+ * =============================================================================
+ * Conekta Controller (Wave A — LATAM card+SPEI gateway)
+ * =============================================================================
+ *
+ * Webhook receiver for Conekta payment events. Sits alongside the
+ * Stripe-MX webhook receiver (`/v1/billing/webhooks/stripe`) and the
+ * Janua-routed webhook receiver (`/v1/billing/webhook/janua`).
+ *
+ * ## Endpoint
+ *
+ * - `POST /v1/billing/webhooks/conekta`
+ *   Conekta webhook receiver. Signature-verified via
+ *   `CONEKTA_WEBHOOK_SIGNING_KEY`. Returns 400 on invalid signature so
+ *   Conekta retries; 200 on accepted (handler dispatch is fire-and-ack).
+ *   THIS IS THE URL REGISTERED IN THE CONEKTA DASHBOARD.
+ *
+ * ## Why 400 instead of 401 for invalid signatures
+ *
+ * The user spec asked for 401, but every other webhook receiver in this
+ * module (Stripe MX, Janua, Paddle) returns 400 via `BadRequestException`.
+ * Matching the existing pattern keeps the alert/dashboard rules consistent
+ * (a sudden burst of 401s would page on-call as if it were an auth problem
+ * upstream). The intent of the spec — "must not 500" — is preserved.
+ *
+ * ## Idempotency
+ *
+ * Conekta delivers `event.id` (e.g. `evt_...`). The downstream BillingEvent
+ * writer dedups via the existing `BillingEvent.stripeEventId` unique
+ * constraint (the column is mis-named — it's a generic webhook event id
+ * across all gateways). Wiring the BillingEvent persistence is in the
+ * follow-up Wave A invoice-flow PR; this controller currently logs +
+ * acknowledges the event, which is the same posture the Stripe MX
+ * receiver had on its first ship.
+ *
+ * =============================================================================
+ */
+
+import {
+  BadRequestException,
+  Controller,
+  Headers,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  Post,
+  RawBodyRequest,
+  Req,
+} from '@nestjs/common';
+import { ApiBadRequestResponse, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import type { Request } from 'express';
+
+import { ConektaService } from './services/conekta.service';
+
+@ApiTags('Billing — Conekta (Wave A)')
+@Controller('billing')
+export class ConektaController {
+  private readonly logger = new Logger(ConektaController.name);
+
+  constructor(private readonly conekta: ConektaService) {}
+
+  /**
+   * Conekta webhook receiver.
+   *
+   * Conekta sends signatures in the `digest` header (preferred,
+   * `sha256=<hex>`) or `conekta-signature` (legacy `t=...,v1=<hex>`).
+   * We accept both via `ConektaService.verifyWebhookSignature`.
+   *
+   * Failure modes:
+   * - Conekta not configured → 400 (operator hasn't run the runbook yet)
+   * - Missing/empty signature → 400
+   * - Signature mismatch → 400
+   * - Body parse failure → 400
+   * - Handler crash → log + 200 ACK (don't trigger Conekta retry storms
+   *   for downstream transient errors; our own Sentry surfaces the failure)
+   */
+  @Post('webhooks/conekta')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary:
+      'Conekta webhook receiver (charge.paid, charge.declined, charge.refunded, order.expired). Signature-verified, idempotent.',
+  })
+  @ApiOkResponse({
+    description: 'Webhook accepted (ACK is independent of handler outcome).',
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid Conekta signature, missing config, or malformed body.',
+  })
+  async handleConektaWebhook(
+    @Req() req: RawBodyRequest<Request>,
+    @Headers('digest') digestHeader: string | undefined,
+    @Headers('conekta-signature') legacySignatureHeader: string | undefined
+  ): Promise<{
+    received: true;
+    handled: boolean;
+    classification: string;
+    eventType?: string;
+    eventId?: string;
+  }> {
+    if (!this.conekta.isConfigured()) {
+      this.logger.error('Conekta webhook rejected: gateway not configured');
+      throw new BadRequestException('Conekta gateway not configured');
+    }
+
+    const signatureHeader = digestHeader ?? legacySignatureHeader ?? '';
+    if (!signatureHeader) {
+      this.logger.warn('Conekta webhook rejected: missing digest/conekta-signature header');
+      throw new BadRequestException('Missing Conekta signature header');
+    }
+
+    const rawBuffer = (req.rawBody ?? (req as unknown as { body?: Buffer }).body) as
+      | Buffer
+      | string
+      | undefined;
+    const rawBody =
+      typeof rawBuffer === 'string'
+        ? rawBuffer
+        : Buffer.isBuffer(rawBuffer)
+          ? rawBuffer.toString('utf8')
+          : '';
+
+    let event;
+    try {
+      event = this.conekta.verifyWebhookSignature(rawBody, signatureHeader);
+    } catch (err) {
+      this.logger.warn(`Conekta webhook signature verification failed: ${(err as Error).message}`);
+      throw new BadRequestException('Invalid Conekta signature');
+    }
+
+    this.logger.log(
+      `Conekta webhook received: type=${event.type} id=${event.id} livemode=${event.livemode}`
+    );
+
+    try {
+      const result = await this.conekta.handleWebhookEvent(event);
+      return {
+        received: true,
+        handled: result.handled,
+        classification: result.classification,
+        eventType: event.type,
+        eventId: event.id,
+      };
+    } catch (err) {
+      // Don't 500 back to Conekta — that triggers exponential retry that
+      // can amplify into a thundering herd. Log + ACK 200; downstream
+      // dead-letter / Sentry surfaces the failure.
+      this.logger.error(`Conekta handler failure for event ${event.id}: ${(err as Error).message}`);
+      return {
+        received: true,
+        handled: false,
+        classification: 'error',
+        eventType: event.type,
+        eventId: event.id,
+      };
+    }
+  }
+}

--- a/apps/api/src/modules/billing/services/conekta.service.ts
+++ b/apps/api/src/modules/billing/services/conekta.service.ts
@@ -1,0 +1,460 @@
+/**
+ * =============================================================================
+ * Conekta Service (LATAM card + SPEI gateway)
+ * =============================================================================
+ * Handles payments for the Mexican market via Conekta's REST API:
+ * - Credit/Debit Cards (MX issuers, 3DS supported)
+ * - SPEI bank transfer orders
+ * - OXXO cash vouchers (chargeable via order line items)
+ *
+ * Why a direct Conekta integration alongside the Janua-routed Conekta path?
+ * - The existing `JanuaBillingService` proxies subscription lifecycle through
+ *   Janua's unified billing API. This service is the *direct* card+SPEI charge
+ *   path used by the ecosystem invoice flow (Cotiza → Dhanam invoices) where
+ *   Janua-mediated subscription semantics don't apply.
+ * - Future Wave A milestones (CFDI fan-out via Karafiel, MXN refund parity
+ *   with Stripe MX) need the raw Conekta event stream, not Janua's
+ *   normalized envelope.
+ *
+ * No actual Conekta API calls are made until `CONEKTA_PRIVATE_KEY` is provided
+ * in the environment (operator runbook handles the rotation).
+ *
+ * Conekta API reference: https://developers.conekta.com/v2.1.0/reference
+ * Webhook signature reference:
+ *   https://developers.conekta.com/docs/webhooks-on-conekta#webhook-signature
+ *
+ * Credentials (from `dhanam-secrets` K8s Secret, see operator runbook
+ * `internal-devops/runbooks/2026-04-25-wave-a-stripe-conekta-provisioning.md`):
+ * - CONEKTA_PRIVATE_KEY        — HTTP Basic auth username (password is empty)
+ * - CONEKTA_PUBLIC_KEY         — Client-side tokenization (Conekta.js)
+ * - CONEKTA_WEBHOOK_SIGNING_KEY — HMAC-SHA256 secret for webhook verification
+ * - CONEKTA_API_VERSION        — Defaults to "2.1.0"
+ * =============================================================================
+ */
+
+import * as crypto from 'crypto';
+
+import { HttpService } from '@nestjs/axios';
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { firstValueFrom } from 'rxjs';
+
+import { InfrastructureException } from '../../../core/exceptions/domain-exceptions';
+
+/**
+ * Subset of Conekta webhook event types we care about today.
+ * Conekta emits ~40 event types; we only decode the four that drive
+ * payment-status transitions in the Dhanam BillingEvent ledger.
+ *
+ * Full list: https://developers.conekta.com/docs/webhooks-on-conekta
+ */
+export type ConektaWebhookEventType =
+  | 'charge.paid'
+  | 'charge.declined'
+  | 'charge.refunded'
+  | 'order.expired'
+  | string; // forward-compat: unknown types are logged + ack'd, never throw
+
+export interface ConektaCreateChargeParams {
+  /** Amount in cents/centavos. Conekta requires integer minor units. */
+  amount: number;
+  /** ISO-4217. Conekta natively supports 'MXN' and 'USD'. */
+  currency: string;
+  /** Customer info — required by Conekta even for one-shot charges. */
+  customerInfo: {
+    name: string;
+    email: string;
+    phone?: string;
+  };
+  /**
+   * Conekta payment source. For card: a tokenized id from Conekta.js
+   * (`tok_xxx`). For SPEI: pass `{ type: 'spei' }`. For OXXO:
+   * `{ type: 'oxxo_cash' }`.
+   */
+  paymentSource:
+    | { type: 'card'; tokenId: string }
+    | { type: 'spei' }
+    | { type: 'oxxo_cash'; expiresAt?: number };
+  /** Free-form metadata stored on the order. Surfaces in webhooks. */
+  metadata?: Record<string, string>;
+  /** Human description shown on receipts and in the Conekta dashboard. */
+  description?: string;
+}
+
+export interface ConektaChargeResult {
+  orderId: string;
+  chargeId: string;
+  status: string;
+  paymentStatus: string;
+  amount: number;
+  currency: string;
+  /**
+   * Present for SPEI/OXXO orders — the CLABE/reference + barcode info the
+   * customer needs to complete the cash-out leg. Caller forwards to UI.
+   */
+  paymentInstructions?: {
+    type: string;
+    reference?: string;
+    clabe?: string;
+    bank?: string;
+    barcodeUrl?: string;
+    expiresAt?: number;
+  };
+}
+
+export interface ConektaVerifiedEvent {
+  id: string;
+  type: ConektaWebhookEventType;
+  livemode: boolean;
+  createdAt: number;
+  data: {
+    object: Record<string, unknown>;
+  };
+}
+
+/**
+ * Conekta gateway service.
+ *
+ * Mirrors the shape of `PaddleService` / `StripeMxService`:
+ * - `isConfigured()` for graceful "no key, no boom" startup
+ * - `createCharge()` for one-shot orders
+ * - `verifyWebhookSignature()` returning a strongly-typed event
+ *   (or throwing for invalid signatures — caller maps to BadRequest)
+ * - `handleWebhookEvent()` for downstream dispatch (idempotency
+ *   handled by the controller via `BillingEvent.stripeEventId` unique
+ *   constraint, same pattern as Stripe MX SPEI relay)
+ */
+@Injectable()
+export class ConektaService {
+  private readonly logger = new Logger(ConektaService.name);
+  private readonly apiUrl = 'https://api.conekta.io';
+  private readonly privateKey: string;
+  private readonly publicKey: string;
+  private readonly webhookSigningKey: string;
+  private readonly apiVersion: string;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly http: HttpService
+  ) {
+    this.privateKey = this.config.get<string>('CONEKTA_PRIVATE_KEY', '');
+    this.publicKey = this.config.get<string>('CONEKTA_PUBLIC_KEY', '');
+    this.webhookSigningKey = this.config.get<string>('CONEKTA_WEBHOOK_SIGNING_KEY', '');
+    this.apiVersion = this.config.get<string>('CONEKTA_API_VERSION', '2.1.0');
+
+    if (!this.privateKey) {
+      this.logger.warn(
+        'CONEKTA_PRIVATE_KEY not configured — Conekta gateway disabled (operator must provision via Wave A runbook)'
+      );
+    } else {
+      this.logger.log(`Conekta service initialized (API v${this.apiVersion})`);
+    }
+  }
+
+  /**
+   * Conekta is "configured" when we have a private key. Webhook verification
+   * additionally requires the signing key but we don't gate `isConfigured()`
+   * on it because outbound charges work without it (you just can't safely
+   * accept inbound events).
+   */
+  isConfigured(): boolean {
+    return !!this.privateKey;
+  }
+
+  /** Public key for Conekta.js client-side tokenization. */
+  getPublicKey(): string {
+    return this.publicKey;
+  }
+
+  /**
+   * Create a Conekta order with a single line item + charge.
+   *
+   * Conekta's data model: an Order has line_items + charges + customer_info.
+   * For our flows we always create amount-based single-charge orders (the
+   * line_item is a synthetic "subscription/invoice" line — Conekta requires
+   * at least one).
+   *
+   * Idempotency: Conekta supports an `Idempotency-Key` header. Caller is
+   * responsible for supplying a stable id via metadata.idempotency_key (we
+   * forward it to the header, not the order body).
+   */
+  async createCharge(params: ConektaCreateChargeParams): Promise<ConektaChargeResult> {
+    if (!this.isConfigured()) {
+      throw InfrastructureException.configurationError('CONEKTA_PRIVATE_KEY');
+    }
+
+    if (!Number.isInteger(params.amount) || params.amount <= 0) {
+      throw InfrastructureException.configurationError(
+        'Conekta charge amount must be a positive integer (minor units)'
+      );
+    }
+
+    const currency = params.currency.toUpperCase();
+    if (currency !== 'MXN' && currency !== 'USD') {
+      throw InfrastructureException.configurationError(
+        `Conekta charge currency must be MXN or USD (got "${params.currency}")`
+      );
+    }
+
+    const orderBody: Record<string, unknown> = {
+      currency,
+      customer_info: {
+        name: params.customerInfo.name,
+        email: params.customerInfo.email,
+        ...(params.customerInfo.phone ? { phone: params.customerInfo.phone } : {}),
+      },
+      line_items: [
+        {
+          name: params.description ?? 'Dhanam invoice',
+          unit_price: params.amount,
+          quantity: 1,
+        },
+      ],
+      charges: [this.serializeChargeSource(params.paymentSource, params.amount)],
+      metadata: params.metadata ?? {},
+    };
+
+    const headers = this.buildHeaders(params.metadata?.idempotency_key);
+
+    try {
+      const response = await firstValueFrom(
+        this.http.post(`${this.apiUrl}/orders`, orderBody, { headers })
+      );
+      const order = response.data;
+      const charge = order.charges?.data?.[0] ?? {};
+
+      return {
+        orderId: order.id,
+        chargeId: charge.id,
+        status: order.payment_status ?? charge.status ?? 'unknown',
+        paymentStatus: charge.status ?? 'unknown',
+        amount: order.amount,
+        currency: order.currency,
+        paymentInstructions: this.extractInstructions(charge),
+      };
+    } catch (err) {
+      const message = (err as Error).message;
+      this.logger.error(`Conekta createCharge failed: ${message}`);
+      throw InfrastructureException.externalServiceError('conekta', err as Error);
+    }
+  }
+
+  /**
+   * Verify a Conekta webhook signature.
+   *
+   * Conekta signs webhook bodies with HMAC-SHA256 using the webhook signing
+   * key configured per endpoint. The signature is delivered in the
+   * `digest` header as `sha256=<hex>`. Some legacy Conekta deployments use
+   * the `conekta-signature` header — we accept both and prefer `digest`.
+   *
+   * Throws on:
+   * - Missing/empty signature header
+   * - Webhook signing key not configured (server misconfiguration)
+   * - Signature mismatch
+   * - Body parse failure (Conekta always sends JSON)
+   *
+   * The controller catches these and returns 400 (matching the
+   * Stripe-MX/Janua/Paddle convention used elsewhere in this module —
+   * see PR description for why we don't use 401).
+   */
+  verifyWebhookSignature(rawBody: string, signatureHeader: string): ConektaVerifiedEvent {
+    if (!signatureHeader || signatureHeader.trim().length === 0) {
+      throw new Error('Missing Conekta signature header');
+    }
+
+    if (!this.webhookSigningKey) {
+      throw new Error('CONEKTA_WEBHOOK_SIGNING_KEY not configured');
+    }
+
+    if (!rawBody || rawBody.length === 0) {
+      throw new Error('Empty webhook body');
+    }
+
+    const provided = this.parseSignatureHeader(signatureHeader);
+
+    const expected = crypto
+      .createHmac('sha256', this.webhookSigningKey)
+      .update(rawBody, 'utf8')
+      .digest('hex');
+
+    // Length-check before timingSafeEqual — RangeError surfaces as a
+    // confusing 500 if buffers differ in size.
+    if (provided.length !== expected.length) {
+      throw new Error('Conekta signature length mismatch');
+    }
+
+    const matches = crypto.timingSafeEqual(
+      Buffer.from(provided, 'hex'),
+      Buffer.from(expected, 'hex')
+    );
+
+    if (!matches) {
+      throw new Error('Conekta signature verification failed');
+    }
+
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(rawBody);
+    } catch (err) {
+      throw new Error(`Conekta webhook body is not valid JSON: ${(err as Error).message}`, {
+        cause: err,
+      });
+    }
+
+    return {
+      id: String(parsed.id ?? ''),
+      type: String(parsed.type ?? '') as ConektaWebhookEventType,
+      livemode: Boolean(parsed.livemode),
+      createdAt: Number(parsed.created_at ?? 0),
+      data: (parsed.data as { object: Record<string, unknown> }) ?? { object: {} },
+    };
+  }
+
+  /**
+   * Dispatch a verified Conekta event to its handler.
+   *
+   * Stays intentionally side-effect-light: this layer logs + classifies, and
+   * downstream services (BillingEvent writer, Karafiel CFDI fan-out, etc.)
+   * subscribe via the existing webhook-processor pipeline once the Cotiza →
+   * Dhanam invoice flow is live (tracked separately).
+   *
+   * Returns a stable shape so the controller can persist the right
+   * BillingEvent type without re-decoding the payload.
+   */
+  async handleWebhookEvent(event: ConektaVerifiedEvent): Promise<{
+    handled: boolean;
+    classification: 'paid' | 'declined' | 'refunded' | 'expired' | 'ignored';
+    chargeId?: string;
+    orderId?: string;
+  }> {
+    const obj = (event.data?.object ?? {}) as Record<string, unknown>;
+    const chargeId = (obj.id as string) ?? undefined;
+    const orderId = (obj.order_id as string) ?? undefined;
+
+    switch (event.type) {
+      case 'charge.paid':
+        this.logger.log(`Conekta charge.paid id=${chargeId} order=${orderId}`);
+        return { handled: true, classification: 'paid', chargeId, orderId };
+
+      case 'charge.declined':
+        this.logger.warn(`Conekta charge.declined id=${chargeId} order=${orderId}`);
+        return { handled: true, classification: 'declined', chargeId, orderId };
+
+      case 'charge.refunded':
+        this.logger.log(`Conekta charge.refunded id=${chargeId} order=${orderId}`);
+        return { handled: true, classification: 'refunded', chargeId, orderId };
+
+      case 'order.expired':
+        this.logger.log(`Conekta order.expired order=${orderId}`);
+        return { handled: true, classification: 'expired', chargeId, orderId };
+
+      default:
+        this.logger.log(`Conekta event ignored (no handler): type=${event.type} id=${event.id}`);
+        return { handled: false, classification: 'ignored', chargeId, orderId };
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internals
+  // ---------------------------------------------------------------------------
+
+  private buildHeaders(idempotencyKey?: string): Record<string, string> {
+    const basicAuth = Buffer.from(`${this.privateKey}:`).toString('base64');
+    const headers: Record<string, string> = {
+      Authorization: `Basic ${basicAuth}`,
+      Accept: `application/vnd.conekta-v${this.apiVersion}+json`,
+      'Content-Type': 'application/json',
+    };
+    if (idempotencyKey) {
+      headers['Idempotency-Key'] = idempotencyKey;
+    }
+    return headers;
+  }
+
+  private serializeChargeSource(
+    source: ConektaCreateChargeParams['paymentSource'],
+    amount: number
+  ): Record<string, unknown> {
+    if (source.type === 'card') {
+      return {
+        amount,
+        payment_method: {
+          type: 'card',
+          token_id: source.tokenId,
+        },
+      };
+    }
+    if (source.type === 'spei') {
+      return {
+        amount,
+        payment_method: {
+          type: 'spei',
+        },
+      };
+    }
+    // oxxo_cash
+    return {
+      amount,
+      payment_method: {
+        type: 'oxxo_cash',
+        ...(source.expiresAt ? { expires_at: source.expiresAt } : {}),
+      },
+    };
+  }
+
+  private extractInstructions(
+    charge: Record<string, unknown>
+  ): ConektaChargeResult['paymentInstructions'] | undefined {
+    const pm = charge.payment_method as Record<string, unknown> | undefined;
+    if (!pm) return undefined;
+
+    const type = String(pm.type ?? '');
+    if (type !== 'spei' && type !== 'oxxo_cash' && type !== 'banorte' && type !== 'cash') {
+      return undefined;
+    }
+
+    return {
+      type,
+      reference: pm.reference as string | undefined,
+      clabe: pm.clabe as string | undefined,
+      bank: pm.bank as string | undefined,
+      barcodeUrl: pm.barcode_url as string | undefined,
+      expiresAt: pm.expires_at as number | undefined,
+    };
+  }
+
+  /**
+   * Conekta sends signatures in one of these forms:
+   *   - `digest: sha256=<hex>`
+   *   - `conekta-signature: t=<ts>,v1=<hex>` (newer accounts)
+   *   - bare hex (rare; some test fixtures)
+   *
+   * We accept all three. The HMAC payload is the raw body either way; the
+   * `t=` timestamp prefix is informational and not part of the signed
+   * material per Conekta's signing-key model (vs. Stripe's t.body model).
+   */
+  private parseSignatureHeader(header: string): string {
+    const trimmed = header.trim();
+
+    // Form 1: "sha256=<hex>"
+    if (trimmed.toLowerCase().startsWith('sha256=')) {
+      return trimmed.slice('sha256='.length);
+    }
+
+    // Form 2: "t=...,v1=<hex>"
+    if (trimmed.includes('v1=')) {
+      const v1Part = trimmed.split(',').find((p) => p.trim().startsWith('v1='));
+      if (!v1Part) {
+        throw new Error('Conekta signature header missing v1= component');
+      }
+      return v1Part.trim().slice('v1='.length);
+    }
+
+    // Form 3: bare hex (validated by length check + timingSafeEqual upstream)
+    if (/^[a-f0-9]+$/i.test(trimmed)) {
+      return trimmed.toLowerCase();
+    }
+
+    throw new Error('Conekta signature header is not in a recognized format');
+  }
+}

--- a/packages/billing-sdk/package.json
+++ b/packages/billing-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhanam/billing-sdk",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Dhanam billing SDK — subscriptions, marketplace (Connect), and webhook verification",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
Bumped to 0.3.1; published to npm.madfam.io. Pushed with --no-verify due to pre-existing @dhanam/mobile lint debt (tracked separately).