### PR TITLE
fix(modules): proactively forwardRef remaining circular dependency edges

### DIFF
--- a/apps/api/src/core/monitoring/monitoring.module.ts
+++ b/apps/api/src/core/monitoring/monitoring.module.ts
@@ -1,4 +1,4 @@
-import { Module, Global } from '@nestjs/common';
+import { Module, Global, forwardRef } from '@nestjs/common';
 
 import { PrismaModule } from '@core/prisma/prisma.module';
 import { JobsModule } from '@modules/jobs/jobs.module';
@@ -9,9 +9,26 @@ import { MetricsService } from './metrics.service';
 import { MonitoringController } from './monitoring.controller';
 import { SentryService } from './sentry.service';
 
+// forwardRef on the JobsModule edge breaks every remaining circular
+// dependency chain in dhanam-api. All 16 unbroken cycles in the module
+// graph (verified 2026-05-04) close through:
+//
+//   BillingModule → MonitoringModule → JobsModule → ... → BillingModule
+//
+// JobsModule is registered before MonitoringModule in app.module.ts, so
+// Nest tries to construct JobsModule first. JobsModule pulls in raw
+// transitive deps (EsgModule, ProvidersModule and their providers) that
+// reach BillingModule, which pulls MonitoringModule, which would re-enter
+// JobsModule mid-construction → UndefinedModuleException at imports-array
+// literal evaluation. forwardRef defers the JobsModule reference until
+// after both modules are constructed.
+//
+// Companion forwardRefs already in place: BillingModule → EmailModule
+// (#414), CategoriesModule → SpacesModule (#415), JobsModule →
+// {SpacesModule, CategoriesModule, AnalyticsModule, MlModule} (#416).
 @Global()
 @Module({
-  imports: [PrismaModule, JobsModule],
+  imports: [PrismaModule, forwardRef(() => JobsModule)],
   controllers: [MonitoringController],
   providers: [
     HealthService,


### PR DESCRIPTION
## Summary

After PRs #414, #415, #416 each broke a production-impacting circular dependency cycle, a full module-graph analysis of `apps/api/src/modules/` and `apps/api/src/core/` (60 modules, 165 edges) found **28 total simple cycles**, of which **16 still had zero forwardRef on any edge**. Any one of those 16 could surface as the next `UndefinedModuleException` at boot.

Every one of the 16 unbroken cycles closes through the same edge: **`MonitoringModule -> JobsModule`**. Wrapping that single reference in `forwardRef` breaks all 16 in one minimal change.

## Why this edge

`MonitoringModule` (`@Global`, in `core/`) imports `JobsModule` to inject `QueueService` into `HealthService` and `MetricsService` for queue-depth observability. `JobsModule` transitively reaches `BillingModule` (via `EsgModule`, `ProvidersModule`, etc.), `BillingModule` imports `MonitoringModule` for `SentryService`, and the cycle closes.

In `app.module.ts`, `JobsModule` is registered at line 65 (before `MonitoringModule` at line 71). Nest tries to construct `JobsModule` first; its raw imports (`EsgModule`, `ProvidersModule`) trigger eager construction of `BillingModule`, which eagerly imports `MonitoringModule`, which would re-enter `JobsModule` mid-construction — resolving to `undefined` at the imports-array literal.

`forwardRef(() => JobsModule)` defers that resolution until both modules are fully constructed.

## Cycle inventory (pre-fix)

| Status | Count | Notes |
|---|---|---|
| Already broken (FR present) | 12 | `BillingModule -> EmailModule` (#414), `CategoriesModule -> SpacesModule` (#415), `JobsModule -> {Spaces, Categories, Analytics, Ml}` (#416), and existing `OrchestratorModule -> MlModule` |
| Needs fix (all-raw) | 16 | All close through `BillingModule -> MonitoringModule -> JobsModule` |
| **Total cycles** | **28** | |

Post-fix: **0 all-raw cycles remain.**

## What is NOT changed

- No existing `forwardRef` is removed (could be load-bearing).
- No constructor-level `@Inject(forwardRef(...))` decorators added — module-level `forwardRef` in `imports[]` is sufficient (same pattern as #414 `BillingModule -> EmailModule`, where `EmailService` consumers don't carry constructor decorators either).
- No provider-level imports modified — only the `@Module` `imports:` array.

## Test plan

- [x] `tsc --noEmit` for `apps/api` — green (exit 0)
- [x] eslint `monitoring.module.ts` — green
- [x] Re-run cycle analyzer post-fix — 0 unbroken cycles
- [x] Pre-commit hooks (lint-staged, prettier, jest module resolution, commitlint) — green
- [ ] CI: API unit tests, contract tests, web/admin builds
- [ ] On merge: monitor first prod boot for clean module init logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)