### PR TITLE
fix(modules): forwardRef SpacesModule in AccountsModule + TransactionsModule (layer 8)

### DIFF
--- a/apps/api/src/modules/accounts/accounts.module.ts
+++ b/apps/api/src/modules/accounts/accounts.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 
 import { LoggerModule } from '@core/logger/logger.module';
 import { PrismaModule } from '@core/prisma/prisma.module';
@@ -10,8 +10,10 @@ import { SpacesModule } from '../spaces/spaces.module';
 import { AccountsController } from './accounts.controller';
 import { AccountsService } from './accounts.service';
 
+// forwardRef per cascade #414-#435 — AccountsModule reached via
+// JobsModule → ProvidersModule → BelvoModule → AccountsModule.
 @Module({
-  imports: [SpacesModule, PrismaModule, LoggerModule, PlaidModule, BitsoModule],
+  imports: [forwardRef(() => SpacesModule), PrismaModule, LoggerModule, PlaidModule, BitsoModule],
   controllers: [AccountsController],
   providers: [AccountsService],
   exports: [AccountsService],

--- a/apps/api/src/modules/transactions/transactions.module.ts
+++ b/apps/api/src/modules/transactions/transactions.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 
 import { PrismaModule } from '../../core/prisma/prisma.module';
 import { SpacesModule } from '../spaces/spaces.module';
@@ -6,8 +6,9 @@ import { SpacesModule } from '../spaces/spaces.module';
 import { TransactionsController } from './transactions.controller';
 import { TransactionsService } from './transactions.service';
 
+// forwardRef per cascade #414-#435.
 @Module({
-  imports: [PrismaModule, SpacesModule],
+  imports: [PrismaModule, forwardRef(() => SpacesModule)],
   controllers: [TransactionsController],
   providers: [TransactionsService],
   exports: [TransactionsService],


### PR DESCRIPTION
Layer-8 cycle: `ProvidersModule -> BelvoModule -> AccountsModule` (+ TransactionsModule). Both import SpacesModule directly; needs forwardRef. Continuation of #414-#435 cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)