### PR TITLE
fix(billing): resolve BillingModule undefined import causing prod CrashLoopBackOff

### DIFF
--- a/apps/api/src/modules/billing/billing.module.ts
+++ b/apps/api/src/modules/billing/billing.module.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 import { HttpModule } from '@nestjs/axios';
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 
 import { AuditModule } from '../../core/audit/audit.module';
@@ -78,7 +78,13 @@ import { UsageAlertsService } from './services/usage-alerts.service';
     ConfigModule,
     PrismaModule,
     AuditModule,
-    EmailModule,
+    // forwardRef breaks the indirect circular dep:
+    //   BillingModule → EmailModule → AnalyticsModule (@Global)
+    //     → SpacesModule → BillingModule
+    // EmailService is consumed only at provider level (UsageAlertsService),
+    // so deferring the module-graph edge is safe. Added 2026-05-04 to fix
+    // the prod CrashLoopBackOff that pinned us to sha256:99f148de (#413).
+    forwardRef(() => EmailModule),
     // MonitoringModule provides the 'SentryService' string token used
     // by WebhookDlqService for per-failure structured Sentry events.
     MonitoringModule,


### PR DESCRIPTION
## Summary

Wraps `EmailModule` in `forwardRef()` inside `BillingModule.imports[]` to break the indirect 4-node circular dependency that has pinned production to the April 9 image (`sha256:99f148de`) since #298 landed on 2026-04-17.

Closes the prod CrashLoopBackOff blocker tracked in #413; supersedes the rollback in #412 (the pin in `infra/k8s/production/kustomization.yaml` will roll forward via the build-publish workflow once this lands and a new image is published — no kustomization edit needed in this PR).

## Root cause

The crash loop:

```
Error: Nest cannot create the BillingModule instance.
The module at index [3] of the BillingModule "imports" array is undefined.
```

Index `[3]` of `imports` is `EmailModule`. The cycle:

```
BillingModule  -> EmailModule  -> AnalyticsModule (@Global)
   ^                                    |
   |                                    v
   +---------- SpacesModule  <----------+
```

When Nest evaluates `BillingModule`, it walks into `EmailModule`, which depends on `AnalyticsModule`, which depends on `SpacesModule`, which itself depends on `BillingModule`. Because module construction can't complete on the first pass, `EmailModule`'s class reference is still `undefined` when the `imports[]` literal is evaluated — surfacing as the error above.

`bisect`: the cycle closed in **8f50caf** "feat(billing): P2.2 Waybill usage-alerts ingest + UI (#298)" on 2026-04-17, which was the first commit to add `EmailModule` to `BillingModule.imports[]` (so `UsageAlertsService` could inject `EmailService` for the budget-alert dispatch). Before that commit, no edge from `BillingModule` to `EmailModule` existed and the cycle was open.

## Fix

```diff
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 ...
   imports: [
     ConfigModule,
     PrismaModule,
     AuditModule,
-    EmailModule,
+    forwardRef(() => EmailModule),
     MonitoringModule,
     HttpModule.register(...),
   ],
```

Same `forwardRef` pattern that `apps/api/src/modules/marketplace/marketplace.module.ts` already uses for its own `BillingModule` edge. `EmailService` is consumed only at the provider level (`UsageAlertsService` constructor injection at `apps/api/src/modules/billing/services/usage-alerts.service.ts:63`), so deferring the module-graph edge is safe — provider DI still resolves correctly once both modules are constructed.

## Test plan

- [x] `pnpm --filter @dhanam/api typecheck` — passes
- [x] `pnpm --filter @dhanam/api test -- --testPathPatterns=billing` — same result on this branch as on `main` (3 failed / 33 passed / 24 failures pre-exist; the failures are unrelated `PostHogService` / `RootTestModule` test-setup issues, not introduced here)
- [x] Pre-commit (lint-staged + commitlint) — passes
- [x] Pre-push (turbo typecheck + lint) — passes (0 errors, only pre-existing warnings)
- [ ] **CI** — full CI must go green
- [ ] **Post-merge**: confirm new image builds, rolls into `infra/k8s/production/kustomization.yaml` via `deploy-k8s.yml`, ArgoCD reconciles, `api.dhan.am/health` 200s
- [ ] **Post-merge regression check**: confirm the runbook at `internal-devops/runbooks/2026-05-04-dhanam-argocd-sync-incident.md` can be retired (no longer pinned to `sha256:99f148de`)

## Refs

- Closes #413
- Supersedes #412 (the rollback this fix unblocks)
- Introduced in #298 (`8f50caf`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)