### PR TITLE
fix(web): skip ESLint during Docker build to unblock image rebuild

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -4,6 +4,11 @@ const { withSentryConfig } = require('@sentry/nextjs');
 const nextConfig = {
   output: 'standalone',
   reactStrictMode: true,
+  eslint: {
+    // ESLint runs in CI/lint workflow; skipping here keeps Docker build green
+    // when project-service mode trips on test files outside the prod tsconfig.
+    ignoreDuringBuilds: true,
+  },
   transpilePackages: [
     '@dhanam/shared',
     '@dhanam/ui',


### PR DESCRIPTION
## Summary

Adds `eslint: { ignoreDuringBuilds: true }` to `apps/web/next.config.js` so the Docker image build can complete.

## Why

The `Build and push Docker image` step in `Deploy Web to K8s (GHCR)` runs `next build`, which triggers ESLint in project-service mode. Project service requires every parsed file to be in the tsconfig include — but `apps/web/src/__tests__/**` and `__mocks__/**` are deliberately excluded from the prod tsconfig. ESLint then errors on hundreds of test files with:

```
Parsing error: <file> was not found by the project service.
Consider either including it in the tsconfig.json or including it in allowDefaultProject.
```

This has been failing every Deploy Web build, leaving prod stuck on the 4-day-old `c377eaf3...` digest. New ReplicaSet pods were crashlooping on the missing `NEXT_PUBLIC_POSTHOG_KEY` env var that PR #399 already made optional in source — but that fix never reached prod because no image rebuild succeeded.

ESLint already runs in the dedicated **Lint & Type Check** workflow on PRs; skipping it inside the build is the canonical Next.js escape hatch and doesn't reduce coverage.

## Test plan

- [ ] After merge, `Deploy Web to K8s (GHCR)` should pass for the first time in 4 days
- [ ] Auto-pin commits new digest to `infra/k8s/production/kustomization.yaml`
- [ ] ArgoCD rolls dhanam-web; new ReplicaSet pods reach Ready
- [ ] `kubectl -n dhanam get deploy dhanam-web` shows `2/2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)