### PR TITLE
fix(api): add WebhookEndpoint + WebhookDelivery Prisma models (typecheck)

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1126,6 +1126,57 @@ model WebhookEvent {
   @@map("webhook_events")
 }
 
+/// Outbound webhook subscription — registered by a consumer app
+/// (forj, karafiel, tezca, ...) to receive Dhanam ecosystem events.
+/// Backed by Svix; `svixEndpointId` is the upstream Svix entity that
+/// owns retry + signing. We persist a local row for audit/replay and
+/// to manage the lifecycle (rotate secret, deactivate, replay-failed).
+/// See `apps/api/src/modules/webhook-outbound/`.
+model WebhookEndpoint {
+  id               String    @id @default(cuid())
+  consumerAppId    String    @map("consumer_app_id")
+  url              String
+  svixEndpointId   String?   @unique @map("svix_endpoint_id")
+  subscribedEvents String[]  @map("subscribed_events")
+  description      String?
+  active           Boolean   @default(true)
+  metadata         Json?
+  createdAt        DateTime  @default(now()) @map("created_at")
+  updatedAt        DateTime  @updatedAt @map("updated_at")
+  disabledAt       DateTime? @map("disabled_at")
+
+  deliveries WebhookDelivery[]
+
+  @@index([consumerAppId])
+  @@index([active])
+  @@map("webhook_endpoints")
+}
+
+/// Local audit row for each outbound webhook delivery attempt. Svix
+/// is the source of truth for retry semantics; this table exists so
+/// admin tooling can correlate a Dhanam event id to a Svix message id
+/// without round-tripping the Svix API.
+model WebhookDelivery {
+  id                String    @id @default(cuid())
+  webhookEndpointId String    @map("webhook_endpoint_id")
+  eventType         String    @map("event_type")
+  eventId           String    @map("event_id")
+  svixMessageId     String?   @map("svix_message_id")
+  payload           Json
+  lastStatus        Int?      @map("last_status")
+  attempts          Int       @default(0)
+  deliveredAt       DateTime? @map("delivered_at")
+  lastAttemptAt     DateTime? @map("last_attempt_at")
+  createdAt         DateTime  @default(now()) @map("created_at")
+
+  endpoint WebhookEndpoint @relation(fields: [webhookEndpointId], references: [id], onDelete: Cascade)
+
+  @@index([webhookEndpointId])
+  @@index([eventId])
+  @@index([deliveredAt])
+  @@map("webhook_deliveries")
+}
+
 model ErrorLog {
   id        String   @id @default(uuid())
   timestamp DateTime @default(now())
@@ -2379,22 +2430,22 @@ model AmbassadorProfile {
 // exactly-once notification delivery despite at-least-once transport.
 
 model UsageAlertIngest {
-  id                String    @id @default(uuid())
-  waybillAlertId    String    @map("waybill_alert_id")
-  projectId         String    @map("project_id") // Enclii project UUID (opaque here)
-  budgetId          String    @map("budget_id")
-  period            String // "monthly" | "weekly" | "quarterly"
-  periodStart       DateTime  @map("period_start")
-  periodEnd         DateTime  @map("period_end")
-  thresholdCrossed  Int       @map("threshold_crossed") // 50, 80, 100, etc.
-  actualCents       BigInt    @map("actual_cents") // BigInt future-proofs against enterprise-scale spend
-  budgetCents       BigInt    @map("budget_cents")
-  currency          String    @default("USD")
-  serviceBreakdown  Json?     @map("service_breakdown")
-  notifiedAt        DateTime? @map("notified_at")
-  seenCount         Int       @default(1) @map("seen_count")
-  lastSeenAt        DateTime  @default(now()) @map("last_seen_at")
-  createdAt         DateTime  @default(now()) @map("created_at")
+  id               String    @id @default(uuid())
+  waybillAlertId   String    @map("waybill_alert_id")
+  projectId        String    @map("project_id") // Enclii project UUID (opaque here)
+  budgetId         String    @map("budget_id")
+  period           String // "monthly" | "weekly" | "quarterly"
+  periodStart      DateTime  @map("period_start")
+  periodEnd        DateTime  @map("period_end")
+  thresholdCrossed Int       @map("threshold_crossed") // 50, 80, 100, etc.
+  actualCents      BigInt    @map("actual_cents") // BigInt future-proofs against enterprise-scale spend
+  budgetCents      BigInt    @map("budget_cents")
+  currency         String    @default("USD")
+  serviceBreakdown Json?     @map("service_breakdown")
+  notifiedAt       DateTime? @map("notified_at")
+  seenCount        Int       @default(1) @map("seen_count")
+  lastSeenAt       DateTime  @default(now()) @map("last_seen_at")
+  createdAt        DateTime  @default(now()) @map("created_at")
 
   @@unique([projectId, periodStart, thresholdCrossed], name: "projectId_periodStart_thresholdCrossed")
   @@index([projectId, createdAt(sort: Desc)])
@@ -2430,7 +2481,7 @@ model FxRateObservation {
   toCurrency   String   @map("to_currency")
   rateType     String   @map("rate_type") // 'spot' | 'dof' | 'settled'
   rate         Decimal  @db.Decimal(18, 8)
-  source       String   // 'openexchangerates' | 'exchangerate_host' | 'banxico_sie' | ...
+  source       String // 'openexchangerates' | 'exchangerate_host' | 'banxico_sie' | ...
   providerId   String?  @map("provider_id") // upstream stable id, e.g. 'oer:2026-04-25T18:14:00Z'
   paymentId    String?  @map("payment_id") // populated only for rateType='settled'
   observedAt   DateTime @map("observed_at")
@@ -2449,7 +2500,7 @@ model FxRatePublication {
   toCurrency    String   @map("to_currency")
   effectiveDate DateTime @map("effective_date") @db.Date
   rate          Decimal  @db.Decimal(18, 8)
-  source        String   // typically 'banxico_sie'
+  source        String // typically 'banxico_sie'
   providerId    String?  @map("provider_id")
   publishedAt   DateTime @map("published_at")
   createdAt     DateTime @default(now()) @map("created_at")
@@ -2466,7 +2517,7 @@ model FxRateOverride {
   toCurrency   String    @map("to_currency")
   rateType     String    @map("rate_type")
   rate         Decimal   @db.Decimal(18, 8)
-  rationale    String    // RFC 0011 §"Override governance" — required runbook entry
+  rationale    String // RFC 0011 §"Override governance" — required runbook entry
   issuedBy     String    @map("issued_by") // Janua sub claim of the operator
   approvedBy   String?   @map("approved_by") // ASK_DUAL second-approver Janua sub claim
   expiresAt    DateTime? @map("expires_at")


### PR DESCRIPTION
## Summary

The `20260424000000_add_marketplace_and_webhook_schema` migration created the `webhook_endpoints` and `webhook_deliveries` SQL tables but the matching Prisma models were never added to `schema.prisma`. The generated client therefore lacked `prisma.webhookEndpoint` / `prisma.webhookDelivery` accessors, breaking `apps/api` typecheck with 11 `TS2339` errors in the `webhook-outbound` module (introduced by 0daa0b1 — *Connect marketplace + outbound webhooks (RFC-5)*).

This PR adds the two missing Prisma models, faithfully mirroring the existing migration SQL.

## Scenario

**Scenario B** — models missing from `schema.prisma` entirely. Confirmed by:

- `grep "model WebhookEndpoint\|model WebhookDelivery" prisma/schema.prisma` returned zero hits.
- The migration SQL at `prisma/migrations/20260424000000_add_marketplace_and_webhook_schema/migration.sql` does create the `webhook_endpoints` + `webhook_deliveries` tables.
- ∴ prod DB already has the tables; only `schema.prisma` needs to catch up. **No new migration is generated** — the schema is just being synchronized to match what the DB already looks like.

## Changes

Added two models in `apps/api/prisma/schema.prisma`, immediately after the existing `WebhookEvent` model:

- **`WebhookEndpoint`** — outbound webhook subscription registered by consumer apps (forj, karafiel, tezca, ...), backed by Svix.
- **`WebhookDelivery`** — local audit row for each delivery attempt (Svix is source of truth for retries; this is for admin correlation).

Field mapping:

| Prisma field | DB column | Source of truth |
|---|---|---|
| `WebhookEndpoint.consumerAppId` | `consumer_app_id` | migration.sql line 100 |
| `WebhookEndpoint.svixEndpointId` (unique) | `svix_endpoint_id` | migration.sql line 102 + line 171 |
| `WebhookEndpoint.subscribedEvents` (`String[]`) | `subscribed_events TEXT[]` | migration.sql line 103 |
| `WebhookEndpoint` indexes | `consumer_app_id`, `active` | migration.sql lines 174–177 |
| `WebhookDelivery.webhookEndpointId` (FK CASCADE) | `webhook_endpoint_id` | migration.sql line 117 + line 204 |
| `WebhookDelivery` indexes | `webhook_endpoint_id`, `event_id`, `delivered_at` | migration.sql lines 180–186 |

`@default(cuid())` is client-side only — the DB column remains `TEXT NOT NULL` with no default, so this is purely a schema↔code sync, not a DB change.

## Verification

- `pnpm prisma validate` → schema valid
- `pnpm prisma generate` → client regenerated successfully
- `pnpm typecheck` baseline (main): **107 errors**
- `pnpm typecheck` after fix: **96 errors** (delta = **11**, all webhook-outbound `webhookEndpoint`/`webhookDelivery` errors gone)
- 2 remaining errors in `webhook-outbound` (`svix.client.ts:75,87`) are pre-existing `InfrastructureException` signature mismatches — out of scope for this PR

## Remaining errors on main (NOT in webhook-outbound)

The other 96 errors that stay deferred for operator review (one or more separate PRs):

- `marketplace/` — same migration shipped `merchantAccount`, `transfer`, `payout`, `dispute`, `applicationFee` models which are also missing from schema.prisma (~28 errors). Fixable the same way as this PR.
- `providers/{finicity,mx,orchestrator}/` — `unknown`/`Record<string,unknown>` type narrowing issues (~14 errors).
- `storage/r2.service.ts` — `S3Client` type incompatibility (3 errors).
- `transaction-execution/transaction-execution.controller.ts` — `string | string[]` not narrowed (5 errors).
- `users/users.service.ts` — `unknown` error type narrowing (3 errors).
- `kyc/`, `email/`, `analytics/`, `billing/` — assorted type errors.

## Hook bypass

Both `git commit --no-verify` and `git push --no-verify` were used because:
1. **Pre-commit hook** runs `pnpm typecheck` against the entire monorepo. Main itself has 107 baseline errors so the hook is unsatisfiable from main; this PR cuts that to 96 but cannot zero it out within scope.
2. **Pre-push hook** likewise fails on the existing 1798 web lint errors per the operator brief.

This matches prior dhanam `--no-verify` precedents documented in repo `CLAUDE.md`.

## Anomaly

Same migration (`20260424000000_add_marketplace_and_webhook_schema`) created **all** the marketplace primitives (`merchant_accounts`, `transfers`, `payouts`, `disputes`, `application_fees`) plus the two webhook tables. None of those Prisma models exist in `schema.prisma` either. This PR **only** addresses the two webhook models per the operator's scoped request. The marketplace models are tracked in the deferred list above.

## Test plan

- [ ] CI typecheck on this branch shows 96 errors (down from 107)
- [ ] Operator reviews schema model definitions vs migration SQL
- [ ] Operator confirms intent: schema-only sync, no new migration needed
- [ ] **DO NOT MERGE** until operator review — touches Prisma schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)