### PR TITLE
fix(jobs): forwardRef CategoriesModule + SpacesModule to break circular dep

### DIFF
--- a/apps/api/src/modules/jobs/jobs.module.ts
+++ b/apps/api/src/modules/jobs/jobs.module.ts
@@ -28,8 +28,14 @@ import { QueueService } from './queue.service';
     ScheduleModule.forRoot(),
     PrismaModule,
     CryptoModule,
-    CategoriesModule,
-    SpacesModule,
+    // forwardRef on the SpacesModule edge breaks the cycle:
+    // JobsModule → SpacesModule → BillingModule → MonitoringModule → JobsModule.
+    // CategoriesModule transitively imports SpacesModule (also via forwardRef
+    // per #415), but JobsModule imports CategoriesModule directly — so wrap
+    // both edges that lead to SpacesModule for safety. Existing forwardRefs
+    // on AnalyticsModule + MlModule were anticipated; SpacesModule wasn't.
+    forwardRef(() => CategoriesModule),
+    forwardRef(() => SpacesModule),
     EsgModule,
     ProvidersModule,
     forwardRef(() => AnalyticsModule),


### PR DESCRIPTION
Third layer of the cascading circular-dep pattern after #414 + #415. `JobsModule → SpacesModule → BillingModule → MonitoringModule → JobsModule` cycle resolves SpacesModule to undefined. forwardRef on both CategoriesModule + SpacesModule edges. 🤖 Generated with [Claude Code](https://claude.com/claude-code)