### PR TITLE
fix(k8s): rollback api digest to last-working + add WEB_URL env

### DIFF
--- a/infra/k8s/production/api-deployment.yaml
+++ b/infra/k8s/production/api-deployment.yaml
@@ -88,6 +88,14 @@ spec:
               value: "production"
             - name: PORT
               value: "4300"
+            # Required by post-2026-04-30 ConfigModule validator
+            # (newer images refuse startup with "Config validation
+            # error: WEB_URL is required"). Old running image
+            # sha256:99f148de predates this validator; once that
+            # image rolls forward to a fixed BillingModule build,
+            # this var becomes load-bearing.
+            - name: WEB_URL
+              value: "https://app.dhan.am"
 
             # =================================================================
             # Janua OIDC (Galaxy Ecosystem Authentication)

--- a/infra/k8s/production/kustomization.yaml
+++ b/infra/k8s/production/kustomization.yaml
@@ -15,7 +15,7 @@ images:
 - digest: sha256:d52d87d0f62b1975a59c234bd27de583d46102e2d61a6d21ab52ca24e7b20779
   name: dhanam-admin
   newName: ghcr.io/madfam-org/dhanam/admin
-- digest: sha256:f684d6ff5539dd7bc08775963c98c327575c329f4c3175a1211f294a1003404b
+- digest: sha256:99f148de658c97258d2bd6756b246bc2a8a7cfb035d50028919cfc6bd88df95d
   name: dhanam-api
   newName: ghcr.io/madfam-org/dhanam/api
 - digest: sha256:b4e9b20fad7bb8c73808aa737d0085253026e116e357fdae4ab86251175e07ec


### PR DESCRIPTION
## Why

Discovered while attempting to deploy the modern billing controllers (Stripe MX, Conekta, credit-billing) post-#411 and the inline-env reconciliation: **the last 3 published api image digests are all broken**.

\`\`\`
Error: Nest cannot create the BillingModule instance.
The module at index [3] of the BillingModule "imports" array is undefined.
Scope [AppModule -> AuthModule -> EmailModule -> AnalyticsModule -> SpacesModule]
\`\`\`

Tested digests (all crash on boot):
- \`sha256:f684d6ff5539...\` (current pin in main, latest)
- \`sha256:54b14cfad1c9...\` (previous)
- \`sha256:69ebe0c6a864...\` (the one the runbook expected to deploy)

The bug is in source code (something between \`AppModule\` → \`AuthModule\` → \`EmailModule\` → \`AnalyticsModule\` → \`SpacesModule\` → \`BillingModule\` is exporting \`undefined\` at module evaluation time). Tracking issue: TODO — open as separate concern.

Currently-running OLD pods (\`dhanam-api-554987bfc7-{kztlb,wb7qk}\`) are on \`sha256:99f148de\` from April 9, predating this regression. They serve traffic correctly on legacy paths.

## What this PR does

1. Reverts the kustomize digest pin from \`f684d6ff\` → \`99f148de\` (last-working).
2. Adds \`WEB_URL\` env to \`api-deployment.yaml\` (required by the newer ConfigModule validator that rejected startup as \`"WEB_URL" is required\` — harmless on \`99f148de\` which doesn't have that validator).

## Trade-off

Gives up the modern Stripe MX / Conekta / credit-billing controllers until the BillingModule code bug is fixed and a new image is built. Legacy \`/v1/billing/webhook\` continues to work; modern \`/v1/billing/webhooks/{stripe,conekta}\` and \`/v1/billing/credits/usage\` remain 404.

## Sequence

This PR is paired with #411 (env wiring for POSTHOG/METAMAP_FLOW_ID/CHECKOUT_ALLOWED_HOSTS). Together they leave dhanam in a stable, ArgoCD-Synced, ready-to-roll-forward state — the moment a fixed image lands and gets pinned, no further env or secret work is required.

## Test plan

- [x] All 3 alt digests verified to crash with the same error
- [x] Old pods on 99f148de continue to serve \`/v1/health\` etc.
- [ ] After merge: ArgoCD sync forces deployment back to 99f148de; new RS no-op rolls (no pods recreate since old pods already on this digest)
- [ ] ArgoCD shows \`Synced/Healthy\`

## Follow-up needed

Open a tracking issue for the BillingModule undefined-import bug. Source-side fix needed in \`apps/api/src/modules/billing/\` — likely a recently extracted sub-module that's exported as \`undefined\` from somewhere in the import chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)