### PR TITLE
docs(claude): cross-ref canonical monetization architecture doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Pricing source-of-truth**: `internal-devops/decisions/2026-04-25-tulana-ecosystem-pricing.md`. Dhanam Consumer tiers (Tulana v0.1 recommended, MXN/mo): Free $0 / Copilot Pro 199 / Family Plus 499 / Teams (B2B) 1,499. Plus Dhanam B2B Platform Billing tiers: Starter $0+3.5% / Scale 499+2.5% / Enterprise 2,999+1.5%. Confidence: low — needs validation with real users.
 - **Note**: Dhanam IS the billing platform for the MADFAM ecosystem — it consumes PMF data from Tulana but its own pricing is anchored by Tulana too (no self-anchoring).
 - **PMF measurement**: per RFC 0013, NPS + Sean Ellis + retention via `@madfam/pmf-widget` → Tulana `/v1/pmf/*` endpoints. Composite PMF Score informs price moves + sunset decisions.
+- **Monetization architecture (full ecosystem)**: `internal-devops/ecosystem/monetization-architecture-2026-04-26.md`. Canonical end-to-end reference for money flows, fan-out signing, CFDI pipeline, PMF gating, and operator-only blockers. Dhanam is the singular Stripe-key holder per the operator's 2026-04-25 directive.
 
 ---
 


### PR DESCRIPTION
## Summary

One-line addition to CLAUDE.md cross-referencing the new canonical monetization architecture doc at \`internal-devops/ecosystem/monetization-architecture-2026-04-26.md\` (internal-devops#72).

Reinforces Dhanam's role as the singular Stripe-key holder per operator's 2026-04-25 directive.

## Test plan
- [ ] Doc renders, link is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)