### PR TITLE
fix(modules): forwardRef SpacesModule edge in MlModule (layer 6)

### DIFF
--- a/apps/api/src/modules/ml/ml.module.ts
+++ b/apps/api/src/modules/ml/ml.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 
 import { LoggerModule } from '@core/logger/logger.module';
 import { PrismaModule } from '@core/prisma/prisma.module';
@@ -13,8 +13,15 @@ import { ProviderSelectionService } from './provider-selection.service';
 import { SplitPredictionService } from './split-prediction.service';
 import { TransactionCategorizationService } from './transaction-categorization.service';
 
+// Cycle: SpacesModule → BillingModule → MonitoringModule → JobsModule
+// → ProvidersModule → OrchestratorModule → MlModule → SpacesModule.
+// forwardRef defers SpacesModule resolution so module-graph
+// construction completes; provider DI resolves once both modules are
+// constructed. Layer-6 edge in the cascade following #414/#415/#416/
+// #417/#418 — surfaced because OrchestratorModule pulls MlModule in
+// via the JobsModule → ProvidersModule chain at instantiation time.
 @Module({
-  imports: [PrismaModule, LoggerModule, SpacesModule],
+  imports: [PrismaModule, LoggerModule, forwardRef(() => SpacesModule)],
   providers: [
     // Core ML services
     FuzzyMatcherService,


### PR DESCRIPTION
## Summary

Layer-6 cycle caught in production after #418 deployed: dhanam-api crashloops with:

\`\`\`
Nest cannot create the MlModule instance.
The module at index [2] of the MlModule \"imports\" array is undefined.
Scope [AppModule -> AuthModule -> EmailModule -> AnalyticsModule -> SpacesModule
       -> BillingModule -> MonitoringModule -> JobsModule -> ProvidersModule
       -> OrchestratorModule]
\`\`\`

OrchestratorModule pulls MlModule in via the JobsModule → ProvidersModule chain. MlModule imports SpacesModule directly, but SpacesModule is the same one mid-resolution at the top of the scope chain. \`forwardRef\` defers the SpacesModule edge so module-graph construction completes; provider DI still resolves once both modules are constructed.

ML services don't inject SpacesService (verified by grep), so no \`@Inject(forwardRef(...))\` needed on the constructor side.

This is the 6th forwardRef PR in the cascade (#414, #415, #416, #417, #418, #419).

## Test plan

- [x] Production crash-log diagnosis confirms scope path
- [x] Local turbo typecheck/build passes
- [ ] Watch new dhanam-api pod come up clean after merge + ArgoCD sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)