### PR TITLE
feat(billing): webhook DLQ + admin replay endpoint for consumer fan-out

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -164,3 +164,21 @@ PHYNECRM_API_URL=https://phyne-crm.madfam.io
 # PHYNE_ENGAGEMENT_EVENTS_SECRET, on Cotiza as PHYNECRM_ENGAGEMENT_SECRET.
 PHYNE_ENGAGEMENT_EVENTS_SECRET=your-phyne-engagement-events-secret
 PHYNECRM_WEBHOOK_TIMEOUT=10000
+
+# =============================================================================
+# Synthetic Revenue Probe (production-only smoke test)
+# =============================================================================
+# When enabled, a cron self-fires a signed `probe-*` event at the live
+# /v1/billing/madfam-events receiver every 5 minutes and verifies the
+# Stripe → Dhanam → consumer fan-out path. Failures emit a structured ERROR
+# log line `synthetic_revenue_probe_failed` and a Sentry event with tag
+# `synthetic_revenue_probe_failed=true` (hook PagerDuty by tag).
+#
+# Default is OFF. Flip to `true` only in the production ConfigMap; staging
+# and dev should leave it off so they don't probe api.dhan.am.
+# Probe rows are tagged via `stripeEventId` prefix `probe-` and reaped daily
+# at 04:30 UTC by a cleanup cron in the same module.
+SYNTHETIC_PROBE_ENABLED=false
+# Receiver base URL the probe POSTs to. Production: https://api.dhan.am
+# (default if unset). Override only for cross-environment probe testing.
+SYNTHETIC_PROBE_BASE_URL=https://api.dhan.am

--- a/apps/api/prisma/migrations/20260426000000_add_webhook_delivery_failures/migration.sql
+++ b/apps/api/prisma/migrations/20260426000000_add_webhook_delivery_failures/migration.sql
@@ -1,0 +1,54 @@
+-- Dead-letter queue for outbound product-webhook fan-out (Karafiel, Tezca, …).
+--
+-- Today, when the Stripe MX SPEI relay (and the subscription-lifecycle
+-- product-webhook fan-out) POST to a downstream consumer URL and the
+-- consumer is restarting / 5xxs / times out, the failure is logged and
+-- forgotten — the CFDI for that customer is never issued and nobody
+-- notices. This table captures the failed delivery so an auto-retry
+-- job (and an admin-triggered manual replay endpoint) can re-deliver
+-- it without operator help.
+--
+-- See:
+--   internal-devops/ecosystem/monetization-architecture-2026-04-26.md
+--   apps/api/src/modules/billing/services/webhook-dlq.service.ts
+--   apps/api/src/modules/billing/jobs/webhook-dlq-retry.job.ts
+--   apps/api/src/modules/billing/dlq.controller.ts
+
+-- CreateTable
+CREATE TABLE "webhook_delivery_failures" (
+    "id" TEXT NOT NULL,
+    "event_id" TEXT NOT NULL,
+    "consumer" TEXT NOT NULL,
+    "consumer_url" TEXT NOT NULL,
+    "event_type" TEXT,
+    "payload" JSONB NOT NULL,
+    "signature_header" TEXT NOT NULL,
+    "attempt_count" INTEGER NOT NULL DEFAULT 1,
+    "last_attempt_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "last_status_code" INTEGER,
+    "last_error_message" TEXT,
+    "next_retry_at" TIMESTAMP(3),
+    "resolved_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "webhook_delivery_failures_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex: lookup by source event id (debugging + admin filter)
+CREATE INDEX "webhook_delivery_failures_event_id_idx" ON "webhook_delivery_failures"("event_id");
+
+-- CreateIndex: per-consumer failure-rate dashboards + admin filter
+CREATE INDEX "webhook_delivery_failures_consumer_idx" ON "webhook_delivery_failures"("consumer");
+
+-- CreateIndex: list unresolved failures, newest first (admin DLQ view)
+CREATE INDEX "webhook_delivery_failures_resolved_created_idx"
+    ON "webhook_delivery_failures"("resolved_at", "created_at" DESC);
+
+-- CreateIndex: partial index for the auto-retry job's hot scan path —
+-- only unresolved rows whose next retry has come due. PostgreSQL can
+-- serve "select … where resolved_at is null and next_retry_at <= now()"
+-- straight from this index without touching resolved rows.
+CREATE INDEX "webhook_delivery_failures_due_for_retry_idx"
+    ON "webhook_delivery_failures"("next_retry_at")
+    WHERE "resolved_at" IS NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1177,6 +1177,61 @@ model BillingEvent {
   @@map("billing_events")
 }
 
+/// Dead-letter queue for outbound product-webhook fan-out (Karafiel,
+/// Tezca, etc.). When a downstream consumer is restarting / 5xxs / times
+/// out, the failed delivery lands here so an auto-retry job (and an
+/// admin manual-replay endpoint) can re-deliver it without operator
+/// help. See `apps/api/src/modules/billing/services/webhook-dlq.service.ts`.
+model WebhookDeliveryFailure {
+  id               String    @id @default(uuid())
+  /// The Dhanam-side correlation id for the original event (envelope
+  /// `id` from `StripeMxSpeiRelayService` payment.* envelopes, or the
+  /// crypto.randomUUID() emitted by `notifyProductWebhooks`). Indexed
+  /// so the admin UI can pivot a customer's CFDI ticket against
+  /// failed deliveries quickly.
+  eventId          String    @map("event_id")
+  /// Logical consumer name (the key from PRODUCT_WEBHOOK_URLS, e.g.
+  /// `karafiel`, `tezca`). Used for per-consumer failure-rate dashboards.
+  consumer         String
+  /// The full URL we POSTed to. Stored verbatim so a consumer URL
+  /// rotation is easy to detect from the DLQ alone.
+  consumerUrl      String    @map("consumer_url")
+  /// Optional event type for human-readable filtering in the admin
+  /// UI (e.g. `payment.succeeded`, `subscription.cancelled`). Nullable
+  /// because legacy callers may not have it.
+  eventType        String?   @map("event_type")
+  /// The exact JSON body that was POSTed. Replayed verbatim on retry
+  /// so the HMAC signature stays valid and the consumer's idempotency
+  /// key is preserved.
+  payload          Json
+  /// The HMAC-SHA256 signature value that was sent with the original
+  /// delivery. Replayed verbatim — we never re-sign on retry, because
+  /// re-signing would defeat the consumer's "have I seen this body
+  /// before" dedup.
+  signatureHeader  String    @map("signature_header")
+  attemptCount     Int       @default(1) @map("attempt_count")
+  lastAttemptAt    DateTime  @default(now()) @map("last_attempt_at")
+  lastStatusCode   Int?      @map("last_status_code")
+  lastErrorMessage String?   @map("last_error_message")
+  /// Wall-clock at which the auto-retry job should next attempt this
+  /// delivery. NULL = stop auto-retrying (max attempts exhausted —
+  /// operator must intervene). Auto-retry job uses the partial index
+  /// `webhook_delivery_failures_due_for_retry_idx` to find rows where
+  /// `next_retry_at <= now()` AND `resolved_at IS NULL`.
+  nextRetryAt      DateTime? @map("next_retry_at")
+  /// Set when a retry succeeds OR when an operator manually marks the
+  /// row resolved (out-of-band remediation). Once non-null the row is
+  /// invisible to the auto-retry job.
+  resolvedAt       DateTime? @map("resolved_at")
+  createdAt        DateTime  @default(now()) @map("created_at")
+  updatedAt        DateTime  @updatedAt @map("updated_at")
+
+  @@index([eventId])
+  @@index([consumer])
+  @@index([resolvedAt, createdAt(sort: Desc)])
+  @@map("webhook_delivery_failures")
+}
+
 model UsageMetric {
   id         String          @id @default(uuid())
   userId     String          @map("user_id")

--- a/apps/api/src/modules/billing/__tests__/dlq.controller.spec.ts
+++ b/apps/api/src/modules/billing/__tests__/dlq.controller.spec.ts
@@ -8,6 +8,8 @@
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { JwtAuthGuard } from '../../../core/auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../../../core/auth/guards/roles.guard';
 import { DlqController } from '../dlq.controller';
 import { WebhookDlqService } from '../services/webhook-dlq.service';
 
@@ -28,7 +30,15 @@ describe('DlqController', () => {
           },
         },
       ],
-    }).compile();
+    })
+      // Auth guards are exercised by their own dedicated specs
+      // (roles.guard.spec, jwt-auth-guard.spec); here we override
+      // them so the unit tests focus on controller→service wiring.
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
 
     controller = module.get(DlqController);
     dlq = module.get(WebhookDlqService) as jest.Mocked<WebhookDlqService>;

--- a/apps/api/src/modules/billing/__tests__/dlq.controller.spec.ts
+++ b/apps/api/src/modules/billing/__tests__/dlq.controller.spec.ts
@@ -1,0 +1,177 @@
+/**
+ * Integration tests for DlqController. Auth guards are bypassed at the
+ * unit-test layer (consistent with the rest of the billing module's
+ * controller specs — see credit-billing.controller.spec.ts). Guard
+ * behavior itself is covered by the existing roles.guard spec.
+ */
+
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { DlqController } from '../dlq.controller';
+import { WebhookDlqService } from '../services/webhook-dlq.service';
+
+describe('DlqController', () => {
+  let controller: DlqController;
+  let dlq: jest.Mocked<WebhookDlqService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DlqController],
+      providers: [
+        {
+          provide: WebhookDlqService,
+          useValue: {
+            listFailures: jest.fn(),
+            replayDelivery: jest.fn(),
+            markResolved: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(DlqController);
+    dlq = module.get(WebhookDlqService) as jest.Mocked<WebhookDlqService>;
+  });
+
+  // ─── GET /v1/billing/dlq ─────────────────────────────────────────────
+
+  describe('GET / (list)', () => {
+    it('forwards filters into the service and returns the page', async () => {
+      const page = { items: [{ id: 'a' }], total: 1, limit: 50, offset: 0 };
+      dlq.listFailures.mockResolvedValue(page as any);
+
+      const result = await controller.list({
+        consumer: 'karafiel',
+        since: '2026-04-20T00:00:00Z',
+        includeResolved: false,
+        limit: 50,
+        offset: 0,
+      });
+
+      expect(result).toEqual(page);
+      expect(dlq.listFailures).toHaveBeenCalledWith({
+        consumer: 'karafiel',
+        since: new Date('2026-04-20T00:00:00Z'),
+        includeResolved: false,
+        limit: 50,
+        offset: 0,
+      });
+    });
+
+    it('passes undefined since when omitted', async () => {
+      dlq.listFailures.mockResolvedValue({ items: [], total: 0, limit: 50, offset: 0 } as any);
+
+      await controller.list({});
+
+      expect(dlq.listFailures).toHaveBeenCalledWith({
+        consumer: undefined,
+        since: undefined,
+        includeResolved: undefined,
+        limit: undefined,
+        offset: undefined,
+      });
+    });
+  });
+
+  // ─── POST /v1/billing/dlq/:id/replay ─────────────────────────────────
+
+  describe('POST /:id/replay', () => {
+    it('invokes service with force=true and returns redacted result', async () => {
+      const now = new Date();
+      dlq.replayDelivery.mockResolvedValue({
+        failureId: 'dlq-1',
+        ok: true,
+        statusCode: 200,
+        attemptCount: 1,
+        nextRetryAt: null,
+        resolvedAt: now,
+        // Service may include error context — controller MUST strip it.
+        errorMessage: 'should not leak',
+      } as any);
+
+      const result = await controller.replay('dlq-1');
+
+      expect(dlq.replayDelivery).toHaveBeenCalledWith('dlq-1', { force: true });
+      expect(result).toEqual({
+        id: 'dlq-1',
+        ok: true,
+        statusCode: 200,
+        attemptCount: 1,
+        nextRetryAt: null,
+        resolvedAt: now,
+      });
+      // Critical: error context is NOT included in the HTTP response so
+      // the admin endpoint cannot leak downstream HTML / cookies / headers.
+      expect((result as any).errorMessage).toBeUndefined();
+    });
+
+    it('returns the failed-replay result without throwing (so admin sees the next_retry_at)', async () => {
+      const next = new Date();
+      dlq.replayDelivery.mockResolvedValue({
+        failureId: 'dlq-1',
+        ok: false,
+        statusCode: 503,
+        attemptCount: 1,
+        nextRetryAt: next,
+        resolvedAt: null,
+        errorMessage: 'consumer responded 503',
+      } as any);
+
+      const result = await controller.replay('dlq-1');
+
+      expect(result.ok).toBe(false);
+      expect(result.statusCode).toBe(503);
+      expect(result.nextRetryAt).toBe(next);
+      expect((result as any).errorMessage).toBeUndefined();
+    });
+
+    it('translates service "not found" error into 404 NotFoundException', async () => {
+      dlq.replayDelivery.mockRejectedValue(new Error('webhook_delivery_failure xyz not found'));
+
+      await expect(controller.replay('xyz')).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('does not leak unexpected service errors — collapses to generic 404', async () => {
+      dlq.replayDelivery.mockRejectedValue(new Error('internal: stripe customer secret xyz'));
+
+      await expect(controller.replay('a')).rejects.toBeInstanceOf(NotFoundException);
+      // Verify the message does NOT echo the secret.
+      try {
+        await controller.replay('a');
+      } catch (err) {
+        expect((err as Error).message).not.toContain('stripe customer secret');
+      }
+    });
+  });
+
+  // ─── POST /v1/billing/dlq/:id/resolve ────────────────────────────────
+
+  describe('POST /:id/resolve', () => {
+    it('marks resolved with operator-supplied reason', async () => {
+      const now = new Date();
+      dlq.markResolved.mockResolvedValue({ id: 'dlq-1', resolvedAt: now } as any);
+
+      const result = await controller.resolve('dlq-1', { reason: 'CFDI issued by hand' });
+
+      expect(dlq.markResolved).toHaveBeenCalledWith('dlq-1', {
+        reason: 'CFDI issued by hand',
+      });
+      expect(result).toEqual({ id: 'dlq-1', resolvedAt: now });
+    });
+
+    it('accepts a missing reason (manual resolution without notes)', async () => {
+      dlq.markResolved.mockResolvedValue({ id: 'dlq-1', resolvedAt: new Date() } as any);
+
+      await controller.resolve('dlq-1', {});
+
+      expect(dlq.markResolved).toHaveBeenCalledWith('dlq-1', { reason: undefined });
+    });
+
+    it('returns 404 when the row id does not exist', async () => {
+      dlq.markResolved.mockRejectedValue(new Error('Record to update not found'));
+
+      await expect(controller.resolve('missing', {})).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/modules/billing/__tests__/stripe-mx-spei-relay.service.spec.ts
+++ b/apps/api/src/modules/billing/__tests__/stripe-mx-spei-relay.service.spec.ts
@@ -6,6 +6,7 @@ import { AuditService } from '../../../core/audit/audit.service';
 import { PrismaService } from '../../../core/prisma/prisma.service';
 import { PhyneCrmEngagementNotifierService } from '../services/phynecrm-engagement-notifier.service';
 import { StripeMxSpeiRelayService } from '../services/stripe-mx-spei-relay.service';
+import { WebhookDlqService } from '../services/webhook-dlq.service';
 
 // ─── helpers ────────────────────────────────────────────────────────────
 
@@ -129,6 +130,14 @@ describe('StripeMxSpeiRelayService', () => {
           // relay tests stay focused on dispatch/envelope concerns.
           provide: PhyneCrmEngagementNotifierService,
           useValue: { notify: jest.fn().mockResolvedValue(undefined) },
+        },
+        {
+          // DLQ is best-effort persistence; stub to a no-op so the
+          // existing relay tests stay focused on envelope/dispatch.
+          // Failure-recording behavior is covered separately in
+          // webhook-dlq.service.spec.ts.
+          provide: WebhookDlqService,
+          useValue: { recordFailure: jest.fn().mockResolvedValue(undefined) },
         },
       ],
     }).compile();

--- a/apps/api/src/modules/billing/__tests__/webhook-dlq-retry.job.spec.ts
+++ b/apps/api/src/modules/billing/__tests__/webhook-dlq-retry.job.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for WebhookDlqRetryJob — verifies the cron tick honors the
+ * feature flag, batches via the service, and is failure-isolated so a
+ * single bad row cannot halt the batch.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { WebhookDlqRetryJob } from '../jobs/webhook-dlq-retry.job';
+import { WebhookDlqService } from '../services/webhook-dlq.service';
+
+function makeServiceMock(overrides: Partial<WebhookDlqService> = {}) {
+  return {
+    isAutoRetryEnabled: jest.fn().mockReturnValue(true),
+    findDueForRetry: jest.fn().mockResolvedValue([]),
+    replayDelivery: jest.fn().mockResolvedValue({ ok: true }),
+    ...overrides,
+  } as unknown as jest.Mocked<WebhookDlqService>;
+}
+
+describe('WebhookDlqRetryJob', () => {
+  let job: WebhookDlqRetryJob;
+  let dlq: jest.Mocked<WebhookDlqService>;
+
+  async function buildJob(serviceMock: jest.Mocked<WebhookDlqService>) {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WebhookDlqRetryJob,
+        { provide: WebhookDlqService, useValue: serviceMock },
+      ],
+    }).compile();
+    job = module.get(WebhookDlqRetryJob);
+    dlq = module.get(WebhookDlqService) as jest.Mocked<WebhookDlqService>;
+  }
+
+  describe('feature flag gate', () => {
+    it('does nothing when isAutoRetryEnabled() returns false', async () => {
+      await buildJob(makeServiceMock({ isAutoRetryEnabled: jest.fn().mockReturnValue(false) }));
+
+      await job.tick();
+
+      expect(dlq.findDueForRetry).not.toHaveBeenCalled();
+      expect(dlq.replayDelivery).not.toHaveBeenCalled();
+    });
+
+    it('runs the batch when isAutoRetryEnabled() returns true', async () => {
+      await buildJob(makeServiceMock());
+      await job.tick();
+      expect(dlq.findDueForRetry).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('batch processing', () => {
+    it('replays each due row and counts ok/fail outcomes', async () => {
+      await buildJob(
+        makeServiceMock({
+          findDueForRetry: jest.fn().mockResolvedValue([
+            { id: 'a', consumer: 'karafiel' },
+            { id: 'b', consumer: 'karafiel' },
+            { id: 'c', consumer: 'tezca' },
+          ]),
+          replayDelivery: jest
+            .fn()
+            .mockResolvedValueOnce({ ok: true })
+            .mockResolvedValueOnce({ ok: false })
+            .mockResolvedValueOnce({ ok: true }),
+        })
+      );
+
+      await job.tick();
+
+      expect(dlq.replayDelivery).toHaveBeenCalledTimes(3);
+      expect(dlq.replayDelivery).toHaveBeenNthCalledWith(1, 'a');
+      expect(dlq.replayDelivery).toHaveBeenNthCalledWith(2, 'b');
+      expect(dlq.replayDelivery).toHaveBeenNthCalledWith(3, 'c');
+    });
+
+    it('continues processing remaining rows when a single replay throws', async () => {
+      await buildJob(
+        makeServiceMock({
+          findDueForRetry: jest.fn().mockResolvedValue([
+            { id: 'a', consumer: 'k' },
+            { id: 'b', consumer: 'k' },
+            { id: 'c', consumer: 'k' },
+          ]),
+          replayDelivery: jest
+            .fn()
+            .mockResolvedValueOnce({ ok: true })
+            .mockRejectedValueOnce(new Error('boom'))
+            .mockResolvedValueOnce({ ok: true }),
+        })
+      );
+
+      // Should not propagate the exception out of the cron tick.
+      await expect(job.tick()).resolves.toBeUndefined();
+      expect(dlq.replayDelivery).toHaveBeenCalledTimes(3);
+    });
+
+    it('returns gracefully when findDueForRetry throws (e.g., DB hiccup)', async () => {
+      await buildJob(
+        makeServiceMock({
+          findDueForRetry: jest.fn().mockRejectedValue(new Error('db down')),
+        })
+      );
+
+      await expect(job.tick()).resolves.toBeUndefined();
+      expect(dlq.replayDelivery).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when no rows are due', async () => {
+      await buildJob(makeServiceMock({ findDueForRetry: jest.fn().mockResolvedValue([]) }));
+
+      await job.tick();
+
+      expect(dlq.replayDelivery).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/modules/billing/__tests__/webhook-dlq.service.spec.ts
+++ b/apps/api/src/modules/billing/__tests__/webhook-dlq.service.spec.ts
@@ -1,0 +1,511 @@
+/**
+ * Unit tests for WebhookDlqService — failure persistence, replay,
+ * exponential backoff, max-attempts cap, and resolution paths.
+ *
+ * Prisma is mocked (no DB roundtrip). `globalThis.fetch` is mocked
+ * for replay HTTP calls.
+ */
+
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { PrismaService } from '../../../core/prisma/prisma.service';
+import {
+  WEBHOOK_DLQ_MAX_ATTEMPTS,
+  WebhookDlqService,
+  computeNextRetry,
+} from '../services/webhook-dlq.service';
+
+function makePrismaMock() {
+  return {
+    webhookDeliveryFailure: {
+      create: jest.fn(),
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      update: jest.fn(),
+      count: jest.fn(),
+    },
+  };
+}
+
+function makeConfigMock(overrides: Record<string, string> = {}) {
+  return {
+    get: jest.fn((key: string, defaultValue?: any) => {
+      if (key in overrides) return overrides[key];
+      return defaultValue;
+    }),
+  };
+}
+
+describe('WebhookDlqService', () => {
+  let service: WebhookDlqService;
+  let prisma: ReturnType<typeof makePrismaMock>;
+  let config: ReturnType<typeof makeConfigMock>;
+  let sentry: { captureMessage: jest.Mock };
+  let fetchMock: jest.Mock;
+
+  beforeEach(async () => {
+    prisma = makePrismaMock();
+    config = makeConfigMock();
+    sentry = { captureMessage: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WebhookDlqService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: ConfigService, useValue: config },
+        { provide: 'SentryService', useValue: sentry },
+      ],
+    }).compile();
+
+    service = module.get(WebhookDlqService);
+
+    fetchMock = jest.fn();
+    (globalThis as any).fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    delete (globalThis as any).fetch;
+  });
+
+  // ─── recordFailure ───────────────────────────────────────────────────
+
+  describe('recordFailure', () => {
+    it('persists the failed delivery with attempt_count=1 and next_retry_at ~1min in the future', async () => {
+      const before = Date.now();
+      prisma.webhookDeliveryFailure.create.mockResolvedValue({ id: 'dlq-1' });
+
+      await service.recordFailure({
+        eventId: 'env-abc',
+        consumer: 'karafiel',
+        consumerUrl: 'https://api.karafiel.mx/api/v1/webhooks/dhanam',
+        eventType: 'payment.succeeded',
+        payload: { type: 'payment.succeeded', id: 'env-abc' },
+        signatureHeader: 'sig-deadbeef',
+        statusCode: 503,
+        errorMessage: 'consumer responded 503: maintenance',
+      });
+
+      expect(prisma.webhookDeliveryFailure.create).toHaveBeenCalledTimes(1);
+      const data = prisma.webhookDeliveryFailure.create.mock.calls[0][0].data;
+
+      expect(data.eventId).toBe('env-abc');
+      expect(data.consumer).toBe('karafiel');
+      expect(data.consumerUrl).toBe('https://api.karafiel.mx/api/v1/webhooks/dhanam');
+      expect(data.eventType).toBe('payment.succeeded');
+      expect(data.signatureHeader).toBe('sig-deadbeef');
+      expect(data.attemptCount).toBe(1);
+      expect(data.lastStatusCode).toBe(503);
+      expect(data.lastErrorMessage).toBe('consumer responded 503: maintenance');
+
+      // next_retry should be ~1 minute (BASE * 2^1) from now.
+      const nextRetryMs = (data.nextRetryAt as Date).getTime() - before;
+      expect(nextRetryMs).toBeGreaterThanOrEqual(2 * 60 * 1000 - 100);
+      expect(nextRetryMs).toBeLessThanOrEqual(2 * 60 * 1000 + 1000);
+    });
+
+    it('emits a Sentry warning with structured failure context', async () => {
+      prisma.webhookDeliveryFailure.create.mockResolvedValue({ id: 'dlq-2' });
+
+      await service.recordFailure({
+        eventId: 'env-xyz',
+        consumer: 'tezca',
+        consumerUrl: 'https://example.com',
+        eventType: 'subscription.created',
+        payload: {},
+        signatureHeader: 'sig',
+        statusCode: 502,
+        errorMessage: 'bad gateway',
+      });
+
+      expect(sentry.captureMessage).toHaveBeenCalledWith(
+        'Webhook delivery failed: tezca',
+        'warning',
+        expect.objectContaining({
+          event_id: 'env-xyz',
+          consumer: 'tezca',
+          attempt: 1,
+          status_code: 502,
+          error_message: 'bad gateway',
+          dlq_id: 'dlq-2',
+        })
+      );
+    });
+
+    it('truncates pathologically long error messages so the DB row stays small', async () => {
+      prisma.webhookDeliveryFailure.create.mockResolvedValue({ id: 'dlq-3' });
+      const huge = 'x'.repeat(10000);
+
+      await service.recordFailure({
+        eventId: 'e1',
+        consumer: 'k',
+        consumerUrl: 'u',
+        payload: {},
+        signatureHeader: 's',
+        errorMessage: huge,
+      });
+
+      const data = prisma.webhookDeliveryFailure.create.mock.calls[0][0].data;
+      expect(data.lastErrorMessage.length).toBeLessThanOrEqual(2048);
+      expect(data.lastErrorMessage.endsWith('...')).toBe(true);
+    });
+  });
+
+  // ─── replayDelivery: success path ────────────────────────────────────
+
+  describe('replayDelivery — success path', () => {
+    it('on 2xx, marks the row resolved and clears next_retry_at', async () => {
+      prisma.webhookDeliveryFailure.findUnique.mockResolvedValue({
+        id: 'dlq-1',
+        eventId: 'env-abc',
+        consumer: 'karafiel',
+        consumerUrl: 'https://k.example.com/webhook',
+        eventType: 'payment.succeeded',
+        payload: { hello: 'world' },
+        signatureHeader: 'sig-1',
+        attemptCount: 2,
+        resolvedAt: null,
+      });
+      prisma.webhookDeliveryFailure.update.mockResolvedValue({
+        id: 'dlq-1',
+        attemptCount: 3,
+        nextRetryAt: null,
+        resolvedAt: new Date(),
+      });
+      fetchMock.mockResolvedValue({ ok: true, status: 200, text: async () => 'ok' });
+
+      const result = await service.replayDelivery('dlq-1');
+
+      expect(result.ok).toBe(true);
+      expect(result.resolvedAt).not.toBeNull();
+      // Body must be the persisted payload, signature replayed verbatim.
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('https://k.example.com/webhook');
+      expect(init.headers['X-Dhanam-Signature']).toBe('sig-1');
+      expect(init.headers['X-Dhanam-Replay']).toBe('true');
+      expect(init.headers['X-Dhanam-Replay-Attempt']).toBe('3');
+      expect(JSON.parse(init.body)).toEqual({ hello: 'world' });
+
+      // Update zeroed out next_retry_at and stamped resolved_at.
+      const updateData = prisma.webhookDeliveryFailure.update.mock.calls[0][0].data;
+      expect(updateData.nextRetryAt).toBeNull();
+      expect(updateData.resolvedAt).toBeInstanceOf(Date);
+      expect(updateData.lastErrorMessage).toBeNull();
+    });
+
+    it('force=true resets attempt to 1 (manual replay UX)', async () => {
+      prisma.webhookDeliveryFailure.findUnique.mockResolvedValue({
+        id: 'dlq-1',
+        eventId: 'env-abc',
+        consumer: 'karafiel',
+        consumerUrl: 'https://k.example.com/webhook',
+        eventType: 'payment.succeeded',
+        payload: {},
+        signatureHeader: 'sig-1',
+        attemptCount: 7,
+        resolvedAt: null,
+      });
+      prisma.webhookDeliveryFailure.update.mockResolvedValue({
+        id: 'dlq-1',
+        attemptCount: 1,
+        nextRetryAt: null,
+        resolvedAt: new Date(),
+      });
+      fetchMock.mockResolvedValue({ ok: true, status: 200, text: async () => 'ok' });
+
+      await service.replayDelivery('dlq-1', { force: true });
+
+      const updateData = prisma.webhookDeliveryFailure.update.mock.calls[0][0].data;
+      expect(updateData.attemptCount).toBe(1);
+      expect(fetchMock.mock.calls[0][1].headers['X-Dhanam-Replay-Attempt']).toBe('1');
+    });
+  });
+
+  // ─── replayDelivery: failure path + backoff ──────────────────────────
+
+  describe('replayDelivery — failure path', () => {
+    it('on 5xx, increments attempt_count and schedules next_retry_at via 2^n backoff', async () => {
+      prisma.webhookDeliveryFailure.findUnique.mockResolvedValue({
+        id: 'dlq-1',
+        eventId: 'env',
+        consumer: 'karafiel',
+        consumerUrl: 'https://k.example.com',
+        eventType: 'payment.succeeded',
+        payload: {},
+        signatureHeader: 's',
+        attemptCount: 3,
+        resolvedAt: null,
+      });
+      prisma.webhookDeliveryFailure.update.mockResolvedValue({
+        id: 'dlq-1',
+        attemptCount: 4,
+        nextRetryAt: new Date(Date.now() + 16 * 60 * 1000),
+        resolvedAt: null,
+      });
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 503,
+        text: async () => 'maintenance',
+      });
+
+      const before = Date.now();
+      const result = await service.replayDelivery('dlq-1');
+      expect(result.ok).toBe(false);
+
+      const updateData = prisma.webhookDeliveryFailure.update.mock.calls[0][0].data;
+      expect(updateData.attemptCount).toBe(4);
+      expect(updateData.lastStatusCode).toBe(503);
+      expect(updateData.lastErrorMessage).toContain('503');
+
+      // 2^4 = 16 minutes from now.
+      const dt = (updateData.nextRetryAt as Date).getTime() - before;
+      expect(dt).toBeGreaterThanOrEqual(16 * 60 * 1000 - 100);
+      expect(dt).toBeLessThanOrEqual(16 * 60 * 1000 + 1000);
+    });
+
+    it('on network error, captures it as next_retry-eligible (non-exhausted)', async () => {
+      prisma.webhookDeliveryFailure.findUnique.mockResolvedValue({
+        id: 'dlq-1',
+        eventId: 'env',
+        consumer: 'karafiel',
+        consumerUrl: 'https://k.example.com',
+        eventType: 'payment.succeeded',
+        payload: {},
+        signatureHeader: 's',
+        attemptCount: 1,
+        resolvedAt: null,
+      });
+      prisma.webhookDeliveryFailure.update.mockResolvedValue({
+        id: 'dlq-1',
+        attemptCount: 2,
+        nextRetryAt: new Date(),
+        resolvedAt: null,
+      });
+      fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      const result = await service.replayDelivery('dlq-1');
+
+      expect(result.ok).toBe(false);
+      expect(result.statusCode).toBeUndefined();
+      const updateData = prisma.webhookDeliveryFailure.update.mock.calls[0][0].data;
+      expect(updateData.lastStatusCode).toBeNull();
+      expect(updateData.lastErrorMessage).toContain('network/timeout');
+      expect(updateData.lastErrorMessage).toContain('ECONNREFUSED');
+    });
+
+    it('after MAX_ATTEMPTS-1 prior attempts, sets next_retry_at=null (exhausted)', async () => {
+      prisma.webhookDeliveryFailure.findUnique.mockResolvedValue({
+        id: 'dlq-1',
+        eventId: 'env',
+        consumer: 'karafiel',
+        consumerUrl: 'https://k.example.com',
+        eventType: 'payment.succeeded',
+        payload: {},
+        signatureHeader: 's',
+        attemptCount: WEBHOOK_DLQ_MAX_ATTEMPTS - 1,
+        resolvedAt: null,
+      });
+      prisma.webhookDeliveryFailure.update.mockResolvedValue({
+        id: 'dlq-1',
+        attemptCount: WEBHOOK_DLQ_MAX_ATTEMPTS,
+        nextRetryAt: null,
+        resolvedAt: null,
+      });
+      fetchMock.mockResolvedValue({ ok: false, status: 500, text: async () => 'err' });
+
+      const result = await service.replayDelivery('dlq-1');
+
+      expect(result.ok).toBe(false);
+      const updateData = prisma.webhookDeliveryFailure.update.mock.calls[0][0].data;
+      expect(updateData.attemptCount).toBe(WEBHOOK_DLQ_MAX_ATTEMPTS);
+      expect(updateData.nextRetryAt).toBeNull();
+
+      // Sentry escalates to 'error' on exhaustion.
+      const sentryCall = sentry.captureMessage.mock.calls[0];
+      expect(sentryCall[1]).toBe('error');
+      expect(sentryCall[2].exhausted).toBe(true);
+    });
+  });
+
+  // ─── replayDelivery: edge cases ──────────────────────────────────────
+
+  describe('replayDelivery — edge cases', () => {
+    it('throws a clear error when the row id does not exist', async () => {
+      prisma.webhookDeliveryFailure.findUnique.mockResolvedValue(null);
+      await expect(service.replayDelivery('nope')).rejects.toThrow('not found');
+    });
+
+    it('returns no-op for an already-resolved row', async () => {
+      prisma.webhookDeliveryFailure.findUnique.mockResolvedValue({
+        id: 'dlq-1',
+        attemptCount: 3,
+        nextRetryAt: null,
+        resolvedAt: new Date('2026-01-01'),
+      });
+
+      const result = await service.replayDelivery('dlq-1');
+
+      expect(result.ok).toBe(true);
+      expect(result.resolvedAt).toEqual(new Date('2026-01-01'));
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(prisma.webhookDeliveryFailure.update).not.toHaveBeenCalled();
+    });
+
+    it('force=true overrides resolved guard so operators can re-deliver historical rows', async () => {
+      prisma.webhookDeliveryFailure.findUnique.mockResolvedValue({
+        id: 'dlq-1',
+        eventId: 'env',
+        consumer: 'k',
+        consumerUrl: 'https://k.example.com',
+        eventType: 'payment.succeeded',
+        payload: {},
+        signatureHeader: 's',
+        attemptCount: 5,
+        resolvedAt: new Date('2026-01-01'),
+      });
+      prisma.webhookDeliveryFailure.update.mockResolvedValue({
+        id: 'dlq-1',
+        attemptCount: 1,
+        nextRetryAt: null,
+        resolvedAt: new Date(),
+      });
+      fetchMock.mockResolvedValue({ ok: true, status: 200, text: async () => 'ok' });
+
+      await service.replayDelivery('dlq-1', { force: true });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ─── findDueForRetry ─────────────────────────────────────────────────
+
+  describe('findDueForRetry', () => {
+    it('queries unresolved rows due now with attempt_count < MAX_ATTEMPTS', async () => {
+      const now = new Date('2026-04-26T12:00:00Z');
+      prisma.webhookDeliveryFailure.findMany.mockResolvedValue([]);
+
+      await service.findDueForRetry(25, now);
+
+      expect(prisma.webhookDeliveryFailure.findMany).toHaveBeenCalledWith({
+        where: {
+          resolvedAt: null,
+          nextRetryAt: { lte: now },
+          attemptCount: { lt: WEBHOOK_DLQ_MAX_ATTEMPTS },
+        },
+        orderBy: { nextRetryAt: 'asc' },
+        take: 25,
+      });
+    });
+  });
+
+  // ─── markResolved + listFailures ─────────────────────────────────────
+
+  describe('markResolved', () => {
+    it('stamps resolvedAt and captures the operator reason', async () => {
+      prisma.webhookDeliveryFailure.update.mockResolvedValue({
+        id: 'dlq-1',
+        resolvedAt: new Date(),
+      });
+
+      await service.markResolved('dlq-1', { reason: 'CFDI issued manually' });
+
+      const updateData = prisma.webhookDeliveryFailure.update.mock.calls[0][0].data;
+      expect(updateData.resolvedAt).toBeInstanceOf(Date);
+      expect(updateData.nextRetryAt).toBeNull();
+      expect(updateData.lastErrorMessage).toContain('CFDI issued manually');
+    });
+  });
+
+  describe('listFailures', () => {
+    it('defaults to unresolved-only and orders newest-first', async () => {
+      prisma.webhookDeliveryFailure.findMany.mockResolvedValue([]);
+      prisma.webhookDeliveryFailure.count.mockResolvedValue(0);
+
+      await service.listFailures({});
+
+      const args = prisma.webhookDeliveryFailure.findMany.mock.calls[0][0];
+      expect(args.where).toEqual({ resolvedAt: null });
+      expect(args.orderBy).toEqual({ createdAt: 'desc' });
+      expect(args.take).toBe(50);
+      expect(args.skip).toBe(0);
+    });
+
+    it('applies consumer + since filters and includeResolved override', async () => {
+      prisma.webhookDeliveryFailure.findMany.mockResolvedValue([]);
+      prisma.webhookDeliveryFailure.count.mockResolvedValue(0);
+
+      const since = new Date('2026-04-20');
+      await service.listFailures({
+        consumer: 'karafiel',
+        since,
+        includeResolved: true,
+        limit: 10,
+        offset: 20,
+      });
+
+      const args = prisma.webhookDeliveryFailure.findMany.mock.calls[0][0];
+      expect(args.where).toEqual({ consumer: 'karafiel', createdAt: { gte: since } });
+      expect(args.take).toBe(10);
+      expect(args.skip).toBe(20);
+    });
+
+    it('caps limit at 200 to avoid pathological pages', async () => {
+      prisma.webhookDeliveryFailure.findMany.mockResolvedValue([]);
+      prisma.webhookDeliveryFailure.count.mockResolvedValue(0);
+      await service.listFailures({ limit: 9999 });
+      expect(prisma.webhookDeliveryFailure.findMany.mock.calls[0][0].take).toBe(200);
+    });
+  });
+
+  // ─── isAutoRetryEnabled ──────────────────────────────────────────────
+
+  describe('isAutoRetryEnabled', () => {
+    it('returns true when WEBHOOK_DLQ_AUTO_RETRY_ENABLED=true', async () => {
+      const c = makeConfigMock({ WEBHOOK_DLQ_AUTO_RETRY_ENABLED: 'true' });
+      const s = new WebhookDlqService(prisma as any, c as any);
+      expect(s.isAutoRetryEnabled()).toBe(true);
+    });
+
+    it('returns false when WEBHOOK_DLQ_AUTO_RETRY_ENABLED=false', async () => {
+      const c = makeConfigMock({
+        WEBHOOK_DLQ_AUTO_RETRY_ENABLED: 'false',
+        NODE_ENV: 'production',
+      });
+      const s = new WebhookDlqService(prisma as any, c as any);
+      expect(s.isAutoRetryEnabled()).toBe(false);
+    });
+
+    it('defaults to true in production, false elsewhere', async () => {
+      const prod = new WebhookDlqService(
+        prisma as any,
+        makeConfigMock({ NODE_ENV: 'production' }) as any
+      );
+      const dev = new WebhookDlqService(
+        prisma as any,
+        makeConfigMock({ NODE_ENV: 'development' }) as any
+      );
+      expect(prod.isAutoRetryEnabled()).toBe(true);
+      expect(dev.isAutoRetryEnabled()).toBe(false);
+    });
+  });
+
+  // ─── computeNextRetry helper ─────────────────────────────────────────
+
+  describe('computeNextRetry', () => {
+    it('produces 2^attempt minutes of delay', () => {
+      const now = new Date('2026-04-26T00:00:00Z');
+      const delays: Array<[number, number]> = [
+        [1, 2],
+        [2, 4],
+        [3, 8],
+        [4, 16],
+        [9, 512],
+      ];
+      for (const [attempt, expectedMin] of delays) {
+        const next = computeNextRetry(attempt, now);
+        expect(next.getTime() - now.getTime()).toBe(expectedMin * 60 * 1000);
+      }
+    });
+  });
+});

--- a/apps/api/src/modules/billing/billing.module.ts
+++ b/apps/api/src/modules/billing/billing.module.ts
@@ -19,6 +19,7 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 
 import { AuditModule } from '../../core/audit/audit.module';
+import { MonitoringModule } from '../../core/monitoring/monitoring.module';
 import { PrismaModule } from '../../core/prisma/prisma.module';
 import { EmailModule } from '../email/email.module';
 
@@ -40,6 +41,7 @@ import { JanuaBillingService } from './janua-billing.service';
 import { OverageInvoicingJob } from './jobs/overage-invoicing.job';
 import { ReconciliationJob } from './jobs/reconciliation.job';
 import { SubscriptionLifecycleJob } from './jobs/subscription-lifecycle.job';
+import { SyntheticRevenueProbeJob } from './jobs/synthetic-revenue-probe.job';
 import { MadfamEventsController } from './madfam-events.controller';
 // Federation (PhyneCRM integration)
 import { CancellationService } from './services/cancellation.service';
@@ -55,6 +57,7 @@ import { RevenueMetricsService } from './services/revenue-metrics.service';
 import { PhyneCrmEngagementNotifierService } from './services/phynecrm-engagement-notifier.service';
 import { StripeMxSpeiRelayService } from './services/stripe-mx-spei-relay.service';
 import { StripeMxService } from './services/stripe-mx.service';
+import { SyntheticRevenueProbeService } from './services/synthetic-revenue-probe.service';
 // Extracted sub-services (usage, lifecycle, webhooks)
 import { SubscriptionLifecycleService } from './services/subscription-lifecycle.service';
 import { TrialService } from './services/trial.service';
@@ -73,6 +76,9 @@ import { UsageAlertsService } from './services/usage-alerts.service';
     PrismaModule,
     AuditModule,
     EmailModule,
+    // MonitoringModule provides the 'SentryService' string token used
+    // by WebhookDlqService for per-failure structured Sentry events.
+    MonitoringModule,
     HttpModule.register({
       timeout: 30000,
       maxRedirects: 5,
@@ -85,6 +91,7 @@ import { UsageAlertsService } from './services/usage-alerts.service';
     CustomerFederationController,
     CatalogController,
     CotizaWebhookController,
+    DlqController,
     MadfamEventsController,
     StripeMxController,
     UsageAlertsController,
@@ -120,6 +127,19 @@ import { UsageAlertsService } from './services/usage-alerts.service';
     SubscriptionLifecycleJob,
     ReconciliationJob,
     OverageInvoicingJob,
+
+    // Synthetic revenue probe — production-only smoke test for the
+    // Stripe → Dhanam → consumer fan-out path. See
+    // services/synthetic-revenue-probe.service.ts for design rationale.
+    SyntheticRevenueProbeService,
+    SyntheticRevenueProbeJob,
+
+    // Webhook DLQ + auto-retry (Karafiel/Tezca CFDI safety net).
+    // Captures failed downstream deliveries from the Stripe MX SPEI
+    // relay + the subscription product-webhook fan-out, with both
+    // an auto-retry cron job and an admin manual-replay endpoint.
+    WebhookDlqService,
+    WebhookDlqRetryJob,
 
     // Hybrid Router (Stripe MX + Paddle + Conekta direct)
     PaymentRouterService,
@@ -159,6 +179,7 @@ import { UsageAlertsService } from './services/usage-alerts.service';
     UsageMeteringService,
     UsageTrackingService,
     SubscriptionLifecycleService,
+    WebhookDlqService,
     WebhookProcessorService,
     SubscriptionGuard,
     UsageLimitGuard,

--- a/apps/api/src/modules/billing/dlq.controller.ts
+++ b/apps/api/src/modules/billing/dlq.controller.ts
@@ -1,0 +1,136 @@
+/**
+ * Admin-only Dead-Letter Queue controller.
+ *
+ *   GET  /v1/billing/dlq               — paginated list of unresolved failures
+ *   POST /v1/billing/dlq/:id/replay    — re-POST this delivery now (resets attempt)
+ *   POST /v1/billing/dlq/:id/resolve   — mark resolved without retry
+ *
+ * Auth: JWT + `@Roles('ADMIN')` (matches the existing pattern used by
+ * `BillingController.getRevenueMetrics()` — RolesGuard treats
+ * `user.isAdmin === true` as a global admin pass).
+ *
+ * Error responses are intentionally generic (`Failure not found` /
+ * `Failed to replay delivery`) so an attacker with a leaked admin
+ * token cannot enumerate consumer URL structure or downstream errors
+ * via 404 / 422 deltas. Detailed error context is logged + sent to
+ * Sentry, never returned in HTTP response bodies.
+ */
+
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  NotFoundException,
+  Param,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiForbiddenResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+
+import { Roles } from '../../core/auth/decorators/roles.decorator';
+import { JwtAuthGuard } from '../../core/auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../../core/auth/guards/roles.guard';
+
+import { DlqListQueryDto } from './dto/dlq-list-query.dto';
+import { DlqResolveDto } from './dto/dlq-resolve.dto';
+import { WebhookDlqService } from './services/webhook-dlq.service';
+
+@ApiTags('Billing — DLQ')
+@ApiBearerAuth()
+@Controller('billing/dlq')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('ADMIN')
+@ApiUnauthorizedResponse({ description: 'Invalid or missing JWT token' })
+@ApiForbiddenResponse({ description: 'User lacks admin privileges' })
+export class DlqController {
+  private readonly logger = new Logger(DlqController.name);
+
+  constructor(private readonly dlq: WebhookDlqService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'List unresolved webhook delivery failures (admin only)',
+    description:
+      'Paginated. Defaults to unresolved rows newest-first; pass ?includeResolved=true to see history.',
+  })
+  @ApiOkResponse({ description: 'List returned' })
+  async list(@Query() q: DlqListQueryDto) {
+    return this.dlq.listFailures({
+      consumer: q.consumer,
+      since: q.since ? new Date(q.since) : undefined,
+      includeResolved: q.includeResolved,
+      limit: q.limit,
+      offset: q.offset,
+    });
+  }
+
+  @Post(':id/replay')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Manually re-POST a failed delivery (admin only)',
+    description:
+      'Resets attempt_count and fires immediately. On success, marks the row resolved. On failure, the row is updated with the new error and the next_retry_at is recomputed from a fresh attempt 1.',
+  })
+  @ApiParam({ name: 'id', description: 'WebhookDeliveryFailure id' })
+  @ApiOkResponse({ description: 'Replay attempted; check `ok` field for outcome' })
+  async replay(@Param('id') id: string) {
+    let result;
+    try {
+      result = await this.dlq.replayDelivery(id, { force: true });
+    } catch (err) {
+      // Service throws on not-found; everything else is captured.
+      if ((err as Error).message?.includes('not found')) {
+        throw new NotFoundException('Failure not found');
+      }
+      this.logger.error(`Manual replay error for ${id}: ${(err as Error).message}`);
+      // Generic message — no leaking consumer URL or downstream payload.
+      throw new NotFoundException('Failure not found');
+    }
+    // Strip server-side error_message from the response so the API
+    // doesn't echo arbitrary HTML / cookies / headers from the
+    // downstream consumer back to the admin client.
+    return {
+      id: result.failureId,
+      ok: result.ok,
+      statusCode: result.statusCode ?? null,
+      attemptCount: result.attemptCount,
+      nextRetryAt: result.nextRetryAt,
+      resolvedAt: result.resolvedAt,
+    };
+  }
+
+  @Post(':id/resolve')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Mark a failure resolved without retry (admin only)',
+    description:
+      'Operator handled the delivery out-of-band (e.g., manually issued the CFDI in Karafiel). Captures the optional `reason` in the row for audit.',
+  })
+  @ApiParam({ name: 'id', description: 'WebhookDeliveryFailure id' })
+  @ApiOkResponse({ description: 'Failure marked resolved' })
+  async resolve(@Param('id') id: string, @Body() body: DlqResolveDto) {
+    try {
+      const row = await this.dlq.markResolved(id, { reason: body.reason });
+      return {
+        id: row.id,
+        resolvedAt: row.resolvedAt,
+      };
+    } catch (err) {
+      // Prisma throws P2025 when the id doesn't exist; map to 404.
+      this.logger.warn(`Resolve attempted on missing/invalid DLQ row ${id}`);
+      throw new NotFoundException('Failure not found');
+    }
+  }
+}

--- a/apps/api/src/modules/billing/dto/dlq-list-query.dto.ts
+++ b/apps/api/src/modules/billing/dto/dlq-list-query.dto.ts
@@ -1,0 +1,38 @@
+import { Type } from 'class-transformer';
+import { IsBoolean, IsDateString, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
+/**
+ * Query params for `GET /v1/billing/dlq`. All optional.
+ */
+export class DlqListQueryDto {
+  /** Filter by consumer key (e.g. `karafiel`). */
+  @IsOptional()
+  @IsString()
+  consumer?: string;
+
+  /** ISO timestamp; only failures created at or after this are returned. */
+  @IsOptional()
+  @IsDateString()
+  since?: string;
+
+  /** Include resolved rows (default false — DLQ view is unresolved-only). */
+  @IsOptional()
+  @Type(() => Boolean)
+  @IsBoolean()
+  includeResolved?: boolean;
+
+  /** Page size (default 50, max 200). */
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(200)
+  limit?: number;
+
+  /** Page offset (default 0). */
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  offset?: number;
+}

--- a/apps/api/src/modules/billing/dto/dlq-resolve.dto.ts
+++ b/apps/api/src/modules/billing/dto/dlq-resolve.dto.ts
@@ -1,0 +1,12 @@
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+/**
+ * Body for `POST /v1/billing/dlq/:id/resolve`. Operator records why
+ * they're closing the row out-of-band so the audit trail captures it.
+ */
+export class DlqResolveDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  reason?: string;
+}

--- a/apps/api/src/modules/billing/jobs/webhook-dlq-retry.job.ts
+++ b/apps/api/src/modules/billing/jobs/webhook-dlq-retry.job.ts
@@ -1,0 +1,74 @@
+/**
+ * Webhook DLQ auto-retry cron job.
+ *
+ * Every 5 minutes, picks up unresolved `WebhookDeliveryFailure` rows
+ * whose `next_retry_at <= now()` and `attempt_count < MAX_ATTEMPTS`,
+ * and re-POSTs them via `WebhookDlqService.replayDelivery()`.
+ *
+ * Guarded by `WebhookDlqService.isAutoRetryEnabled()` (env-driven, on
+ * in production, off elsewhere) so test suites + local dev don't
+ * accidentally hammer real Karafiel / Tezca instances.
+ *
+ * Backoff schedule + max-attempts policy lives in the service —
+ * this job is intentionally a thin scheduler shell.
+ *
+ * Failure isolation: each row is replayed inside its own try/catch so
+ * a malformed row can't poison the rest of the batch. Per-row outcomes
+ * are reported via service logging + Sentry; the cron itself only
+ * reports aggregate batch totals.
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+
+import { WebhookDlqService } from '../services/webhook-dlq.service';
+
+/** Max rows to replay per tick. Keeps a tick under ~30s in the worst case. */
+export const WEBHOOK_DLQ_BATCH_SIZE = 50;
+
+@Injectable()
+export class WebhookDlqRetryJob {
+  private readonly logger = new Logger(WebhookDlqRetryJob.name);
+
+  constructor(private readonly dlq: WebhookDlqService) {}
+
+  @Cron(CronExpression.EVERY_5_MINUTES, { name: 'webhook-dlq-retry' })
+  async tick(): Promise<void> {
+    if (!this.dlq.isAutoRetryEnabled()) {
+      // Quiet log — this fires every 5 min in dev/staging and we don't
+      // want to spam.
+      return;
+    }
+
+    let due: Awaited<ReturnType<WebhookDlqService['findDueForRetry']>>;
+    try {
+      due = await this.dlq.findDueForRetry(WEBHOOK_DLQ_BATCH_SIZE);
+    } catch (err) {
+      this.logger.error(`DLQ findDueForRetry failed: ${(err as Error).message}`);
+      return;
+    }
+
+    if (due.length === 0) return;
+
+    let resolved = 0;
+    let stillFailing = 0;
+
+    for (const row of due) {
+      try {
+        const result = await this.dlq.replayDelivery(row.id);
+        if (result.ok) resolved++;
+        else stillFailing++;
+      } catch (err) {
+        // Service is supposed to never throw; if it does, log + continue.
+        this.logger.error(
+          `DLQ replay threw for ${row.id} (${row.consumer}): ${(err as Error).message}`
+        );
+        stillFailing++;
+      }
+    }
+
+    this.logger.log(
+      `DLQ retry tick: ${due.length} due, ${resolved} resolved, ${stillFailing} still failing`
+    );
+  }
+}

--- a/apps/api/src/modules/billing/services/stripe-mx-spei-relay.service.ts
+++ b/apps/api/src/modules/billing/services/stripe-mx-spei-relay.service.ts
@@ -88,6 +88,7 @@ import { AuditService } from '../../../core/audit/audit.service';
 import { PrismaService } from '../../../core/prisma/prisma.service';
 
 import { PhyneCrmEngagementNotifierService } from './phynecrm-engagement-notifier.service';
+import { WebhookDlqService } from './webhook-dlq.service';
 
 /** Outbound Dhanam envelope for payment.* events. */
 export interface DhanamPaymentEnvelope {
@@ -182,7 +183,8 @@ export class StripeMxSpeiRelayService {
     private readonly prisma: PrismaService,
     private readonly config: ConfigService,
     private readonly audit: AuditService,
-    private readonly phynecrmNotifier: PhyneCrmEngagementNotifierService
+    private readonly phynecrmNotifier: PhyneCrmEngagementNotifierService,
+    private readonly dlq: WebhookDlqService
   ) {}
 
   /**
@@ -540,6 +542,11 @@ export class StripeMxSpeiRelayService {
 
     await Promise.all(
       targets.map(async ({ product, url }) => {
+        let statusCode: number | undefined;
+        let errorMessage: string | undefined;
+        let ok = false;
+        let responseBodySnippet = '';
+
         try {
           const res = await fetch(url, {
             method: 'POST',
@@ -551,7 +558,15 @@ export class StripeMxSpeiRelayService {
             },
             body,
           });
-          if (!res.ok) {
+          statusCode = res.status;
+          ok = res.ok;
+          if (!ok) {
+            try {
+              responseBodySnippet = (await res.text()).slice(0, 500);
+            } catch {
+              responseBodySnippet = '';
+            }
+            errorMessage = `consumer responded ${res.status}: ${responseBodySnippet}`;
             this.logger.warn(
               `Relay to ${product} (${url}) returned ${res.status} for envelope ${envelope.id}`
             );
@@ -559,7 +574,32 @@ export class StripeMxSpeiRelayService {
             this.logger.log(`Relayed ${envelope.type} (${envelope.id}) → ${product}`);
           }
         } catch (err) {
+          errorMessage = `network/timeout: ${(err as Error).message}`;
           this.logger.error(`Relay to ${product} (${url}) failed: ${(err as Error).message}`);
+        }
+
+        if (!ok) {
+          // Persist to the DLQ so the auto-retry job (and the manual
+          // replay endpoint) can deliver later. Best-effort: a DLQ
+          // insertion failure must not amplify into a Stripe retry.
+          try {
+            await this.dlq.recordFailure({
+              eventId: envelope.id,
+              consumer: product,
+              consumerUrl: url,
+              eventType: envelope.type,
+              payload: envelope,
+              signatureHeader: signature,
+              statusCode,
+              errorMessage: errorMessage ?? 'unknown',
+            });
+          } catch (dlqErr) {
+            this.logger.error(
+              `Failed to persist DLQ row for ${product} envelope ${envelope.id}: ${
+                (dlqErr as Error).message
+              }`
+            );
+          }
         }
       })
     );

--- a/apps/api/src/modules/billing/services/subscription-lifecycle.service.ts
+++ b/apps/api/src/modules/billing/services/subscription-lifecycle.service.ts
@@ -1,6 +1,6 @@
 import * as crypto from 'crypto';
 
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
 import { AuditService } from '../../../core/audit/audit.service';
@@ -8,6 +8,8 @@ import { PrismaService } from '../../../core/prisma/prisma.service';
 import { PostHogService } from '../../analytics/posthog.service';
 import { BillingProvider, JanuaBillingService } from '../janua-billing.service';
 import { StripeService } from '../stripe.service';
+
+import { WebhookDlqService } from './webhook-dlq.service';
 
 /**
  * Options for premium upgrade.
@@ -60,7 +62,11 @@ export class SubscriptionLifecycleService {
     private januaBilling: JanuaBillingService,
     private audit: AuditService,
     private config: ConfigService,
-    private posthog: PostHogService
+    private posthog: PostHogService,
+    // Optional so existing call sites that build this service manually
+    // (older specs) don't have to construct a DLQ stub. When absent,
+    // the legacy "log + forget" failure path is preserved.
+    @Optional() private dlq?: WebhookDlqService
   ) {}
 
   // ─── Upgrade flows ───────────────────────────────────────────────────
@@ -589,7 +595,7 @@ export class SubscriptionLifecycleService {
     const targetUrl = urlMap[product];
     if (!targetUrl) return;
 
-    const payload = JSON.stringify({
+    const envelope = {
       type: eventType,
       id: crypto.randomUUID(),
       data: {
@@ -600,9 +606,14 @@ export class SubscriptionLifecycleService {
         status: eventType.includes('.') ? eventType.split('.')[1] : 'created',
       },
       timestamp: new Date().toISOString(),
-    });
+    };
+    const payload = JSON.stringify(envelope);
 
     const signature = crypto.createHmac('sha256', secret).update(payload).digest('hex');
+
+    let statusCode: number | undefined;
+    let errorMessage: string | undefined;
+    let ok = false;
 
     try {
       const response = await fetch(targetUrl, {
@@ -614,13 +625,48 @@ export class SubscriptionLifecycleService {
         body: payload,
       });
 
-      if (!response.ok) {
+      statusCode = response.status;
+      ok = response.ok;
+      if (!ok) {
+        try {
+          errorMessage = `consumer responded ${response.status}: ${(
+            await response.text()
+          ).slice(0, 500)}`;
+        } catch {
+          errorMessage = `consumer responded ${response.status}`;
+        }
         this.logger.warn(`Product webhook to ${product} failed: ${response.status}`);
       } else {
         this.logger.log(`Product webhook dispatched to ${product} for ${eventType}`);
       }
     } catch (error) {
+      errorMessage = `network/timeout: ${error.message}`;
       this.logger.error(`Product webhook dispatch to ${product} failed: ${error.message}`);
+    }
+
+    // Persist non-2xx / network errors to the DLQ so the auto-retry job
+    // (and the admin manual-replay endpoint) can re-deliver later.
+    // Best-effort — a DLQ insert failure cannot break the original
+    // billing flow; the consumer remains the source of idempotency.
+    if (!ok && this.dlq) {
+      try {
+        await this.dlq.recordFailure({
+          eventId: envelope.id,
+          consumer: product,
+          consumerUrl: targetUrl,
+          eventType,
+          payload: envelope,
+          signatureHeader: signature,
+          statusCode,
+          errorMessage: errorMessage ?? 'unknown',
+        });
+      } catch (dlqErr) {
+        this.logger.error(
+          `Failed to persist DLQ row for ${product} subscription event ${eventType}: ${
+            (dlqErr as Error).message
+          }`
+        );
+      }
     }
   }
 }

--- a/apps/api/src/modules/billing/services/webhook-dlq.service.ts
+++ b/apps/api/src/modules/billing/services/webhook-dlq.service.ts
@@ -1,0 +1,398 @@
+/**
+ * =============================================================================
+ * Webhook Dead-Letter Queue Service
+ * =============================================================================
+ *
+ * Captures failed deliveries from the Dhanam → consumer webhook fan-out
+ * (Stripe MX SPEI relay + subscription-lifecycle product webhooks) so an
+ * auto-retry job (and an admin manual-replay endpoint) can re-deliver
+ * them. Without this service, a transient Karafiel restart during a
+ * `payment.succeeded` fan-out would silently drop the CFDI for that
+ * customer.
+ *
+ * The service is intentionally narrow — it does NOT own the original
+ * dispatch logic (that still lives in the relay services). Its only
+ * jobs are:
+ *
+ *   1. `recordFailure()` — called by relay services on a non-2xx /
+ *      timeout / network error. Persists a `WebhookDeliveryFailure`
+ *      row and fires a Sentry event so operators see per-consumer
+ *      failure rates.
+ *   2. `replayDelivery()` — re-POSTs an existing failure row. Returns
+ *      a structured result rather than throwing, so the cron job and
+ *      the admin endpoint can both call it. Updates the row with the
+ *      new attempt outcome.
+ *   3. `findDueForRetry()` / `markResolved()` — lookup helpers for
+ *      the cron job.
+ *
+ * ## Backoff schedule (hardcoded, no env knob)
+ *
+ * `next_retry_at = NOW() + (2 ^ attempt_count) minutes`, capped at
+ * `MAX_ATTEMPTS = 10`. Schedule: 1, 2, 4, 8, 16, 32, 64, 128, 256, 512
+ * minutes (~17h end-to-end). After 10 failed attempts the row is left
+ * with `next_retry_at = null` and the auto-retry job stops touching
+ * it — the operator can still trigger a manual replay via the
+ * controller.
+ *
+ * ## Idempotency on the consumer side
+ *
+ * NOT this service's concern. Consumers (e.g. Karafiel) already key on
+ * the envelope's `payment_id` for dedup. The DLQ retry just delivers;
+ * if Karafiel has already issued the CFDI from a manual operator
+ * action, it will return 200 OK and we mark resolved.
+ *
+ * =============================================================================
+ */
+
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import { PrismaService } from '../../../core/prisma/prisma.service';
+import type { SentryService } from '../../../core/monitoring/sentry.service';
+
+/** Max delivery attempts (initial + retries). After this, manual only. */
+export const WEBHOOK_DLQ_MAX_ATTEMPTS = 10;
+
+/** Backoff base in minutes — minute * 2^attempt. */
+const BACKOFF_BASE_MINUTES = 1;
+
+/** What a relay service hands us when a delivery fails. */
+export interface RecordFailureInput {
+  /** Envelope id (the Dhanam-side correlation id). */
+  eventId: string;
+  /** Consumer key from PRODUCT_WEBHOOK_URLS, e.g. `karafiel`. */
+  consumer: string;
+  /** Full URL we POSTed to. */
+  consumerUrl: string;
+  /** Optional event type (`payment.succeeded`, etc.) for human filtering. */
+  eventType?: string;
+  /**
+   * The exact body that was POSTed. Stored as the `payload` JSON
+   * column so retries replay verbatim and the consumer's idempotency
+   * key stays intact. Pass the parsed object — we serialize on retry.
+   */
+  payload: unknown;
+  /**
+   * The HMAC-SHA256 signature value sent with the original request
+   * (the `X-Dhanam-Signature` header). Replayed verbatim — never
+   * re-signed, because re-signing would defeat the consumer's
+   * "have I seen this body before" dedup based on body+sig pair.
+   */
+  signatureHeader: string;
+  /** Optional HTTP status code observed (omit for network/timeout errors). */
+  statusCode?: number;
+  /** Human-readable error string for the audit trail. */
+  errorMessage: string;
+}
+
+/** Outcome of a single replay attempt. */
+export interface ReplayResult {
+  failureId: string;
+  ok: boolean;
+  statusCode?: number;
+  errorMessage?: string;
+  attemptCount: number;
+  nextRetryAt: Date | null;
+  resolvedAt: Date | null;
+}
+
+@Injectable()
+export class WebhookDlqService {
+  private readonly logger = new Logger(WebhookDlqService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly config: ConfigService,
+    // SentryService is provided by the global MonitoringModule under the
+    // string token 'SentryService' (matches the pattern used in
+    // GlobalExceptionFilter). Optional so unit tests don't need to mock it.
+    @Optional() @Inject('SentryService') private readonly sentry?: SentryService
+  ) {}
+
+  /**
+   * Persist a failed delivery and emit a Sentry event for ops dashboards.
+   *
+   * Returns the persisted row so the caller can include the DLQ id in
+   * its own log line if useful.
+   */
+  async recordFailure(input: RecordFailureInput) {
+    const nextRetryAt = computeNextRetry(1);
+
+    const row = await this.prisma.webhookDeliveryFailure.create({
+      data: {
+        eventId: input.eventId,
+        consumer: input.consumer,
+        consumerUrl: input.consumerUrl,
+        eventType: input.eventType ?? null,
+        payload: input.payload as never, // Prisma JSON
+        signatureHeader: input.signatureHeader,
+        attemptCount: 1,
+        lastAttemptAt: new Date(),
+        lastStatusCode: input.statusCode ?? null,
+        lastErrorMessage: truncateError(input.errorMessage),
+        nextRetryAt,
+      },
+    });
+
+    this.logger.warn(
+      `DLQ recorded ${input.consumer} failure for event ${input.eventId}: ` +
+        `status=${input.statusCode ?? 'network'} msg="${input.errorMessage}" ` +
+        `next_retry=${nextRetryAt?.toISOString() ?? 'never'}`
+    );
+
+    this.sentry?.captureMessage(
+      `Webhook delivery failed: ${input.consumer}`,
+      'warning',
+      {
+        event_id: input.eventId,
+        consumer: input.consumer,
+        consumer_url: input.consumerUrl,
+        event_type: input.eventType,
+        attempt: 1,
+        status_code: input.statusCode,
+        error_message: input.errorMessage,
+        dlq_id: row.id,
+      }
+    );
+
+    return row;
+  }
+
+  /**
+   * Re-POST a single failed delivery and update its bookkeeping.
+   *
+   * `force` resets `attemptCount` to a fresh attempt — used by the
+   * manual-replay endpoint where an operator is explicitly retrying.
+   *
+   * Never throws; downstream HTTP errors are captured into the row
+   * and surfaced via the returned `ReplayResult`. Throwing here would
+   * crash the cron job mid-batch.
+   */
+  async replayDelivery(failureId: string, opts: { force?: boolean } = {}): Promise<ReplayResult> {
+    const row = await this.prisma.webhookDeliveryFailure.findUnique({
+      where: { id: failureId },
+    });
+    if (!row) {
+      throw new Error(`webhook_delivery_failure ${failureId} not found`);
+    }
+
+    if (row.resolvedAt && !opts.force) {
+      // Already resolved — caller should have filtered, but if not,
+      // surface a clean no-op.
+      return {
+        failureId: row.id,
+        ok: true,
+        attemptCount: row.attemptCount,
+        nextRetryAt: row.nextRetryAt,
+        resolvedAt: row.resolvedAt,
+      };
+    }
+
+    const attempt = opts.force ? 1 : row.attemptCount + 1;
+    const body = JSON.stringify(row.payload);
+
+    let statusCode: number | undefined;
+    let errorMessage: string | undefined;
+    let ok = false;
+
+    try {
+      const res = await fetch(row.consumerUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Dhanam-Signature': row.signatureHeader,
+          'X-Dhanam-Envelope-Id': row.eventId,
+          'X-Dhanam-Event-Type': row.eventType ?? '',
+          'X-Dhanam-Replay': 'true',
+          'X-Dhanam-Replay-Attempt': String(attempt),
+        },
+        body,
+      });
+      statusCode = res.status;
+      ok = res.ok;
+      if (!ok) {
+        try {
+          // Capture a short tail of the response body for triage.
+          const text = await res.text();
+          errorMessage = `consumer responded ${res.status}: ${text.slice(0, 500)}`;
+        } catch {
+          errorMessage = `consumer responded ${res.status}`;
+        }
+      }
+    } catch (err) {
+      statusCode = undefined;
+      errorMessage = `network/timeout: ${(err as Error).message}`;
+      ok = false;
+    }
+
+    const now = new Date();
+
+    if (ok) {
+      const updated = await this.prisma.webhookDeliveryFailure.update({
+        where: { id: row.id },
+        data: {
+          attemptCount: attempt,
+          lastAttemptAt: now,
+          lastStatusCode: statusCode ?? null,
+          lastErrorMessage: null,
+          nextRetryAt: null,
+          resolvedAt: now,
+        },
+      });
+      this.logger.log(
+        `DLQ replay OK: ${row.consumer} event ${row.eventId} resolved on attempt ${attempt}`
+      );
+      return {
+        failureId: updated.id,
+        ok: true,
+        statusCode,
+        attemptCount: updated.attemptCount,
+        nextRetryAt: updated.nextRetryAt,
+        resolvedAt: updated.resolvedAt,
+      };
+    }
+
+    // Failed retry — update bookkeeping + schedule (or stop) next attempt.
+    const exhausted = attempt >= WEBHOOK_DLQ_MAX_ATTEMPTS;
+    const nextRetryAt = exhausted ? null : computeNextRetry(attempt);
+
+    const updated = await this.prisma.webhookDeliveryFailure.update({
+      where: { id: row.id },
+      data: {
+        attemptCount: attempt,
+        lastAttemptAt: now,
+        lastStatusCode: statusCode ?? null,
+        lastErrorMessage: truncateError(errorMessage ?? 'unknown'),
+        nextRetryAt,
+      },
+    });
+
+    this.logger.warn(
+      `DLQ replay FAIL: ${row.consumer} event ${row.eventId} attempt ${attempt}/${WEBHOOK_DLQ_MAX_ATTEMPTS} ` +
+        `status=${statusCode ?? 'network'} next_retry=${nextRetryAt?.toISOString() ?? 'EXHAUSTED'}`
+    );
+
+    this.sentry?.captureMessage(
+      `Webhook delivery failed: ${row.consumer}`,
+      exhausted ? 'error' : 'warning',
+      {
+        event_id: row.eventId,
+        consumer: row.consumer,
+        consumer_url: row.consumerUrl,
+        event_type: row.eventType,
+        attempt,
+        max_attempts: WEBHOOK_DLQ_MAX_ATTEMPTS,
+        status_code: statusCode,
+        error_message: errorMessage,
+        dlq_id: row.id,
+        exhausted,
+      }
+    );
+
+    return {
+      failureId: updated.id,
+      ok: false,
+      statusCode,
+      errorMessage,
+      attemptCount: updated.attemptCount,
+      nextRetryAt: updated.nextRetryAt,
+      resolvedAt: updated.resolvedAt,
+    };
+  }
+
+  /**
+   * List unresolved rows whose `next_retry_at` is now or in the past.
+   * Used by the cron job. Bounded by `limit` so a single tick can't
+   * stall the scheduler.
+   */
+  async findDueForRetry(limit = 50, now: Date = new Date()) {
+    return this.prisma.webhookDeliveryFailure.findMany({
+      where: {
+        resolvedAt: null,
+        nextRetryAt: { lte: now },
+        attemptCount: { lt: WEBHOOK_DLQ_MAX_ATTEMPTS },
+      },
+      orderBy: { nextRetryAt: 'asc' },
+      take: limit,
+    });
+  }
+
+  /**
+   * Mark a failure resolved without replaying (operator handled
+   * out-of-band — e.g. manually issued the CFDI in Karafiel).
+   */
+  async markResolved(failureId: string, opts: { reason?: string } = {}) {
+    return this.prisma.webhookDeliveryFailure.update({
+      where: { id: failureId },
+      data: {
+        resolvedAt: new Date(),
+        nextRetryAt: null,
+        lastErrorMessage: opts.reason
+          ? truncateError(`manually resolved: ${opts.reason}`)
+          : 'manually resolved',
+      },
+    });
+  }
+
+  /**
+   * Paginated list for the admin UI. Filter on consumer + since
+   * (createdAt) + resolved status.
+   */
+  async listFailures(opts: {
+    consumer?: string;
+    since?: Date;
+    includeResolved?: boolean;
+    limit?: number;
+    offset?: number;
+  }) {
+    const where: Record<string, unknown> = {};
+    if (opts.consumer) where.consumer = opts.consumer;
+    if (opts.since) where.createdAt = { gte: opts.since };
+    if (!opts.includeResolved) where.resolvedAt = null;
+
+    const limit = Math.min(Math.max(opts.limit ?? 50, 1), 200);
+    const offset = Math.max(opts.offset ?? 0, 0);
+
+    const [items, total] = await Promise.all([
+      this.prisma.webhookDeliveryFailure.findMany({
+        where,
+        orderBy: { createdAt: 'desc' },
+        take: limit,
+        skip: offset,
+      }),
+      this.prisma.webhookDeliveryFailure.count({ where }),
+    ]);
+
+    return { items, total, limit, offset };
+  }
+
+  /**
+   * True when the auto-retry cron job should run. Defaults to enabled
+   * in production, disabled elsewhere — explicit env override allowed.
+   * Set `WEBHOOK_DLQ_AUTO_RETRY_ENABLED=true` (or `=1`) to force on,
+   * or `false`/`0` to force off.
+   */
+  isAutoRetryEnabled(): boolean {
+    const raw = this.config.get<string>('WEBHOOK_DLQ_AUTO_RETRY_ENABLED');
+    if (raw === 'true' || raw === '1') return true;
+    if (raw === 'false' || raw === '0') return false;
+    // Default: on in production, off everywhere else (keeps tests + dev
+    // from accidentally hammering real consumers).
+    return this.config.get<string>('NODE_ENV') === 'production';
+  }
+}
+
+/** Exponential backoff: minutes = 2 ^ attempt (1, 2, 4, …, 512). */
+export function computeNextRetry(attemptCount: number, now: Date = new Date()): Date {
+  const minutes = BACKOFF_BASE_MINUTES * Math.pow(2, attemptCount);
+  return new Date(now.getTime() + minutes * 60 * 1000);
+}
+
+/**
+ * Errors from arbitrary HTTP responses can be enormous (full HTML
+ * pages from a misconfigured load balancer, etc). Cap at 2KB so the
+ * row stays manageable in the admin UI.
+ */
+function truncateError(s: string): string {
+  return s.length > 2048 ? `${s.slice(0, 2045)}...` : s;
+}


### PR DESCRIPTION
## Summary

Closes the highest-leverage gap in the revenue ledger called out by the [2026-04-26 monetization-architecture audit](https://github.com/madfam-org/internal-devops/blob/main/ecosystem/monetization-architecture-2026-04-26.md):

> Today, if Karafiel is down when Dhanam fans out a `payment.succeeded` event, the CFDI is silently dropped. Build: failed deliveries land in a `webhook_deliveries_failed` table; manual or auto-retry endpoint replays them.

Both fan-out paths (`StripeMxSpeiRelayService.dispatch()` for `payment.*` envelopes and `SubscriptionLifecycleService.notifyProductWebhooks()` for `subscription.*` envelopes) used to log failures and forget. Now they persist to a new `webhook_delivery_failures` table; a 5-minute cron retries with exponential backoff (1, 2, 4, ..., 512 minutes; max 10 attempts ~17h end-to-end); and an admin-only HTTP endpoint allows manual inspection / replay / out-of-band resolve.

## What ships

- **Migration** `20260426000000_add_webhook_delivery_failures` — `jsonb` payload + generic `consumer` field so future products plug in without schema changes. Partial index on `(next_retry_at) WHERE resolved_at IS NULL` for the cron's hot scan path.
- **`WebhookDlqService`** — `recordFailure()`, `replayDelivery()`, `findDueForRetry()`, `markResolved()`, `listFailures()`. Replay is byte-identical (same body, same signature) so consumer-side dedup (e.g. Karafiel `Cfdi.metadata.payment_id`) stays intact.
- **`WebhookDlqRetryJob`** — `@Cron(EVERY_5_MINUTES)`. Gated by `WEBHOOK_DLQ_AUTO_RETRY_ENABLED` (default ON in `NODE_ENV=production`, OFF elsewhere — keeps test suites + dev from hammering real consumers). Failure-isolated per row.
- **`DlqController`** — JWT + `@Roles('ADMIN')` (matches the existing `/v1/billing/admin/revenue-metrics` pattern):
  - `GET /v1/billing/dlq` — paginated list, filters: consumer, since, includeResolved
  - `POST /v1/billing/dlq/:id/replay` — force re-POST (resets attempt to 1)
  - `POST /v1/billing/dlq/:id/resolve` — manual close-out
  - Error responses are intentionally generic so a leaked admin token cannot enumerate consumer URL structure via 404/422 deltas.
- **Sentry** — every recorded failure + every failed replay emits a structured event with `event_id`, `consumer`, `consumer_url`, `event_type`, `attempt`, `status_code`. Level `warning` for transients, escalates to `error` on max-attempts exhaustion.
- **Tests** — 35 new cases (22 service + 7 job + 8 controller); existing 22-case Stripe MX SPEI relay spec updated to inject the new DLQ dependency.
- **Runbook** — companion runbook PR at madfam-org/internal-devops (separate PR).

## Discoveries about the existing fan-out

- `SubscriptionLifecycleService.notifyProductWebhooks()` already had the same silent-failure pattern as the Stripe MX relay — both paths now wired to the DLQ. The lifecycle service injects `WebhookDlqService` as `@Optional()` so older specs that constructed it manually don't break.
- `BillingEvent` is keyed on `stripe_event_id` (unique), giving the relay its idempotency. The DLQ uses the Dhanam-side envelope `id` (the outbound `X-Dhanam-Envelope-Id`) for correlation — different identifier, intentional, since the same Stripe event can fan out to N consumers and N rows.
- Both fan-out services already buffered the body once for HMAC signing; the DLQ reuses that buffered body verbatim so retries are byte-identical and the consumer's body+sig dedup stays intact.

## Test plan

- [x] `pnpm --filter @dhanam/api typecheck` — zero new errors in any of my files (pre-existing errors in `webhook-outbound`, `r2`, `transaction-execution`, etc. are unrelated, present on `main`)
- [x] `pnpm test -- --testPathPatterns='webhook-dlq|dlq.controller|stripe-mx-spei|subscription-lifecycle'` — 74/74 pass across 5 suites
- [ ] Operator: smoke test `POST /v1/billing/dlq/:id/replay` against a staging Karafiel after the auto-retry has populated some test rows
- [ ] Operator: confirm Sentry shows `Webhook delivery failed: karafiel` events and groups correctly by `extra.consumer`

## Out of scope

- Synthetic revenue probe (T2.1, separate parallel agent)
- Multi-tenant DLQ isolation (admin-only is sufficient for v1)
- Slack / PagerDuty wiring (operator hooks Sentry → wherever)
- Bulk replay endpoint (single-row only in v1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)