### PR TITLE
fix(web): bump @hookform/resolvers to v5 for Zod v4 compat

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@dhanam/shared": "workspace:*",
     "@dhanam/ui": "workspace:*",
-    "@hookform/resolvers": "^3.10.0",
+    "@hookform/resolvers": "^5.2.2",
     "@janua/react-sdk": "0.1.3",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",

--- a/apps/web/src/components/forms/register-form.test.tsx
+++ b/apps/web/src/components/forms/register-form.test.tsx
@@ -218,7 +218,7 @@ describe('RegisterForm', () => {
     });
   });
 
-  it.skip('should show error when password missing number', async () => {
+  it('should show error when password missing number', async () => {
     const user = userEvent.setup();
     render(<RegisterForm onSubmit={mockOnSubmit} />);
 
@@ -264,9 +264,7 @@ describe('RegisterForm', () => {
     expect(submittedData).not.toHaveProperty('confirmPassword');
   });
 
-  // Skipped: ZodError from z.literal(true) propagates through jsdom event system
-  // in @hookform/resolvers@3.10.0, same root cause as other skipped validation tests
-  it.skip('should not submit without accepting terms', async () => {
+  it('should not submit without accepting terms', async () => {
     const user = userEvent.setup();
     render(<RegisterForm onSubmit={mockOnSubmit} />);
 

--- a/apps/web/src/components/forms/register-form.tsx
+++ b/apps/web/src/components/forms/register-form.tsx
@@ -48,18 +48,22 @@ export function RegisterForm({ onSubmit, isLoading }: RegisterFormProps) {
     [tv]
   );
 
+  type RegisterFormValues = z.infer<typeof registerSchema>;
+
   const {
     register,
     handleSubmit,
     setValue,
     watch,
     formState: { errors },
-  } = useForm<RegisterDto & { acceptTerms: boolean; confirmPassword: string }>({
+  } = useForm<RegisterFormValues>({
     resolver: zodResolver(registerSchema),
     defaultValues: {
       locale: geo.locale,
       timezone: geo.timezone,
-      acceptTerms: false,
+      // Cast required: schema demands `true` literal but checkbox starts unchecked.
+      // Validation enforces `true` on submit; TS just needs assignability for default.
+      acceptTerms: false as unknown as true,
     },
   });
 
@@ -160,7 +164,7 @@ export function RegisterForm({ onSubmit, isLoading }: RegisterFormProps) {
             id="acceptTerms"
             checked={acceptTerms}
             onCheckedChange={(checked) =>
-              setValue('acceptTerms', checked === true, { shouldValidate: true })
+              setValue('acceptTerms', (checked === true) as true, { shouldValidate: true })
             }
             disabled={isLoading}
             className="mt-0.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -656,8 +656,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       '@hookform/resolvers':
-        specifier: ^3.10.0
-        version: 3.10.0(react-hook-form@7.71.2(react@18.3.1))
+        specifier: ^5.2.2
+        version: 5.2.2(react-hook-form@7.71.2(react@18.3.1))
       '@janua/react-sdk':
         specifier: 0.1.3
         version: 0.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(axios@1.15.2)(immer@11.1.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@4.2.3)(use-sync-external-store@1.6.0(react@18.3.1))
@@ -2508,10 +2508,10 @@ packages:
     peerDependencies:
       hono: '>=4.12.7'
 
-  '@hookform/resolvers@3.10.0':
-    resolution: {integrity: sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==}
+  '@hookform/resolvers@5.2.2':
+    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
     peerDependencies:
-      react-hook-form: ^7.0.0
+      react-hook-form: ^7.55.0
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -14288,8 +14288,9 @@ snapshots:
     dependencies:
       hono: 4.12.14
 
-  '@hookform/resolvers@3.10.0(react-hook-form@7.71.2(react@18.3.1))':
+  '@hookform/resolvers@5.2.2(react-hook-form@7.71.2(react@18.3.1))':
     dependencies:
+      '@standard-schema/utils': 0.3.0
       react-hook-form: 7.71.2(react@18.3.1)
 
   '@humanfs/core@0.19.1': {}


### PR DESCRIPTION
## Summary

Re-applies the @hookform/resolvers v3 -> v5 bump on apps/web to fix the Zod v4 incompatibility tracked in **task #212** and **dhanam-debt-2026-04-27.md cause #3**.

## Root cause

`@hookform/resolvers@3.x` detects ZodErrors via `Array.isArray(error?.errors)`. Zod v4 (which apps/web upgraded to in PR #178) renamed `.errors` -> `.issues`, so the v3 adapter re-throws instead of returning form errors, breaking every `zodResolver`-backed form (login-form, register-form, order-placement-form). v5 of resolvers checks `.issues` natively and explicitly supports Zod v4 (release notes 5.1.0+).

## PR #172 history

PR #172 was already merged (2026-01-29) bumping resolvers 3.10.0 -> 5.2.2. It was then **reverted in commit `be331f5`** ("fix: resolve all pre-existing CI failures") together with a zod 4 -> 3 downgrade, with the rationale: *pnpm was hoisting zod v3 (used by 3 sibling workspace packages) over apps/web's v4, breaking 'zod/v4/core' module resolution*.

That blocker is gone: all five workspaces (`apps/{web,admin,api}`, `packages/{shared,esg}`) are now on zod `^4.3.6`. There is no v3 anywhere to hoist. Safe to re-apply resolvers v5 alone.

## Changes

- `apps/web/package.json`: `@hookform/resolvers` `^3.10.0` -> `^5.2.2`
- `apps/web/src/components/forms/register-form.tsx`: switched the `useForm` generic to `z.infer<typeof registerSchema>` because v5's stricter resolver typing infers `acceptTerms: true` (literal) from `z.literal(true)` rather than `boolean`. Two narrow `as true` casts on the unchecked default + the Checkbox `onCheckedChange` handler. Runtime behaviour unchanged — validation still enforces the literal on submit.
- `apps/web/src/components/forms/register-form.test.tsx`: un-skipped the two tests explicitly gated on this exact bug (`should show error when password missing number`, `should not submit without accepting terms`).

**No import-path changes** — `@hookform/resolvers/zod` deep import is still the v5 entry for the Zod adapter.

## Test plan

- [x] `pnpm --filter @dhanam/web test`: **538 passed** (+2 vs main), 8 skipped (-2 vs main, both Zod-bug tests now pass), 0 failed
- [x] `pnpm --filter @dhanam/web typecheck`: passes
- [x] `pnpm install --frozen-lockfile`: lockfile in sync
- [ ] Manual smoke in browser — register/login/order forms render validation errors correctly

## References

- Task #212 (deferred Zod v4 / resolvers v3 API drift)
- `dhanam-debt-2026-04-27.md` cause #3
- PR #172 (original bump, reverted by be331f5)
- Resolvers v5.1.0 release notes — Zod v4 support

🤖 Generated with [Claude Code](https://claude.com/claude-code)