### PR TITLE
fix(api): typecheck green-up — Prisma import normalize + Json widening + error narrowing

### DIFF
--- a/apps/api/src/modules/billing/madfam-events.controller.ts
+++ b/apps/api/src/modules/billing/madfam-events.controller.ts
@@ -21,6 +21,8 @@ import {
 } from '@nestjs/swagger';
 import type { Request } from 'express';
 
+import { Prisma } from '@db';
+
 import { AuditService } from '../../core/audit/audit.service';
 import { PrismaService } from '../../core/prisma/prisma.service';
 import { PostHogService } from '../analytics/posthog.service';
@@ -174,7 +176,7 @@ export class MadfamEventsController {
           occurred_at: payload.occurred_at,
           attribution: payload.attribution ?? null,
           source_metadata: payload.metadata ?? null,
-        },
+        } as unknown as Prisma.InputJsonValue,
       },
     });
 

--- a/apps/api/src/modules/billing/services/payment-processor.interface.ts
+++ b/apps/api/src/modules/billing/services/payment-processor.interface.ts
@@ -17,7 +17,7 @@
  * =============================================================================
  */
 
-import { Currency } from '@prisma/client';
+import { Currency } from '@db';
 
 export type ProcessorId = 'stripe' | 'stripe_mx' | 'paddle' | 'conekta' | 'polar';
 

--- a/apps/api/src/modules/billing/services/product-catalog.service.ts
+++ b/apps/api/src/modules/billing/services/product-catalog.service.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@db';
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 
 import { PrismaService } from '../../../core/prisma/prisma.service';
@@ -157,7 +158,7 @@ export class ProductCatalogService {
         iconUrl: data.iconUrl,
         websiteUrl: data.websiteUrl,
         stripeProductId: data.stripeProductId,
-        metadata: data.metadata,
+        metadata: data.metadata as Prisma.InputJsonValue,
         sortOrder: data.sortOrder ?? 0,
       },
       update: {
@@ -167,7 +168,7 @@ export class ProductCatalogService {
         ...(data.iconUrl !== undefined && { iconUrl: data.iconUrl }),
         ...(data.websiteUrl !== undefined && { websiteUrl: data.websiteUrl }),
         ...(data.stripeProductId && { stripeProductId: data.stripeProductId }),
-        ...(data.metadata && { metadata: data.metadata }),
+        ...(data.metadata && { metadata: data.metadata as Prisma.InputJsonValue }),
         ...(data.sortOrder !== undefined && { sortOrder: data.sortOrder }),
       },
     });
@@ -212,14 +213,14 @@ export class ProductCatalogService {
         stripePriceId: data.stripePriceId,
         displayName: data.displayName,
         description: data.description,
-        metadata: data.metadata,
+        metadata: data.metadata as Prisma.InputJsonValue,
       },
       update: {
         amountCents: data.amountCents,
         ...(data.stripePriceId && { stripePriceId: data.stripePriceId }),
         ...(data.displayName !== undefined && { displayName: data.displayName }),
         ...(data.description !== undefined && { description: data.description }),
-        ...(data.metadata && { metadata: data.metadata }),
+        ...(data.metadata && { metadata: data.metadata as Prisma.InputJsonValue }),
       },
     });
 

--- a/apps/api/src/modules/kyc/kyc.service.ts
+++ b/apps/api/src/modules/kyc/kyc.service.ts
@@ -1,4 +1,4 @@
-import { KycStatus } from '@db';
+import { KycStatus, Prisma } from '@db';
 import {
   BadRequestException,
   ConflictException,
@@ -153,7 +153,7 @@ export class KycService {
             sanctionsMatch: result.sanctionsMatch,
             curpValidated: result.curpValidated,
             ineValidated: result.ineValidated,
-            verificationData: result.details,
+            verificationData: result.details as Prisma.InputJsonValue,
             completedAt: new Date(),
           },
         });
@@ -197,7 +197,7 @@ export class KycService {
             sanctionsMatch: updatedResult.sanctionsMatch,
             curpValidated: updatedResult.curpValidated,
             ineValidated: updatedResult.ineValidated,
-            verificationData: updatedResult.details,
+            verificationData: updatedResult.details as Prisma.InputJsonValue,
             completedAt: new Date(),
           },
         });

--- a/apps/api/src/modules/marketplace/dto/marketplace.dto.ts
+++ b/apps/api/src/modules/marketplace/dto/marketplace.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Currency } from '@prisma/client';
+import { Currency } from '@db';
 import { IsEnum, IsInt, IsOptional, IsString, IsUrl, Min } from 'class-validator';
 
 export class CreateMerchantDto {

--- a/apps/api/src/modules/marketplace/services/charge.service.ts
+++ b/apps/api/src/modules/marketplace/services/charge.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
-import { Currency, Prisma } from '@prisma/client';
+import { Currency, Prisma } from '@db';
 
 import { PrismaService } from '../../../core/prisma/prisma.service';
 import { StripeConnectService } from '../../billing/services/stripe-connect.service';

--- a/apps/api/src/modules/marketplace/services/connect-webhook.handler.ts
+++ b/apps/api/src/modules/marketplace/services/connect-webhook.handler.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { Currency, Prisma } from '@prisma/client';
+import { Currency, Prisma } from '@db';
 import type Stripe from 'stripe';
 
 import { PrismaService } from '../../../core/prisma/prisma.service';

--- a/apps/api/src/modules/marketplace/services/dispute.service.ts
+++ b/apps/api/src/modules/marketplace/services/dispute.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
+import { Prisma } from '@db';
 
 import { PrismaService } from '../../../core/prisma/prisma.service';
 import { StripeConnectService } from '../../billing/services/stripe-connect.service';

--- a/apps/api/src/modules/marketplace/services/merchant.service.ts
+++ b/apps/api/src/modules/marketplace/services/merchant.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
-import { Currency, Prisma } from '@prisma/client';
+import { Currency, Prisma } from '@db';
 
 import { PrismaService } from '../../../core/prisma/prisma.service';
 import { StripeConnectService } from '../../billing/services/stripe-connect.service';

--- a/apps/api/src/modules/marketplace/services/payout.service.ts
+++ b/apps/api/src/modules/marketplace/services/payout.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
+import { Prisma } from '@db';
 
 import { PrismaService } from '../../../core/prisma/prisma.service';
 import { StripeConnectService } from '../../billing/services/stripe-connect.service';

--- a/apps/api/src/modules/marketplace/services/transfer.service.ts
+++ b/apps/api/src/modules/marketplace/services/transfer.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
+import { Prisma } from '@db';
 
 import { PrismaService } from '../../../core/prisma/prisma.service';
 import { StripeConnectService } from '../../billing/services/stripe-connect.service';

--- a/apps/api/src/modules/users/users.service.ts
+++ b/apps/api/src/modules/users/users.service.ts
@@ -27,15 +27,16 @@ export class UsersService {
    */
   private handlePrismaError(error: unknown, operation: string): never {
     if (error instanceof PrismaClientKnownRequestError) {
-      switch (error.code) {
+      const prismaErr = error as InstanceType<typeof PrismaClientKnownRequestError>;
+      switch (prismaErr.code) {
         case 'P2025':
           throw BusinessRuleException.resourceNotFound('User', operation);
         case 'P2002':
           throw ValidationException.duplicateEntry(
-            (error.meta?.target as string[])?.join(', ') || 'field'
+            (prismaErr.meta?.target as string[])?.join(', ') || 'field'
           );
         default:
-          throw InfrastructureException.databaseError(operation, error);
+          throw InfrastructureException.databaseError(operation, prismaErr);
       }
     }
 


### PR DESCRIPTION
## Summary
- Fixes **21 of 37 typecheck errors** broken on `main` since PR #364 (marketplace + Prisma 7 bump). Type Check job has been failing on every push since 2026-04-27.
- Three orthogonal clusters, all low-risk:

### 1. Prisma import normalize (8 files)
The marketplace module + `payment-processor.interface.ts` import directly from `@prisma/client`. The rest of the API uses the canonical `@db` re-export at `apps/api/src/db/index.ts` (which re-exports `apps/api/generated/prisma`). Fixed those 8 imports — same pattern as P0-F (#386).

### 2. Json column widening (5 sites)
Writes to JSON columns (`BillingEvent.metadata`, `Product.metadata`, `ProductPrice.metadata`, `IdentityVerification.verificationData`) need `Prisma.InputJsonValue` typing. `madfam-events.controller` needs the `as unknown as ...` double-cast because `EcosystemEventAttribution`'s missing index signature.

### 3. Prisma error narrowing (1 site)
`users.service.handlePrismaError` casts inside the `instanceof PrismaClientKnownRequestError` branch to `InstanceType<typeof PrismaClientKnownRequestError>` so `.code` and `.meta` access typecheck.

## What's NOT in this PR
16 errors remain. They cluster into **higher-risk buckets needing owner input** before I touch them:

- **Stripe API drift** — `coupon` removed from `SubscriptionUpdateParams`; `spei_transfer` not in `PaymentMethodType`; missing args in `stripe-connect`. Stripe SDK was bumped recently — these need a deliberate "do we still want SPEI?" decision.
- **Webhook payload narrowing** — `finicity` + `mx` + `analytics-query` destructure typed `unknown` from `Record<string, unknown>` payload. Needs explicit `WebhookPayload` shape contracts (real domain types, not casts).
- **Schema gap** — `circuit-breaker.service` reads `consecutiveFailures` field that's not on the `ProviderHealth` Prisma model. Needs migration or service refactor.
- **Email API drift** — `drip-campaign.task` uses `text` option that was removed from `EmailOptions`.
- **`InfrastructureException` arg count** — `svix.client` + `stripe-connect` pass 1 arg; constructor requires `(code, message)`. 1-line fix per call site but touches error-reporting contract.
- **`DisputeEvidence` index signature** — `marketplace.controller.ts:171` SubmitDisputeEvidenceDto missing index signature.

Each is a one-decision fix but they touch live ecosystem contracts (Stripe webhooks, MX/Finicity webhooks, KYC) so I'm landing the safe cluster first and surfacing the rest for review.

## Test plan
- [x] Local `DATABASE_URL=... pnpm --filter @dhanam/api typecheck` — error count goes from 37 → 16, all 21 of my fixes verified
- [ ] CI Type Check job — should also drop to 16 (still red, but no longer rising)
- [ ] No runtime risk — all changes are type-only (import path, casts)

## Why `--no-verify`
Pre-push hook runs the same `pnpm typecheck` that this PR partially fixes. The hook fails on the 16 remaining errors I haven't owner-confirmed how to handle. Per dhanam's documented `--no-verify` precedent (#83/#345/#364/#365/#375), pushing dep-only / type-only fixes that the hook itself blocks is the established pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)