### PR TITLE
fix(k8s): wire POSTHOG_API_KEY + METAMAP_FLOW_ID + CHECKOUT_ALLOWED_HOSTS

### DIFF
--- a/infra/k8s/production/api-deployment.yaml
+++ b/infra/k8s/production/api-deployment.yaml
@@ -290,6 +290,29 @@ spec:
                   key: FEDERATION_API_TOKEN
 
             # =================================================================
+            # Analytics + KYC flow + Checkout host allowlist
+            # Reconciled into dhanam-secrets 2026-05-04 (previously kubectl-edit
+            # inline-patched on the live deployment, which blocked ArgoCD sync
+            # for 25+ days). See:
+            # internal-devops/runbooks/2026-05-04-dhanam-argocd-sync-incident.md
+            # =================================================================
+            - name: POSTHOG_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: dhanam-secrets
+                  key: POSTHOG_API_KEY
+            - name: METAMAP_FLOW_ID
+              valueFrom:
+                secretKeyRef:
+                  name: dhanam-secrets
+                  key: METAMAP_FLOW_ID
+            - name: CHECKOUT_ALLOWED_HOSTS
+              valueFrom:
+                secretKeyRef:
+                  name: dhanam-secrets
+                  key: CHECKOUT_ALLOWED_HOSTS
+
+            # =================================================================
             # Email / SMTP
             # =================================================================
             - name: SMTP_HOST


### PR DESCRIPTION
## Why

These three env vars were live-only (kubectl-edited inline as plaintext on the running pod) for 25+ days, with no source-side wiring. Combined with two MetaMap secrets that had stale values in `dhanam-secrets`, the inline-vs-source mismatch was blocking ArgoCD sync of `dhanam-services` since the modern Stripe MX/Conekta/credit-billing controllers landed.

## What this PR does

Adds source-side env wiring (using `valueFrom: secretKeyRef`) for:
- `POSTHOG_API_KEY`
- `METAMAP_FLOW_ID`
- `CHECKOUT_ALLOWED_HOSTS`

All three now live in `dhanam-secrets` as of 2026-05-04 (reconciliation step).

## Sequence

1. ✅ The 5 inline values were captured + reconciled into `dhanam-secrets` (METAMAP_CLIENT_ID/CLIENT_SECRET updated; the 3 added by this PR were added fresh).
2. ✅ This PR adds source-side env wiring for the 3 new keys.
3. ⏭️ Next: remove the 5 inline entries from the live deployment via `kubectl patch`. After which ArgoCD reconciles cleanly to this source state.
4. ⏭️ ArgoCD then deploys the modern Stripe MX/Conekta/credit-billing controllers from the in-repo digest pin (sha256:69ebe0c6, ~25 days stale).

Reference: `internal-devops/runbooks/2026-05-04-dhanam-argocd-sync-incident.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)