### PR TITLE
fix(billing): coerce JWT date strings to Date before TrialService (P1-G)

### DIFF
--- a/apps/api/src/modules/billing/billing.controller.ts
+++ b/apps/api/src/modules/billing/billing.controller.ts
@@ -243,13 +243,16 @@ export class BillingController {
       promoEndsAt: string | null;
     };
 
+    // JWT round-trip serializes Dates as ISO strings; coerce back before
+    // passing to TrialService methods which expect `Date | null`.
+    const toDate = (s: string | null): Date | null => (s ? new Date(s) : null);
     const isInTrial = this.trialService.isInTrial({
       trialTier: user.trialTier,
-      trialEndsAt: user.trialEndsAt,
+      trialEndsAt: toDate(user.trialEndsAt),
     });
     const isInPromo = this.trialService.isInPromo({
-      promoStartedAt: user.promoStartedAt,
-      promoEndsAt: user.promoEndsAt,
+      promoStartedAt: toDate(user.promoStartedAt),
+      promoEndsAt: toDate(user.promoEndsAt),
     });
 
     return {


### PR DESCRIPTION
## Summary

Surgical fix to \`billing.controller.getSubscriptionStatus()\`. Adds a 1-line \`toDate()\` helper that coerces JWT-serialized ISO date strings back to \`Date\` objects at the boundary where TrialService methods are called (which expect strict \`Date | null\`).

## Root cause

The controller correctly casts JWT-derived user fields as \`string | null\` (JWT round-trip serializes Date → ISO string), but then passes them to \`trialService.isInTrial({ trialEndsAt: Date | null })\` and \`trialService.isInPromo({ promoStartedAt + promoEndsAt: Date | null })\` without deserializing. 3 TS2322 errors at lines 248, 251, 252.

## Fix

\`\`\`ts
const toDate = (s: string | null): Date | null => (s ? new Date(s) : null);
\`\`\`

Applied at the 3 fields. TrialService keeps its strict Date contract; the JWT boundary explicitly does the round-trip deserialization.

## Verification

\`\`\`
$ pnpm typecheck 2>&1 | grep -c \"error TS\"
68   # was 71 — billing.controller errors gone
\`\`\`

## Stack progression

| State | Errors |
|---|---|
| baseline | 107 |
| after #364 | 96 |
| after #365 | 71 |
| after #366 | 61 |
| after #367 | 48 |
| after #368 | 42 |
| after #369 | 37 |
| **after this PR** | **34** |

68% reduction from baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)