### PR TITLE
fix(categories): forwardRef SpacesModule edge to break circular dep

### DIFF
--- a/apps/api/src/modules/categories/categories.module.ts
+++ b/apps/api/src/modules/categories/categories.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 
 import { PrismaModule } from '../../core/prisma/prisma.module';
 import { SpacesModule } from '../spaces/spaces.module';
@@ -8,8 +8,13 @@ import { CategoriesService } from './categories.service';
 import { CategorizationRulesController } from './categorization-rules.controller';
 import { RulesService } from './rules.service';
 
+// Cycle: JobsModule → CategoriesModule → SpacesModule → BillingModule
+// → MonitoringModule → JobsModule. forwardRef defers the SpacesModule
+// edge so module-graph construction completes; provider DI still
+// resolves once both modules are constructed. Mirrors the pattern in
+// billing.module.ts (#414) for the BillingModule → EmailModule edge.
 @Module({
-  imports: [PrismaModule, SpacesModule],
+  imports: [PrismaModule, forwardRef(() => SpacesModule)],
   controllers: [CategoriesController, CategorizationRulesController],
   providers: [CategoriesService, RulesService],
   exports: [CategoriesService, RulesService],


### PR DESCRIPTION
## Why

After #414 fixed BillingModule→EmailModule, prod deployment of the new image hit the next layer of the same circular-dep pattern:

\`\`\`
JobsModule → CategoriesModule → SpacesModule → BillingModule → MonitoringModule → JobsModule
\`\`\`

CategoriesModule.imports[1] (= SpacesModule) resolves to \`undefined\` because the cycle re-enters BillingModule (now eagerly constructed via #414's chain) before SpacesModule's class export is bound.

Live error from \`dhanam-api-7fd74d874d-rdk75\`:
\`\`\`
UndefinedModuleException [Error]: Nest cannot create the CategoriesModule instance.
The module at index [1] of the CategoriesModule "imports" array is undefined.
Scope [AppModule -> AuthModule -> EmailModule -> AnalyticsModule -> SpacesModule -> BillingModule -> MonitoringModule -> JobsModule]
\`\`\`

## Fix

Mirrors #414's pattern. \`forwardRef(() => SpacesModule)\` defers the module-graph edge; provider DI still resolves once both modules construct.

## Sequence

This is the next blocker on the dhanam billing pipeline. After this lands, modern Stripe MX / Conekta / credit-billing controllers should finally come up cleanly.

## Test plan

- [x] Local typecheck clean
- [ ] Post-merge: dhanam-api new pod reaches Ready
- [ ] \`/v1/billing/webhooks/stripe\` returns non-404
- [ ] If a third circular-dep layer surfaces, repeat the same fix one more time

🤖 Generated with [Claude Code](https://claude.com/claude-code)