### PR TITLE
fix(publish): --ignore-scripts so postinstalls don't block SDK publish

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -88,7 +88,11 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        # --ignore-scripts so workspace postinstall hooks (e.g. apps/api's
+        # Prisma config loader that needs DATABASE_URL) don't block SDK
+        # publishing. The published packages (billing-sdk, shared, esg,
+        # simulations) have no lifecycle scripts of their own.
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Authenticate to npm.madfam.io
         run: |


### PR DESCRIPTION
Stale-but-real branch from prior work, now pushed. Single commit: 579f3e5 fix(publish): --ignore-scripts so postinstalls don't block SDK publish