### PR TITLE
fix(modules): proactively forwardRef provider sub-modules (layer 7+)

### DIFF
--- a/apps/api/src/modules/providers/belvo/belvo.module.ts
+++ b/apps/api/src/modules/providers/belvo/belvo.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 
 import { AuditModule } from '@core/audit/audit.module';
@@ -12,6 +12,8 @@ import { TransactionsModule } from '@modules/transactions/transactions.module';
 import { BelvoController } from './belvo.controller';
 import { BelvoService } from './belvo.service';
 
+// forwardRef per cascade #414-#419 — BillingModule reached transitively
+// from JobsModule → ProvidersModule → BelvoModule.
 @Module({
   imports: [
     ConfigModule,
@@ -21,7 +23,7 @@ import { BelvoService } from './belvo.service';
     AccountsModule,
     TransactionsModule,
     OrchestratorModule,
-    BillingModule,
+    forwardRef(() => BillingModule),
   ],
   controllers: [BelvoController],
   providers: [BelvoService],

--- a/apps/api/src/modules/providers/bitso/bitso.module.ts
+++ b/apps/api/src/modules/providers/bitso/bitso.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 
 import { CryptoModule } from '../../../core/crypto/crypto.module';
 import { PrismaModule } from '../../../core/prisma/prisma.module';
@@ -9,8 +9,16 @@ import { OrchestratorModule } from '../orchestrator/orchestrator.module';
 import { BitsoController } from './bitso.controller';
 import { BitsoService } from './bitso.service';
 
+// forwardRef per cascade #414-#419 — SpacesModule/BillingModule reached
+// transitively from JobsModule → ProvidersModule → BitsoModule.
 @Module({
-  imports: [PrismaModule, CryptoModule, SpacesModule, OrchestratorModule, BillingModule],
+  imports: [
+    PrismaModule,
+    CryptoModule,
+    forwardRef(() => SpacesModule),
+    OrchestratorModule,
+    forwardRef(() => BillingModule),
+  ],
   controllers: [BitsoController],
   providers: [BitsoService],
   exports: [BitsoService],

--- a/apps/api/src/modules/providers/blockchain/blockchain.module.ts
+++ b/apps/api/src/modules/providers/blockchain/blockchain.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 
 import { AuditModule } from '@core/audit/audit.module';
 import { CoreModule } from '@core/core.module';
@@ -7,8 +7,9 @@ import { SpacesModule } from '@modules/spaces/spaces.module';
 import { BlockchainController } from './blockchain.controller';
 import { BlockchainService } from './blockchain.service';
 
+// forwardRef per cascade #414-#419.
 @Module({
-  imports: [CoreModule, AuditModule, SpacesModule],
+  imports: [CoreModule, AuditModule, forwardRef(() => SpacesModule)],
   providers: [BlockchainService],
   controllers: [BlockchainController],
   exports: [BlockchainService],

--- a/apps/api/src/modules/providers/connection-health/connection-health.module.ts
+++ b/apps/api/src/modules/providers/connection-health/connection-health.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 
 import { PrismaModule } from '../../../core/prisma/prisma.module';
 import { SpacesModule } from '../../spaces/spaces.module';
@@ -8,8 +8,9 @@ import { ConnectionHealthController } from './connection-health.controller';
 import { ConnectionHealthService } from './connection-health.service';
 import { ErrorMessagesService } from './error-messages.service';
 
+// forwardRef per cascade #414-#419.
 @Module({
-  imports: [PrismaModule, OrchestratorModule, SpacesModule],
+  imports: [PrismaModule, OrchestratorModule, forwardRef(() => SpacesModule)],
   controllers: [ConnectionHealthController],
   providers: [ConnectionHealthService, ErrorMessagesService],
   exports: [ConnectionHealthService, ErrorMessagesService],

--- a/apps/api/src/modules/providers/defi/defi.module.ts
+++ b/apps/api/src/modules/providers/defi/defi.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 
 import { PrismaModule } from '../../../core/prisma/prisma.module';
@@ -10,8 +10,16 @@ import { DeFiController } from './defi.controller';
 import { DeFiService } from './defi.service';
 import { ZapperService } from './zapper.service';
 
+// forwardRef per cascade #414-#419 — DeFiService also @Inject(forwardRef)
+// SpacesService at the constructor since it's actively injected.
 @Module({
-  imports: [ConfigModule, RedisModule, PrismaModule, SpacesModule, BillingModule],
+  imports: [
+    ConfigModule,
+    RedisModule,
+    PrismaModule,
+    forwardRef(() => SpacesModule),
+    forwardRef(() => BillingModule),
+  ],
   controllers: [DeFiController],
   providers: [ZapperService, DeFiService],
   exports: [ZapperService, DeFiService],

--- a/apps/api/src/modules/providers/defi/defi.service.ts
+++ b/apps/api/src/modules/providers/defi/defi.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Inject, Injectable, Logger, NotFoundException, forwardRef } from '@nestjs/common';
 
 import { PrismaService } from '../../../core/prisma/prisma.service';
 import { SpacesService } from '../../spaces/spaces.service';
@@ -33,6 +33,7 @@ export class DeFiService {
 
   constructor(
     private readonly prisma: PrismaService,
+    @Inject(forwardRef(() => SpacesService))
     private readonly spacesService: SpacesService,
     private readonly zapperService: ZapperService
   ) {}

--- a/apps/api/src/modules/providers/plaid/plaid.module.ts
+++ b/apps/api/src/modules/providers/plaid/plaid.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 
 import { AuditModule } from '../../../core/audit/audit.module';
 import { CryptoModule } from '../../../core/crypto/crypto.module';
@@ -11,14 +11,18 @@ import { PlaidWebhookHandler } from './plaid-webhook.handler';
 import { PlaidController } from './plaid.controller';
 import { PlaidService } from './plaid.service';
 
+// Cycle: SpacesModule/BillingModule are reached transitively by
+// JobsModule → ProvidersModule → PlaidModule. forwardRef defers
+// resolution so the JS module-evaluation order doesn't see undefined
+// references. See #414/#415/#416/#417/#418/#419 for the cascade.
 @Module({
   imports: [
     PrismaModule,
     CryptoModule,
-    SpacesModule,
+    forwardRef(() => SpacesModule),
     OrchestratorModule,
     AuditModule,
-    BillingModule,
+    forwardRef(() => BillingModule),
   ],
   controllers: [PlaidController],
   providers: [PlaidService, PlaidWebhookHandler],


### PR DESCRIPTION
## Summary

Extends the cycle cascade fix (#414, #415, #416, #417, #418, #419) to all provider sub-modules reachable via \`JobsModule → ProvidersModule\`. Each sub-module that imported SpacesModule or BillingModule directly is at risk of an UndefinedModuleException when JobsModule's transitive import graph is being evaluated and the upstream module is mid-resolution.

## What changed

| Module | Wrapped |
|---|---|
| \`belvo.module.ts\` | BillingModule |
| \`bitso.module.ts\` | SpacesModule, BillingModule |
| \`blockchain.module.ts\` | SpacesModule |
| \`connection-health.module.ts\` | SpacesModule |
| \`defi.module.ts\` | SpacesModule, BillingModule |
| \`plaid.module.ts\` | SpacesModule, BillingModule |
| \`defi.service.ts\` | \`@Inject(forwardRef(() => SpacesService))\` |

\`defi.service.ts\` is the only provider service that actively injects SpacesService, so it gets the constructor-side decorator. The others don't inject the wrapped services — modules just re-export them.

## Why proactive

We've been on a 1-PR-per-layer cascade for 6 layers. Each PR exposes the next. Doing this comprehensively in one PR avoids another 3-5 round-trips and stops the cascade.

## Test plan

- [x] Local turbo typecheck passes
- [ ] Watch new dhanam-api pod come up clean after merge + ArgoCD sync
- [ ] Spot-check \`/v1/health\` endpoint flips to 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)