### PR TITLE
fix(web): reorder imports to satisfy import/order eslint rule

### DIFF
--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -1,6 +1,6 @@
+import { User } from '@dhanam/shared';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import { User } from '@dhanam/shared';
 
 interface AuthState {
   user: User | null;

--- a/apps/web/src/stores/space.ts
+++ b/apps/web/src/stores/space.ts
@@ -1,6 +1,6 @@
+import { Space } from '@dhanam/shared';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import { Space } from '@dhanam/shared';
 
 interface SpaceStore {
   currentSpace: Space | null;


### PR DESCRIPTION
## Summary
\`next build\` runs ESLint inline and was failing on \`@dhanam/shared\` import order in \`auth.ts\` and \`space.ts\`. This was blocking the Deploy Web pipeline post-PR #401, leaving dhanam-web stuck in CrashLoopBackOff on the stale digest.

## Test plan
- [ ] Deploy Web to K8s (GHCR) succeeds
- [ ] dhanam-web ReplicaSet rolls; new pods reach 1/1 Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)