### PR TITLE
fix(api+web): clear referral DTO TDZ + jest text-match drift

### DIFF
--- a/apps/api/src/modules/referral/dto/referral-event.dto.ts
+++ b/apps/api/src/modules/referral/dto/referral-event.dto.ts
@@ -2,18 +2,15 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber, IsOptional, IsString } from 'class-validator';
 
 /**
- * Payload for the `referral.converted` webhook from PhyneCRM.
- * Received via HMAC-authenticated POST /v1/referral/reward.
+ * NOTE: `ReferralConversionDataDto` is declared BEFORE `ReferralConversionWebhookDto`
+ * intentionally. With `emitDecoratorMetadata: true`, ts-jest emits a runtime
+ * `Reflect.metadata("design:type", ReferralConversionDataDto)` call at the
+ * `data: ReferralConversionDataDto` property in `ReferralConversionWebhookDto`,
+ * which evaluates the class reference at class-construction time. If the
+ * referenced class is declared later in the file, suite-load fails with
+ * `ReferenceError: Cannot access 'ReferralConversionDataDto' before initialization`
+ * (TDZ). Keep this order. See dhanam-debt-2026-04-27.md cause #4.
  */
-export class ReferralConversionWebhookDto {
-  @ApiProperty({ description: 'Event type', example: 'referral.converted' })
-  @IsString()
-  type: string;
-
-  @ApiProperty({ description: 'Conversion data payload' })
-  data: ReferralConversionDataDto;
-}
-
 export class ReferralConversionDataDto {
   @ApiProperty({ description: 'The referral code used', example: 'MADFAM-A1B2C3D4' })
   @IsString()
@@ -44,4 +41,17 @@ export class ReferralConversionDataDto {
   @IsOptional()
   @IsNumber()
   revenue_cents?: number;
+}
+
+/**
+ * Payload for the `referral.converted` webhook from PhyneCRM.
+ * Received via HMAC-authenticated POST /v1/referral/reward.
+ */
+export class ReferralConversionWebhookDto {
+  @ApiProperty({ description: 'Event type', example: 'referral.converted' })
+  @IsString()
+  type: string;
+
+  @ApiProperty({ description: 'Conversion data payload' })
+  data: ReferralConversionDataDto;
 }


### PR DESCRIPTION
## Summary

Reference: `claudedocs/dhanam-debt-2026-04-27.md` causes #3 + #4.

This PR ships a clean fix for **cause #4 only**. **Cause #3 was misdiagnosed** in the debt doc — investigation below.

---

## Cause #4 — Referral DTO TDZ at suite-load (FIXED)

**File**: `apps/api/src/modules/referral/dto/referral-event.dto.ts`

**Symptom**: 12 e2e suites failing with
```
ReferenceError: Cannot access 'ReferralConversionDataDto' before initialization
  at apps/api/src/modules/referral/dto/referral-event.dto.ts:14:9
```

**Root cause**: NOT a barrel cycle (no barrel exists for these DTOs). With `emitDecoratorMetadata: true` in `packages/config/typescript/nestjs.json`, ts-jest emits a runtime `Reflect.metadata("design:type", ReferralConversionDataDto)` call at the `data: ReferralConversionDataDto` property of `ReferralConversionWebhookDto`. Since `ReferralConversionDataDto` was declared **after** `ReferralConversionWebhookDto` in the same file (lines 17 vs 8), the runtime metadata lookup hit TDZ before the class binding initialized.

**Fix**: Reorder the two classes — declare `ReferralConversionDataDto` first. Single-file change, no API surface change, no import change. Added an in-file comment so future formatters don't re-shuffle it.

**Verification**: Ran `pnpm jest --config ./test/jest-e2e.json --testPathPatterns=billing-webhooks` locally. Before: suite fails to LOAD with ReferenceError. After: suite loads, all 18 tests run (and fail on DB connection — expected without local Postgres). Suite-load TDZ is gone.

---

## Cause #3 — Web jest "text-match drift" (NOT shipping; misdiagnosed)

**Files**: `apps/web/src/components/forms/{register,login}-form.test.tsx`

The debt doc diagnoses this as a Zod message string change with a stale test assertion. **It is not.** The mock translations in the test files match the rendered Zod messages **exactly** (`'Name must be at least {{min}} characters'` → `'Name must be at least 2 characters'`).

**Real root cause**: Dependency-version mismatch.

- `apps/web/package.json`: `zod@^4.3.6` (bumped in PR #178) + `@hookform/resolvers@^3.10.0`.
- `@hookform/resolvers@3.x` Zod adapter checks `Array.isArray(error?.errors)` to detect a `ZodError`. **Zod v4 renamed `.errors` → `.issues` on `ZodError`.**
- Result: `isZodError()` returns `false`, so the resolver **re-throws** the `ZodError` synchronously instead of returning it as form-state errors. The thrown error propagates through user-event/jsdom and the test fails before `getByText` can run.

**Evidence**:
```
ZodError: [{ code: "too_small", path: ["password"], message: "Password must be at least 8 characters" }, ...]
  at resolve (.../@hookform+resolvers@3.10.0/.../zod/src/zod.ts:61:32)
```
The message string IS exactly what the test asserts.

**Why this is out of scope for this PR**: per the task's stated scope discipline ("If cause #4 turns out to be deeper than a simple barrel cycle, document what you found and stop"), the analogous outcome applies to #3 — the real fix is bumping `@hookform/resolvers` to `^4.x` (Zod v4 support landed in resolvers v4) plus a lockfile update. That's a dep upgrade with broader blast radius (touches the auth surface) and deserves its own PR. PR #172 previously attempted this bump (to 5.2.2) but appears to have been reverted; whoever picks this up should investigate why.

**Recommendation**: file a follow-up issue to bump `@hookform/resolvers` to `^4` (or `^5`), re-run the form tests, and update the debt doc's cause #3 diagnosis.

---

## Files changed

- `apps/api/src/modules/referral/dto/referral-event.dto.ts` — class reorder + explainer comment

## Test plan

- [x] Local: `pnpm jest --config ./test/jest-e2e.json --testPathPatterns=billing-webhooks` — suite now loads (DB-dependent assertions out of scope)
- [ ] CI: confirm Test API e2e job is no longer red on suite-load TDZ for the 12 affected suites
- [ ] CI: Test Web jest job will still fail (cause #3 unchanged) — that is expected and documented above

## DO NOT MERGE until reviewer confirms scope decision on cause #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)