### PR TITLE
fix(web): downgrade missing PostHog from fatal to console.warn

### DIFF
--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -35,7 +35,7 @@ const envSchemaBase = z.object({
 });
 
 const envSchema = envSchemaBase.superRefine((data, ctx) => {
-  // In janua auth mode, OIDC vars are required
+  // In janua auth mode, OIDC vars are required (auth literally won't work without them)
   if (data.NEXT_PUBLIC_AUTH_MODE === 'janua') {
     if (!data.NEXT_PUBLIC_OIDC_ISSUER) {
       ctx.addIssue({
@@ -60,16 +60,12 @@ const envSchema = envSchemaBase.superRefine((data, ctx) => {
     }
   }
 
-  // Production guards
-  if (data.NODE_ENV === 'production') {
-    if (!data.NEXT_PUBLIC_POSTHOG_KEY) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'NEXT_PUBLIC_POSTHOG_KEY should be set in production for observability',
-        path: ['NEXT_PUBLIC_POSTHOG_KEY'],
-      });
-    }
-  }
+  // Note: PostHog absence used to be a fatal error in production — that was
+  // wrong. Observability is non-essential for the app to serve users; treating
+  // it as load-blocking caused 5+ days of CrashLoopBackOff (660 restarts on
+  // dhanam-web-85f66c94fb) when the env var was simply forgotten in the K8s
+  // Secret rollout. The check was downgraded to a non-blocking warn at module
+  // load (see getEnv() below) so prod can boot even when PostHog is unset.
 });
 
 export type Env = z.infer<typeof envSchema>;
@@ -87,6 +83,16 @@ export function getEnv(): Env {
     throw new Error(`[dhanam-web] Invalid environment variables:\n${message}`);
   }
   cachedEnv = parsed.data;
+
+  // Warn (but don't fail) on missing observability — see superRefine note above.
+  if (cachedEnv.NODE_ENV === 'production' && !cachedEnv.NEXT_PUBLIC_POSTHOG_KEY) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[dhanam-web] NEXT_PUBLIC_POSTHOG_KEY not set in production — observability disabled. ' +
+        'Set it in dhanam-secrets to re-enable PostHog tracking.',
+    );
+  }
+
   return cachedEnv;
 }
 

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:aae3763b58f5e8114f25aafc4d80e62590ed8667f7cba4b473dabadfbdfbcd29
+    digest: sha256:fd028729e8720ccf86173151e891b8aeb89e9db24c4bad7ad2e39635e5dfae0c
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:1a9a77fd2debaf8d590177189d549cf9cc85e79d62dccf29c1a0d92335fd575d
+    digest: sha256:68002fd78a6d9c2a6b7edc821bc4763e521db2130329daf17fb4bb6c9fc20e58
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:9984c044c5a8303a05292a5239166dda59490912e23ff3217c5be9a63f11947d
+    digest: sha256:238ed41badb3dbfe6ae52c5ca8adb298a2f2f117e00bd7af7e3e0258ae78f1e7
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:45717fc3420165039e5257daa276f941b9c42ba2fd237de946138729d0dd6821
+    digest: sha256:770c89d04ff0ad2980e325c3b5230f33e9b85fd2514060c2c6f989f9708cac05
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:200702681f328e6d06324ffbb0efe0b8c7575f8a48a2f377d1b11d356bf6b219
+    digest: sha256:cb0c9e5a367f46458d5edeb8b16ff1b80845d97ec9634b5c19be87f8ce029015
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:c07eacaab81ea7511c00a9253458844828e80b27f52212908be56c7ec6434749
+    digest: sha256:8ee37235a579abab83e41b27b247167ef593175e09fb896854dbf29dcc88ace1
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:bb995f2011ce53020ff7e263999a199e6478aa9709395163c8d187e3d0cabb31
+    digest: sha256:3ee611e650a2c7255f9875978d4e57bd8a15e45635b2bade374375a587e99801
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:62c6c8f2f1eb8672da14c63521646d4689c61ca8aa4e78d9582f026f1fcc4fc4
+    digest: sha256:77bb7970f9abf1ee1fb84b06c96e2157a6445604c14a0118075247052521d7ad
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:6dad035551712e7608ff11f0209dcf58a7332761d30046d08b83079a79bab397
+    digest: sha256:d1afd0465dbfc8e9a86d93c8bea1a2b320203c8f422e99bbe4b083b73cb6ea5b
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:b40a20a7efb1bf938c275144d86fd87b8961a65d168929a6755864c4440ebc14
+    digest: sha256:973ee02b516b9160b83d04fe066cde36e09332729203c237e5c9cfa4935e1ed7
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:d15c252cf3cd3ff80253eda5390a0342abfe79e1e23602de909c03955029000a
+    digest: sha256:fd67fa8836162c5699eaed3a700c91defad7e7dcdcb9ebe9a9f1fdd4e92f3241
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:66497de6d54fdc4e2593c8e1a5b59a5b0351d77f3ccd4a53060b58f5297be965
+    digest: sha256:710ffc6901b33e6c3013720a17a2758d900cce900c500a94783c43e9e4cda985
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:c7895e5e23951dcedcf3908dd96d7c61cf17f1a5de0ee36b83968a697d512773
+    digest: sha256:4db872f90efdf19e43023c0df6dc8a47c5a33146424fd8a505717cbfeee63a23
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:ba117342abaeec6e069ed37ba1435d8695d83705a901072cbf7c5ac4dcca3de8
+    digest: sha256:12775c24144f3e2f084f2d48b690fe854cba0757e6fe576441fb27adc6a6f87b
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:50a236e833c79902d5056014595ad74e52589a58ef2d783af4c99081cd46a941
+    digest: sha256:dc6d92325c07d3cfc3571bfd4df30867dcc3d6081a5e278ee222c28e7ad4feea
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:1424420e8946214a2f16e9958ccb9740ad80767ee366db258c39a349df906c35
+    digest: sha256:b40a20a7efb1bf938c275144d86fd87b8961a65d168929a6755864c4440ebc14
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:a13cf5aaf2b2f77319503f1ca7abdcaee671aee6eba4d52a5c5e6eb312216bae
+    digest: sha256:7870b3f0d5143ad94717e304911a3aaa7ed76316866fdf90e22c6c69146cd617
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:c921914cb1a56968ac323b1442f6344d74642287d478594dd83a2b5687af4621
+    digest: sha256:c069e3b219d1998a4218062906f24ec9ecda5928dba6df68d22f40a5d7c0fca8
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:68d0e0b18803f763939630752307bc8afafa53874cafc842ee664af953444bb9
+    digest: sha256:5e54930b494d5c2b985e11023d86732d901ea8c4164ad733702544d4f2e32db9
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:3ee611e650a2c7255f9875978d4e57bd8a15e45635b2bade374375a587e99801
+    digest: sha256:866e940686c18f31988fd529d255dff7cfeb94f13c04c6ee342cffb83e5e4187
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:0c44fa6cc28ed6034dc96ebea2e425ae99c524c0dfcfc5e00ce243e0328866c4
+    digest: sha256:fa7a06ea729198ba4dd2d8dc081312dec4447764ac5245f417f82f188829d9b4
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:d3321d7cf155e263f11644242fc4186df849fb4eaf10b4746c92cc5171f44214
+    digest: sha256:98b02e0f34f851c3caa70e58079c7262ca9f067d833a673c7fd2ffd687888503
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:09df3d66140a27c6785eabf616da5eafaa3b82aa50a140020f93d92b024a4f94
+    digest: sha256:c7fa4ecbde1ed2054f4fe9b678048ccf1bd996ac61c161ec0e5d8e4967ecb3e0
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:710ffc6901b33e6c3013720a17a2758d900cce900c500a94783c43e9e4cda985
+    digest: sha256:9e72b191c39a793e4a5919de5f3818ffb59e43284b30ceef343424c816d606be
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:ef18175753a519a37fcb8c828e892167fa01052a9b4411d9432c6ff6a10a5c59
+    digest: sha256:1cbe7896944c0b713ad4370db41dde8636b2734beb8b899871a2b27ec63ee30b
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:3ef66da737ef69701bf996a6a1b58be189df108c8b40ebd6275e696f531fdf9f
+    digest: sha256:87bece7cee86899cc592c3e87b1c6ea4b9609d216d79d4fbf5293242eea24f7d
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:ad69a14a6af5f847e35680bac5bd23263a21f4f9a21048c5cfa2cd49fa869ef4
+    digest: sha256:65183ef522bcd7988e46d17c34f4f2552fd672a3b440f751d811ab302ebb339e
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:2ea46863436b413fdd04cabd608da43fd0c3d36ddea4cc94cea07d6250dfdbb9
+    digest: sha256:1cb87125c974c6a4c8e8b86b9efaa258258c2453c46e01ce9604225987775b2f
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:d40dec99703995d3d7d76422e38d7037083dc2f58fc99a1bf075324653531650
+    digest: sha256:4fe380677f0a9516242c026dbc2a2593c49b2ea6c01d3f0f085e00150515a2c0
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:eabe76de230379921167534654cfa5bb5bf7645144e316d94249366de625851c
+    digest: sha256:d93ae08a5c10fbced01349facc0077ff339889f579c298b5ed7a7723039b3e6d
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:1ced6e70679a3ef25027198ecc470dc1e4af20ee91a4eb5bb5cf5efd4ff34c69
+    digest: sha256:380b55623c30ed08beca2260866dab761577afcf2bcb0d4ff3b95ed4a3c028ce
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:11dfd565275bf3c636a918483b48496d2a1480d6d948518bf1e31552541e23b5
+    digest: sha256:ad69a14a6af5f847e35680bac5bd23263a21f4f9a21048c5cfa2cd49fa869ef4
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:e39cb9a3afc0d042510c08e724dd2c8c8259c619cbe86a5fb98c2fdd0f185f4e
+    digest: sha256:fa913d1d48b07875008b93a03cec5cb9db7fcb9209ed4b0c5ab08b1187149053
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:3f2648a2923c09661697c398b42aa09782db38f766f8ff8ce3545ade170abcc0
+    digest: sha256:030d00a04895c525de2582a14945829081f9b3e0d7affed01ed4b911925d2607
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:52e09596591b48cc366ee7af3049a09e851054fe529ec7a190cce4068fff7655
+    digest: sha256:356247c1044cdcde949197fea35a56fd74ea98be0d5dae407b5384fa97085a62
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:6612c8b62ad3c57ff522edde2f3a0b7aa5165a62148efbf877728cceb6785bf7
+    digest: sha256:c2d292bfadde07abdaaa3d0ca28db0fdb6feaa52f61ab1aa2492b883b989d4f9
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:f2fa0a9465d2aaeceef456d0a22d5f58bfcbffe14e7bd31b114698bc071c51ac
+    digest: sha256:675bc83a19d33b73b00662e89d4f229672d00513c8afc559b4458a7f79062e90
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:0b02562175783570eb1d36422dca8bcefd99890f81ef5f1884ceb150e7a6c1d1
+    digest: sha256:7955237cdc06c4dbd177fa79fb1efad0e8f010a8f3b90c65f4c5bbafb0ff4d97
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:46d095ad245c94b2c4a93306cecb980c4e869313d0e8444ec62f1286703a7507
+    digest: sha256:47e982162d43df674a99e22523eee620c85a8bda2a2601c5d3039483b0f61481
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:47e982162d43df674a99e22523eee620c85a8bda2a2601c5d3039483b0f61481
+    digest: sha256:a68d89e41bb5508e138fe9cfe38e6a638b9a93f2b78b410695a1d727f3f6f5d4
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:748ef6ab62411f885b789c42dd160143bea17cdc3d6fbb00c2f36a6442186cff
+    digest: sha256:50a236e833c79902d5056014595ad74e52589a58ef2d783af4c99081cd46a941
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:adc7cf630ca10176c48f279cae689e765ce1c745fd0018daa5bf6547362f3d40
+    digest: sha256:11dfd565275bf3c636a918483b48496d2a1480d6d948518bf1e31552541e23b5
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:316dd76e0abf5a1043880d902504121aa70a867c4aa502d40f1c8344396a0a05
+    digest: sha256:4d401d8f4593b530f82b606533e07c6094b2ef6294e1df766b274ebbc92cbc20
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:74966f5f0d32aa0355776537249d886f75c6bd7894f4b5360eb3089d38404135
+    digest: sha256:281e75be1b902653d12bced9d4d59537c7820f4f25617fd1708e6102c92f54c8
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:ec74238cea5a382c091f9f42281b5733969ae197c21d9e4572cd3654bf33f611
+    digest: sha256:c71d55ca45139022bd81ae5b7c94bd5b221a077601a6fa36960190a936611bfb
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:063bea78e675a75a64f9205b88a0bd4361611336d2bb64065afa42d9130ad7e4
+    digest: sha256:0ce503d8abeea79e8a2016265f74cc2be1a56eb248008972ee8db428d698d187
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:cb0c9e5a367f46458d5edeb8b16ff1b80845d97ec9634b5c19be87f8ce029015
+    digest: sha256:1a9a77fd2debaf8d590177189d549cf9cc85e79d62dccf29c1a0d92335fd575d
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:675bc83a19d33b73b00662e89d4f229672d00513c8afc559b4458a7f79062e90
+    digest: sha256:2d0a51cf43fbbeda3d85e7363db42c4621fdbb5e4ecc0589bf7f83030bdbadef
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:a68d89e41bb5508e138fe9cfe38e6a638b9a93f2b78b410695a1d727f3f6f5d4
+    digest: sha256:21152a18b61238774f17125faa54fcfb5740f8bc1a6ce9d27491edc48faa9772
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:467860e8797981eba8f0c3ecdb91515774247027b0c604f9d65010173f2efcc1
+    digest: sha256:190dede8e10f3dee400e908a5118bf4ad89a8368dc1abfb1ac132a6ad395552e
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:492b357b62d9c450f4bc064cd89f5e6f184189822c21aff864048dd74bb39ba4
+    digest: sha256:c3aad081b046dc5ea676dff2ae81251d2b06da6c224940227ef5aef11ec2605c
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:fa913d1d48b07875008b93a03cec5cb9db7fcb9209ed4b0c5ab08b1187149053
+    digest: sha256:ba117342abaeec6e069ed37ba1435d8695d83705a901072cbf7c5ac4dcca3de8
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:adadfee5e0d11bfd17961c78660f7bd7e378c03ea09456b72c821a75eb03626c
+    digest: sha256:1424420e8946214a2f16e9958ccb9740ad80767ee366db258c39a349df906c35
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:834dc803d670af29282724f58e0da1ae2a7656c5abf1013831799f5ef498c8ed
+    digest: sha256:255dc6930bc72328c207d3aa8f3de820b87497cc306ecec1494b94bd9526aedb
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:245a83e25ee64788e2d4b7d2238ed13db9d28c35bd65ce834816d92616d07d24
+    digest: sha256:68d0e0b18803f763939630752307bc8afafa53874cafc842ee664af953444bb9
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:c069e3b219d1998a4218062906f24ec9ecda5928dba6df68d22f40a5d7c0fca8
+    digest: sha256:94609f6433cc1aa6cb85224da9002151fca32e1e3236ca9081cd1947ac4eae3c
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:c71d55ca45139022bd81ae5b7c94bd5b221a077601a6fa36960190a936611bfb
+    digest: sha256:cc1bbb709d6270718e9e45b41b8d279c59e35a9ba2216cd9276aa9970aeca87f
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:fd028729e8720ccf86173151e891b8aeb89e9db24c4bad7ad2e39635e5dfae0c
+    digest: sha256:7d6bbe866adf5f220209ed31abcab377d6a125819c400abade669ddede598d41
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:8a98bed1b8a631789b23ef2f390943c6a10c7edbcea79095c51000a9c0ea32a1
+    digest: sha256:c8671b9141b47549d1d5f1e567bd8716312f0b84cc597fe5f848534968d3be7f
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:5f52acb03ac23ab39b75b7eff02b4c8551c160320a3702232a2201cf7e1cdf5c
+    digest: sha256:58849ee19fcf1781198bcc68ddc4b09b453a6b2548d8761012d509d4a5775621
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:8fc7f194790a99ba5ff037858750dfdfe336439bdc658df9f7445273e0691d0f
+    digest: sha256:628bf83acb6f5ce4ec85c71250406728be4dfc89f7297021fb297319dc4c7b79
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:dca91baa4eb58aaf675a3c7fea6a0fabf6881667ca8d25964f50ae9cfbe82b5a
+    digest: sha256:ce7b6cc4e42c524b73557b382c0ab75a069197a95e9fd870e8eaf9380631abed
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:4a553c32513cc3803ca593938620505f19506f6ec4abc8cf33c339e46922d009
+    digest: sha256:9477e8c3629dd7c2bffdc9a845781d0bb1c6eb964f99c973db24c577b10e2ae0
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:3826192350e24eea926c5dc3916bbad8025f7563aeb21297a2c3e4e36d522392
+    digest: sha256:6ea38beb872662f8e376443a4670777974f2abd00674d3c1548c583745ba1964
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:13a1fc5d9c1bc0bfa161ee0ae9df08373b930e18ec0d9ef0296074349decf24e
+    digest: sha256:71d9103ce96d5ba513e170381044851cd26b1b9f93d68379a65e7e05be15123f
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:98b02e0f34f851c3caa70e58079c7262ca9f067d833a673c7fd2ffd687888503
+    digest: sha256:c5acc88e7fcc8b686e53c54a2b1af8b75da40b6544af067a5fe4fd184f574469
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:92a2d1162307b5322d587eee57c04eba17d713d4773e1a6ad33d88a83a6d357f
+    digest: sha256:9984c044c5a8303a05292a5239166dda59490912e23ff3217c5be9a63f11947d
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:4d401d8f4593b530f82b606533e07c6094b2ef6294e1df766b274ebbc92cbc20
+    digest: sha256:a19df0bf0708c772d99178edf62d99105e928627abec3ca18219818bb612ce10
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:d540aea8144b6e4f740ae934092cdeecc3ed41f98bf6942bb7ee487005dee089
+    digest: sha256:74966f5f0d32aa0355776537249d886f75c6bd7894f4b5360eb3089d38404135
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:0c7ed68cc42a696de8b46798be0cb4ee69818cca76ce44467cc8a1922ce48e73
+    digest: sha256:0bd51215425243e97682a81545ccd3dc7e352fbe80d48c0980d1f98e7a62433f
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:7b3322b23cd5972be56269aada4120ed94539ea7e28908d42cfb09c22390e3cd
+    digest: sha256:eb13937d04716ad80dc373e698ec2eaeeb64e80181971bbee4839a7fccce9eb3
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:8ee37235a579abab83e41b27b247167ef593175e09fb896854dbf29dcc88ace1
+    digest: sha256:5635caf11925a7b93f80bd3dd8188a1c1355988d4abd4c47cd9cef8f2d7724ba
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:3771140bf75419ef6e74f0d0401a64d3278ca64a702eb859895aeac2d03b3b96
+    digest: sha256:eff1fe6dfad34797e2db796088db3f3df0aaf10dbb8731fe95705ed60272af0e
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:5d6e586df00b223cb8484a2953e3700c105c33a41f3dcd3104a56e513dd701a0
+    digest: sha256:2bff362e24ccc6bf7ab8b3d2bfbf89767763f772822fd62d7dabc85cb11b7728
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:79616d6868700d31b701d6ee41507635dd9b874f5a914151f84b39ae9551b4cc
+    digest: sha256:245a83e25ee64788e2d4b7d2238ed13db9d28c35bd65ce834816d92616d07d24
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:2d0a51cf43fbbeda3d85e7363db42c4621fdbb5e4ecc0589bf7f83030bdbadef
+    digest: sha256:8fc7f194790a99ba5ff037858750dfdfe336439bdc658df9f7445273e0691d0f
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:281e75be1b902653d12bced9d4d59537c7820f4f25617fd1708e6102c92f54c8
+    digest: sha256:748ef6ab62411f885b789c42dd160143bea17cdc3d6fbb00c2f36a6442186cff
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:21152a18b61238774f17125faa54fcfb5740f8bc1a6ce9d27491edc48faa9772
+    digest: sha256:0c44fa6cc28ed6034dc96ebea2e425ae99c524c0dfcfc5e00ce243e0328866c4
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:0590229439f06776695dd23bf6b0ca41b830ca96e38bcbf33f24927abbb0e87e
+    digest: sha256:d40dec99703995d3d7d76422e38d7037083dc2f58fc99a1bf075324653531650
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:fd67fa8836162c5699eaed3a700c91defad7e7dcdcb9ebe9a9f1fdd4e92f3241
+    digest: sha256:bae0401a15218fe9db8835963d994d91fe23bfa62c804dcbbf94d9a6854129fc
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:e0cc75e3c9b13b51e0d7814106063d0df8b7eb2a695ac4876ad7b941269a4dda
+    digest: sha256:92a2d1162307b5322d587eee57c04eba17d713d4773e1a6ad33d88a83a6d357f
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:c8671b9141b47549d1d5f1e567bd8716312f0b84cc597fe5f848534968d3be7f
+    digest: sha256:eee757a8444d46a9e5a951aa416667b1aaf77ff2cff79c8b9c70caa39ac890e8
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:238ed41badb3dbfe6ae52c5ca8adb298a2f2f117e00bd7af7e3e0258ae78f1e7
+    digest: sha256:ae8c7fc20522a6349f6cc731e3aaef5098b72bec1ac0416437a2d8210990139d
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:7870b3f0d5143ad94717e304911a3aaa7ed76316866fdf90e22c6c69146cd617
+    digest: sha256:aae3763b58f5e8114f25aafc4d80e62590ed8667f7cba4b473dabadfbdfbcd29
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:9433479aacfabb376c0277d04bd1bafd5ee0e3225ba0a6ebd9d175615f83ae57
+    digest: sha256:3f2648a2923c09661697c398b42aa09782db38f766f8ff8ce3545ade170abcc0
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:cd13e55296e806a2d68ba36076f25e9077ac2e271f0c89289e34343c033c4d50
+    digest: sha256:0c7ed68cc42a696de8b46798be0cb4ee69818cca76ce44467cc8a1922ce48e73
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:e89cfd7481e9ef567414e162f36663c7413e9bd359ff823037131756333febfd
+    digest: sha256:45717fc3420165039e5257daa276f941b9c42ba2fd237de946138729d0dd6821
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:8a4dd78a48ddec3894c01c26f5ed75eb05a20cdea0fcf49b6d266d07ff6d7939
+    digest: sha256:56d3d709d20f82ad45299d96cbf4f2d5c09c82588af18b2233f34c165b4fe551
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:0b3af38aa055e622bb32b70c4ae317b63ea7c0b1ea44659ac6500df688b0deae
+    digest: sha256:ac83f008f46e301f0dca7488095c211ce8f5166e1780960a8cbaee6fe82b8838
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:eb5f0fb92dac95d680dc8032acfdb2cb32022b4fc4c177170f1e63566694ab91
+    digest: sha256:6e7903e26dd8698332fbe922ce3a80e43d3ae758c786ce2b417e2cb742b70c29
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:6ca1d0360c246b49645cb349fc35863458b933d81da487e4b0f0fd837a81418b
+    digest: sha256:c7895e5e23951dcedcf3908dd96d7c61cf17f1a5de0ee36b83968a697d512773
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:4fe380677f0a9516242c026dbc2a2593c49b2ea6c01d3f0f085e00150515a2c0
+    digest: sha256:0b3af38aa055e622bb32b70c4ae317b63ea7c0b1ea44659ac6500df688b0deae
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:356247c1044cdcde949197fea35a56fd74ea98be0d5dae407b5384fa97085a62
+    digest: sha256:09df3d66140a27c6785eabf616da5eafaa3b82aa50a140020f93d92b024a4f94
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:3b325d207e97f74f6b6cdaf2a20b89a1dfa830e2bbe0b3be4e75242581a64e64
+    digest: sha256:e23bd39e4b17db5804ad9e4c04bd67e36e0759d48ee897cc7e423f1074917a12
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:eff1fe6dfad34797e2db796088db3f3df0aaf10dbb8731fe95705ed60272af0e
+    digest: sha256:81c0d17d236c9903214cf10980255b37a354c88b201d67c1677222fd9b777a83
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:0bd51215425243e97682a81545ccd3dc7e352fbe80d48c0980d1f98e7a62433f
+    digest: sha256:6dad035551712e7608ff11f0209dcf58a7332761d30046d08b83079a79bab397
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:65183ef522bcd7988e46d17c34f4f2552fd672a3b440f751d811ab302ebb339e
+    digest: sha256:c921914cb1a56968ac323b1442f6344d74642287d478594dd83a2b5687af4621
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:b7b4bc434ae731689dff7307fae7566cc52c93bd9fe2ac1409fb30f6379e1eb7
+    digest: sha256:3b325d207e97f74f6b6cdaf2a20b89a1dfa830e2bbe0b3be4e75242581a64e64
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:fa7a06ea729198ba4dd2d8dc081312dec4447764ac5245f417f82f188829d9b4
+    digest: sha256:247bad501033521502d22235788ae2513a340818e6d465baf0cbc32e102ccbf9
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:c5acc88e7fcc8b686e53c54a2b1af8b75da40b6544af067a5fe4fd184f574469
+    digest: sha256:4a553c32513cc3803ca593938620505f19506f6ec4abc8cf33c339e46922d009
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:4aae345754503a6b8ecd826d8ad41b5cb4d3e368a2e21428bbc7bd676358cf7f
+    digest: sha256:13a1fc5d9c1bc0bfa161ee0ae9df08373b930e18ec0d9ef0296074349decf24e
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:247bad501033521502d22235788ae2513a340818e6d465baf0cbc32e102ccbf9
+    digest: sha256:8369869a2df2ef0e93adedca467d16044aadc12f641d090e33cd7b3fecc83ba6
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:bae0401a15218fe9db8835963d994d91fe23bfa62c804dcbbf94d9a6854129fc
+    digest: sha256:834dc803d670af29282724f58e0da1ae2a7656c5abf1013831799f5ef498c8ed
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:7d6bbe866adf5f220209ed31abcab377d6a125819c400abade669ddede598d41
+    digest: sha256:79616d6868700d31b701d6ee41507635dd9b874f5a914151f84b39ae9551b4cc
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:ae8c7fc20522a6349f6cc731e3aaef5098b72bec1ac0416437a2d8210990139d
+    digest: sha256:7b3322b23cd5972be56269aada4120ed94539ea7e28908d42cfb09c22390e3cd
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:c3aad081b046dc5ea676dff2ae81251d2b06da6c224940227ef5aef11ec2605c
+    digest: sha256:4c86242bf5b95df613d4b7940ebcb3567cc2a8da21b338a730b6c6ca13e8167d
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:a19df0bf0708c772d99178edf62d99105e928627abec3ca18219818bb612ce10
+    digest: sha256:e89cfd7481e9ef567414e162f36663c7413e9bd359ff823037131756333febfd
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:6ea38beb872662f8e376443a4670777974f2abd00674d3c1548c583745ba1964
+    digest: sha256:c07eacaab81ea7511c00a9253458844828e80b27f52212908be56c7ec6434749
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:ce7b6cc4e42c524b73557b382c0ab75a069197a95e9fd870e8eaf9380631abed
+    digest: sha256:3ef66da737ef69701bf996a6a1b58be189df108c8b40ebd6275e696f531fdf9f
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:e5caba0348908019e850a2a91743c1c3977357eca0c15e8acc7b4c3ece18902e
+    digest: sha256:3826192350e24eea926c5dc3916bbad8025f7563aeb21297a2c3e4e36d522392
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:4c9b6f7b80ca03159cc69bec29f20117a0df438a30c2f7e363de8d08e9dffaf0
+    digest: sha256:c3bfbdc907782ba022a73051fe2b50b50ab89fe6fd56140db1cbe03165e897c1
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:e23bd39e4b17db5804ad9e4c04bd67e36e0759d48ee897cc7e423f1074917a12
+    digest: sha256:de86c1e60750dcddcef6cf950cd2ed80c9661aef4ec35ab85788a5872daf756f
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:7955237cdc06c4dbd177fa79fb1efad0e8f010a8f3b90c65f4c5bbafb0ff4d97
+    digest: sha256:063bea78e675a75a64f9205b88a0bd4361611336d2bb64065afa42d9130ad7e4
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:9477e8c3629dd7c2bffdc9a845781d0bb1c6eb964f99c973db24c577b10e2ae0
+    digest: sha256:9f5f3357477989694b839e906c453aa15ded1e5327be9fab4c39f5aeebc5c7e9
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:81c0d17d236c9903214cf10980255b37a354c88b201d67c1677222fd9b777a83
+    digest: sha256:b0d1956800cbc881884db731811c6c2b453024ac15c964556006e4088c98861d
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:c3bfbdc907782ba022a73051fe2b50b50ab89fe6fd56140db1cbe03165e897c1
+    digest: sha256:f5ed3728ecb79da5bec70d5abbfef092c7d5bd6034fc97e1c4d30bd2369890aa
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:9f5f3357477989694b839e906c453aa15ded1e5327be9fab4c39f5aeebc5c7e9
+    digest: sha256:cd13e55296e806a2d68ba36076f25e9077ac2e271f0c89289e34343c033c4d50
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:58849ee19fcf1781198bcc68ddc4b09b453a6b2548d8761012d509d4a5775621
+    digest: sha256:8a98bed1b8a631789b23ef2f390943c6a10c7edbcea79095c51000a9c0ea32a1
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:9e72b191c39a793e4a5919de5f3818ffb59e43284b30ceef343424c816d606be
+    digest: sha256:dca91baa4eb58aaf675a3c7fea6a0fabf6881667ca8d25964f50ae9cfbe82b5a
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:2beea60a564278a8678263466c8d2e9b82ccd4b3f1c93be99ec80d10a78757b2
+    digest: sha256:467860e8797981eba8f0c3ecdb91515774247027b0c604f9d65010173f2efcc1
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:22f2271f047414a6cc22cd3bf0102c8c53dc8dda459cbe140c9dad159d3785fa
+    digest: sha256:e39cb9a3afc0d042510c08e724dd2c8c8259c619cbe86a5fb98c2fdd0f185f4e
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:0c720330453e850bb1ac1688482dcfe84f15f25ad01918725d536e451946f15d
+    digest: sha256:adadfee5e0d11bfd17961c78660f7bd7e378c03ea09456b72c821a75eb03626c
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:1cb87125c974c6a4c8e8b86b9efaa258258c2453c46e01ce9604225987775b2f
+    digest: sha256:eabe76de230379921167534654cfa5bb5bf7645144e316d94249366de625851c
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:7c3c522fdfc6bc4b6f4b13cbc2306de7c14c40fc814182587bd8718cd841884d
+    digest: sha256:22f2271f047414a6cc22cd3bf0102c8c53dc8dda459cbe140c9dad159d3785fa
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:bbcf2fbde9816289f82d69af05f78fba56249cb954797e6c6772ab28b5de55bb
+    digest: sha256:59431a85aebe0f01e91af2381c58168c78ff5523c9abdd369a5db493ac68b2a8
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:8369869a2df2ef0e93adedca467d16044aadc12f641d090e33cd7b3fecc83ba6
+    digest: sha256:ef18175753a519a37fcb8c828e892167fa01052a9b4411d9432c6ff6a10a5c59
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:ac83f008f46e301f0dca7488095c211ce8f5166e1780960a8cbaee6fe82b8838
+    digest: sha256:4c9b6f7b80ca03159cc69bec29f20117a0df438a30c2f7e363de8d08e9dffaf0
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:77bb7970f9abf1ee1fb84b06c96e2157a6445604c14a0118075247052521d7ad
+    digest: sha256:6ca1d0360c246b49645cb349fc35863458b933d81da487e4b0f0fd837a81418b
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:0ce503d8abeea79e8a2016265f74cc2be1a56eb248008972ee8db428d698d187
+    digest: sha256:66ff7ee18906c3779a8f55ba28fe27984f441b44b62ffbd23fbe4fdd48cd9eb6
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:94609f6433cc1aa6cb85224da9002151fca32e1e3236ca9081cd1947ac4eae3c
+    digest: sha256:d3321d7cf155e263f11644242fc4186df849fb4eaf10b4746c92cc5171f44214
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:4c86242bf5b95df613d4b7940ebcb3567cc2a8da21b338a730b6c6ca13e8167d
+    digest: sha256:46d095ad245c94b2c4a93306cecb980c4e869313d0e8444ec62f1286703a7507
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:d1afd0465dbfc8e9a86d93c8bea1a2b320203c8f422e99bbe4b083b73cb6ea5b
+    digest: sha256:a3ae80001662f6c3a1f6e78cdc23d04e2d53ebee2b40efefce3582186957793b
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:5635caf11925a7b93f80bd3dd8188a1c1355988d4abd4c47cd9cef8f2d7724ba
+    digest: sha256:1ced6e70679a3ef25027198ecc470dc1e4af20ee91a4eb5bb5cf5efd4ff34c69
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:68002fd78a6d9c2a6b7edc821bc4763e521db2130329daf17fb4bb6c9fc20e58
+    digest: sha256:f2fa0a9465d2aaeceef456d0a22d5f58bfcbffe14e7bd31b114698bc071c51ac
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:030d00a04895c525de2582a14945829081f9b3e0d7affed01ed4b911925d2607
+    digest: sha256:d15c252cf3cd3ff80253eda5390a0342abfe79e1e23602de909c03955029000a
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:eee757a8444d46a9e5a951aa416667b1aaf77ff2cff79c8b9c70caa39ac890e8
+    digest: sha256:52e09596591b48cc366ee7af3049a09e851054fe529ec7a190cce4068fff7655
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:866e940686c18f31988fd529d255dff7cfeb94f13c04c6ee342cffb83e5e4187
+    digest: sha256:23311eae4e039171b78e270df012d835efbf37e4b70e7b54b9280446aa92b599
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:23311eae4e039171b78e270df012d835efbf37e4b70e7b54b9280446aa92b599
+    digest: sha256:bbcf2fbde9816289f82d69af05f78fba56249cb954797e6c6772ab28b5de55bb
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:770c89d04ff0ad2980e325c3b5230f33e9b85fd2514060c2c6f989f9708cac05
+    digest: sha256:492b357b62d9c450f4bc064cd89f5e6f184189822c21aff864048dd74bb39ba4
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:6102ba490246edb53064ebcd2457038b010b2a5e1808968297db4ee220768747
+    digest: sha256:9433479aacfabb376c0277d04bd1bafd5ee0e3225ba0a6ebd9d175615f83ae57
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:56d3d709d20f82ad45299d96cbf4f2d5c09c82588af18b2233f34c165b4fe551
+    digest: sha256:4aae345754503a6b8ecd826d8ad41b5cb4d3e368a2e21428bbc7bd676358cf7f
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:a3ae80001662f6c3a1f6e78cdc23d04e2d53ebee2b40efefce3582186957793b
+    digest: sha256:46c6dfa6f7aeb03b0968c110227396f595abb32b3dd88b18d0b67ff50dfb26a3
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:d93ae08a5c10fbced01349facc0077ff339889f579c298b5ed7a7723039b3e6d
+    digest: sha256:5d6e586df00b223cb8484a2953e3700c105c33a41f3dcd3104a56e513dd701a0
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:2bff362e24ccc6bf7ab8b3d2bfbf89767763f772822fd62d7dabc85cb11b7728
+    digest: sha256:eb5f0fb92dac95d680dc8032acfdb2cb32022b4fc4c177170f1e63566694ab91
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:1cbe7896944c0b713ad4370db41dde8636b2734beb8b899871a2b27ec63ee30b
+    digest: sha256:66497de6d54fdc4e2593c8e1a5b59a5b0351d77f3ccd4a53060b58f5297be965
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:c2d292bfadde07abdaaa3d0ca28db0fdb6feaa52f61ab1aa2492b883b989d4f9
+    digest: sha256:6102ba490246edb53064ebcd2457038b010b2a5e1808968297db4ee220768747
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:de86c1e60750dcddcef6cf950cd2ed80c9661aef4ec35ab85788a5872daf756f
+    digest: sha256:e0cc75e3c9b13b51e0d7814106063d0df8b7eb2a695ac4876ad7b941269a4dda
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:f5ed3728ecb79da5bec70d5abbfef092c7d5bd6034fc97e1c4d30bd2369890aa
+    digest: sha256:a13cf5aaf2b2f77319503f1ca7abdcaee671aee6eba4d52a5c5e6eb312216bae
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:c7fa4ecbde1ed2054f4fe9b678048ccf1bd996ac61c161ec0e5d8e4967ecb3e0
+    digest: sha256:bb995f2011ce53020ff7e263999a199e6478aa9709395163c8d187e3d0cabb31
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:dc6d92325c07d3cfc3571bfd4df30867dcc3d6081a5e278ee222c28e7ad4feea
+    digest: sha256:b7b4bc434ae731689dff7307fae7566cc52c93bd9fe2ac1409fb30f6379e1eb7
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:b0d1956800cbc881884db731811c6c2b453024ac15c964556006e4088c98861d
+    digest: sha256:5f52acb03ac23ab39b75b7eff02b4c8551c160320a3702232a2201cf7e1cdf5c
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:380b55623c30ed08beca2260866dab761577afcf2bcb0d4ff3b95ed4a3c028ce
+    digest: sha256:c2ec536f69febb766c0ddf20bf230a57e3fcf52c00b8e485d34cb573d0e5ce10
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:6e7903e26dd8698332fbe922ce3a80e43d3ae758c786ce2b417e2cb742b70c29
+    digest: sha256:200702681f328e6d06324ffbb0efe0b8c7575f8a48a2f377d1b11d356bf6b219
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:46c6dfa6f7aeb03b0968c110227396f595abb32b3dd88b18d0b67ff50dfb26a3
+    digest: sha256:2ea46863436b413fdd04cabd608da43fd0c3d36ddea4cc94cea07d6250dfdbb9
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:59431a85aebe0f01e91af2381c58168c78ff5523c9abdd369a5db493ac68b2a8
+    digest: sha256:e5caba0348908019e850a2a91743c1c3977357eca0c15e8acc7b4c3ece18902e
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:255dc6930bc72328c207d3aa8f3de820b87497cc306ecec1494b94bd9526aedb
+    digest: sha256:62c6c8f2f1eb8672da14c63521646d4689c61ca8aa4e78d9582f026f1fcc4fc4
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:b7612a35400efe7ec75f683cca8c64c3a73347c6f8eefed32112b108cff3dbe9
+    digest: sha256:6612c8b62ad3c57ff522edde2f3a0b7aa5165a62148efbf877728cceb6785bf7
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:12775c24144f3e2f084f2d48b690fe854cba0757e6fe576441fb27adc6a6f87b
+    digest: sha256:ec74238cea5a382c091f9f42281b5733969ae197c21d9e4572cd3654bf33f611
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:5e54930b494d5c2b985e11023d86732d901ea8c4164ad733702544d4f2e32db9
+    digest: sha256:316dd76e0abf5a1043880d902504121aa70a867c4aa502d40f1c8344396a0a05
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:4db872f90efdf19e43023c0df6dc8a47c5a33146424fd8a505717cbfeee63a23
+    digest: sha256:7c3c522fdfc6bc4b6f4b13cbc2306de7c14c40fc814182587bd8718cd841884d
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:87bece7cee86899cc592c3e87b1c6ea4b9609d216d79d4fbf5293242eea24f7d
+    digest: sha256:b7612a35400efe7ec75f683cca8c64c3a73347c6f8eefed32112b108cff3dbe9
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:66ff7ee18906c3779a8f55ba28fe27984f441b44b62ffbd23fbe4fdd48cd9eb6
+    digest: sha256:3771140bf75419ef6e74f0d0401a64d3278ca64a702eb859895aeac2d03b3b96
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:71d9103ce96d5ba513e170381044851cd26b1b9f93d68379a65e7e05be15123f
+    digest: sha256:a281873d0df0826919f739b9df597da93024a99e9c2c7dbfd6ccbffc71467e61
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:c2ec536f69febb766c0ddf20bf230a57e3fcf52c00b8e485d34cb573d0e5ce10
+    digest: sha256:0590229439f06776695dd23bf6b0ca41b830ca96e38bcbf33f24927abbb0e87e
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:eb13937d04716ad80dc373e698ec2eaeeb64e80181971bbee4839a7fccce9eb3
+    digest: sha256:8a4dd78a48ddec3894c01c26f5ed75eb05a20cdea0fcf49b6d266d07ff6d7939
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:190dede8e10f3dee400e908a5118bf4ad89a8368dc1abfb1ac132a6ad395552e
+    digest: sha256:0b02562175783570eb1d36422dca8bcefd99890f81ef5f1884ceb150e7a6c1d1
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:628bf83acb6f5ce4ec85c71250406728be4dfc89f7297021fb297319dc4c7b79
+    digest: sha256:d540aea8144b6e4f740ae934092cdeecc3ed41f98bf6942bb7ee487005dee089
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:a281873d0df0826919f739b9df597da93024a99e9c2c7dbfd6ccbffc71467e61
+    digest: sha256:0c720330453e850bb1ac1688482dcfe84f15f25ad01918725d536e451946f15d
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:cc1bbb709d6270718e9e45b41b8d279c59e35a9ba2216cd9276aa9970aeca87f
+    digest: sha256:adc7cf630ca10176c48f279cae689e765ce1c745fd0018daa5bf6547362f3d40
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin


### PR DESCRIPTION
## Summary
Stops missing PostHog observability config from throwing fatal errors on web app boot — degrades gracefully to console.warn instead.

## Why
PostHog observability is currently optional/operator-managed. A missing key shouldn't take down the app; a warning is sufficient signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)