### PR TITLE
fix(billing): reconciliation job types — Stripe API + enum extensions (P1-I)

### DIFF
--- a/apps/api/prisma/migrations/20260427000000_add_reconciliation_billing_event_status/migration.sql
+++ b/apps/api/prisma/migrations/20260427000000_add_reconciliation_billing_event_status/migration.sql
@@ -1,0 +1,10 @@
+-- Add `reconciliation_mismatch` to BillingEventType + `flagged` to BillingStatus
+-- so the nightly reconciliation job (apps/api/src/modules/billing/jobs/
+-- reconciliation.job.ts) can flag Stripe-vs-local-DB discrepancies as
+-- BillingEvent records for manual review without compile errors.
+--
+-- These are additive enum changes — no data migration required, no rollback
+-- impact on existing rows. Postgres ALTER TYPE ... ADD VALUE is non-blocking.
+
+ALTER TYPE "BillingEventType" ADD VALUE IF NOT EXISTS 'reconciliation_mismatch';
+ALTER TYPE "BillingStatus" ADD VALUE IF NOT EXISTS 'flagged';

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -81,6 +81,7 @@ enum BillingEventType {
   refund_issued
   cancel_intent_created
   save_offer_accepted
+  reconciliation_mismatch
 }
 
 enum BillingStatus {
@@ -89,6 +90,7 @@ enum BillingStatus {
   failed
   refunded
   paused
+  flagged
 }
 
 enum CancellationReason {

--- a/apps/api/src/modules/billing/jobs/reconciliation.job.ts
+++ b/apps/api/src/modules/billing/jobs/reconciliation.job.ts
@@ -1,4 +1,5 @@
 import { PrismaService } from '@core/prisma/prisma.service';
+import { Prisma } from '@db';
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Cron } from '@nestjs/schedule';
@@ -14,7 +15,7 @@ export class ReconciliationJob {
     private config: ConfigService
   ) {
     this.stripe = new Stripe(this.config.get('STRIPE_SECRET_KEY') ?? '', {
-      apiVersion: '2024-12-18.acacia',
+      apiVersion: '2026-02-25.clover',
     });
   }
 
@@ -93,7 +94,11 @@ export class ReconciliationJob {
         amount: 0,
         currency: 'USD',
         status: 'flagged',
-        metadata: details,
+        // `details` is shaped as Record<string, unknown>; Prisma's Json column
+        // accepts InputJsonValue (a recursively-typed JSON shape). The runtime
+        // value IS valid JSON, but TS can't prove it from the unknown value
+        // type — cast at the boundary.
+        metadata: details as Prisma.InputJsonValue,
       },
     });
   }


### PR DESCRIPTION
## Summary

Surgical fix to \`reconciliation.job.ts\`:

1. Stripe \`apiVersion: '2024-12-18.acacia'\` → \`'2026-02-25.clover'\` (matches stripe.service, stripe-mx.service, stripe-connect.service).
2. Adds \`reconciliation_mismatch\` to \`BillingEventType\` enum + \`flagged\` to \`BillingStatus\` enum.
3. Casts \`metadata: Record<string, unknown>\` → \`Prisma.InputJsonValue\` at the boundary.

## Migration

\`prisma/migrations/20260427000000_add_reconciliation_billing_event_status/migration.sql\` uses \`ALTER TYPE ... ADD VALUE IF NOT EXISTS\` — non-blocking, additive, zero data migration, zero rollback impact.

## Verification

\`reconciliation.job.ts\`: 4 errors → 0.

## ⚠️ Regen side-effect to flag

Running \`pnpm prisma generate\` against the new schema surfaced ~30 NEW typecheck errors elsewhere (product-catalog, madfam-events, kyc.service, drip-campaign.task, etc.). These were previously latent — the OLD generated Prisma client typed \`InputJsonValue\` permissively enough to hide \`Record<string, unknown>\` mismatches.

**This PR did not introduce those errors.** They're pre-existing latent debt now made visible by the schema regen. Each is a 1-3 line cast similar to the metadata cast in this PR. Best handled as a follow-on PR after this one lands.

## Stack progression

After #364-#371 + this PR land, dhanam api typecheck baseline shifts due to the Prisma regen. Honest framing: this PR fixes 4 reconciliation errors AND surfaces ~30 pre-existing-latent-debt errors. The next 1-2 follow-on PRs will sweep those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)