### PR TITLE
fix(referral): auto-enqueue reward apply job on webhook arrival

### DIFF
--- a/apps/api/src/modules/jobs/__tests__/queue.service.referral-backoff.spec.ts
+++ b/apps/api/src/modules/jobs/__tests__/queue.service.referral-backoff.spec.ts
@@ -1,0 +1,38 @@
+import { QueueService } from '../queue.service';
+
+/**
+ * =============================================================================
+ * Referral-rewards queue backoff schedule
+ * =============================================================================
+ * Asserts the audit-mandated 1m / 5m / 30m retry curve. BullMQ calls the
+ * `backoffStrategy` with the 1-indexed upcoming attempt number (i.e.
+ * `attemptsMade + 1` after a failure). With `attempts: 4` (initial + 3
+ * retries) the strategy is queried with values 2, 3, and 4.
+ *
+ * The schedule is exposed as a static method so the worker registration
+ * and these tests share the single source of truth.
+ * =============================================================================
+ */
+describe('QueueService.referralRewardBackoff', () => {
+  it('returns 1 minute before retry #2 (after the 1st failure)', () => {
+    expect(QueueService.referralRewardBackoff(2)).toBe(60_000);
+  });
+
+  it('returns 5 minutes before retry #3 (after the 2nd failure)', () => {
+    expect(QueueService.referralRewardBackoff(3)).toBe(5 * 60_000);
+  });
+
+  it('returns 30 minutes before retry #4 (after the 3rd failure)', () => {
+    expect(QueueService.referralRewardBackoff(4)).toBe(30 * 60_000);
+  });
+
+  it('falls back to the 1-minute floor for the (unused) first-call branch', () => {
+    // BullMQ does not call this with 1 in normal operation — defensive only.
+    expect(QueueService.referralRewardBackoff(1)).toBe(60_000);
+  });
+
+  it('caps at 30 minutes for any defensive higher-attempt branch', () => {
+    expect(QueueService.referralRewardBackoff(5)).toBe(30 * 60_000);
+    expect(QueueService.referralRewardBackoff(99)).toBe(30 * 60_000);
+  });
+});

--- a/apps/api/src/modules/jobs/queue.service.ts
+++ b/apps/api/src/modules/jobs/queue.service.ts
@@ -1,9 +1,10 @@
-import { InfrastructureException } from '@core/exceptions/domain-exceptions';
 import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as Sentry from '@sentry/node';
 import { Queue, Worker, Job, QueueEvents } from 'bullmq';
 import { Redis } from 'ioredis';
+
+import { InfrastructureException } from '@core/exceptions/domain-exceptions';
 
 export interface JobData {
   type: string;
@@ -70,12 +71,23 @@ export interface EmailJobData {
   };
 }
 
+export interface ReferralRewardJobData {
+  type: 'referral-reward-apply';
+  payload: {
+    rewardId: string;
+    recipientUserId: string;
+    rewardType: string;
+    referralId: string;
+  };
+}
+
 export type QueueJobData =
   | SyncTransactionsJobData
   | CategorizeTransactionsJobData
   | ESGUpdateJobData
   | ValuationSnapshotJobData
-  | EmailJobData;
+  | EmailJobData
+  | ReferralRewardJobData;
 
 @Injectable()
 export class QueueService implements OnModuleInit, OnModuleDestroy {
@@ -164,6 +176,7 @@ export class QueueService implements OnModuleInit, OnModuleDestroy {
       'valuation-snapshots',
       'email-notifications',
       'system-maintenance',
+      'referral-rewards',
     ];
 
     // Initialize dead letter queue first
@@ -183,10 +196,15 @@ export class QueueService implements OnModuleInit, OnModuleDestroy {
           removeOnComplete: 100,
           removeOnFail: 50,
           attempts: maxAttempts,
-          backoff: {
-            type: 'exponential',
-            delay: this.getBackoffDelayForQueue(queueName),
-          },
+          backoff:
+            queueName === 'referral-rewards'
+              ? // Custom backoff resolved on the worker via `referral-reward-backoff`
+                // strategy (60s / 5m / 30m). See registerWorker().
+                { type: 'referral-reward-backoff' }
+              : {
+                  type: 'exponential',
+                  delay: this.getBackoffDelayForQueue(queueName),
+                },
         },
       });
 
@@ -255,7 +273,37 @@ export class QueueService implements OnModuleInit, OnModuleDestroy {
     if (highPriorityQueues.includes(queueName)) {
       return 4;
     }
+    if (queueName === 'referral-rewards') {
+      // Initial try + 3 retries (1m / 5m / 30m). Total: 4 BullMQ
+      // attempts. Tied to the `referral-reward-backoff` worker strategy.
+      return 4;
+    }
     return 3; // Default
+  }
+
+  /**
+   * Custom backoff schedule for the referral-rewards queue.
+   *
+   * Per BullMQ source (`bullmq/classes/job.js`), the strategy is called with
+   * `attemptsMade + 1` after a failure — i.e. the 1-indexed number of the
+   * upcoming retry. With `attempts: 4` (initial + 3 retries) the audit's
+   * requested 1m / 5m / 30m schedule maps to:
+   *   - 2 (before retry #2): wait 1 minute
+   *   - 3 (before retry #3): wait 5 minutes
+   *   - 4 (before retry #4): wait 30 minutes
+   *
+   * After the final failure the job exits to BullMQ's `failed` set, where
+   * `handlePotentialDLQJob()` moves it to the dead letter queue.
+   *
+   * Exported as a static helper so the worker registration in
+   * `registerWorker()` and unit tests can both reference the same
+   * authoritative schedule.
+   */
+  static referralRewardBackoff(upcomingAttempt: number): number {
+    const minute = 60_000;
+    if (upcomingAttempt <= 2) return 1 * minute;
+    if (upcomingAttempt === 3) return 5 * minute;
+    return 30 * minute;
   }
 
   /**
@@ -433,6 +481,30 @@ export class QueueService implements OnModuleInit, OnModuleDestroy {
     });
   }
 
+  /**
+   * Enqueue a referral reward application job.
+   *
+   * Idempotency: jobId is the reward id, so a second webhook delivering the
+   * same reward (or a retry from PhyneCRM) cannot create a duplicate job
+   * — BullMQ silently no-ops the second `add()`.
+   *
+   * Retry policy is queue-level (3 attempts, 1m / 5m / 30m custom backoff).
+   * Final failures fall through to QueueService's existing dead letter
+   * queue handling.
+   */
+  async addReferralRewardJob(
+    data: ReferralRewardJobData['payload'],
+    priority: number = 60
+  ): Promise<Job | null> {
+    const queue = this.getQueueOrSkip('referral-rewards');
+    if (!queue) return null;
+
+    return queue.add('referral-reward-apply', data, {
+      priority,
+      jobId: data.rewardId,
+    });
+  }
+
   // Recurring job scheduling
   async scheduleRecurringJob(
     queueName: string,
@@ -523,13 +595,24 @@ export class QueueService implements OnModuleInit, OnModuleDestroy {
   }
 
   registerWorker(queueName: string, processor: (job: Job) => Promise<any>): Worker {
-    const worker = new Worker(queueName, processor, {
+    const workerOptions: ConstructorParameters<typeof Worker>[2] = {
       connection: this.redis,
       concurrency: this.configService.get(
         `QUEUE_${queueName.toUpperCase().replace('-', '_')}_CONCURRENCY`,
         5
       ),
-    });
+    };
+
+    // Register custom backoff strategies. BullMQ resolves
+    // `backoff.type === 'referral-reward-backoff'` against this map at
+    // failure time on the worker side.
+    if (queueName === 'referral-rewards') {
+      workerOptions.settings = {
+        backoffStrategy: (attemptsMade: number) => QueueService.referralRewardBackoff(attemptsMade),
+      };
+    }
+
+    const worker = new Worker(queueName, processor, workerOptions);
 
     worker.on('completed', (job) => {
       this.logger.log(`Worker completed job ${job.id} in queue ${queueName}`);

--- a/apps/api/src/modules/referral/__tests__/referral-reward.processor.spec.ts
+++ b/apps/api/src/modules/referral/__tests__/referral-reward.processor.spec.ts
@@ -1,0 +1,153 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Job } from 'bullmq';
+
+import { QueueService, ReferralRewardJobData } from '../../jobs/queue.service';
+import { AmbassadorService } from '../ambassador.service';
+import { ReferralRewardProcessor } from '../jobs/referral-reward.processor';
+import { ReferralRewardService } from '../referral-reward.service';
+
+/**
+ * =============================================================================
+ * Referral Reward Processor unit tests
+ * =============================================================================
+ * Covers the BullMQ-side contract: success, transient failure (applied=false
+ * → throw → BullMQ retry), thrown exception propagation, and best-effort
+ * tier recalculation.
+ *
+ * The retry policy itself (3 retries, 1m/5m/30m custom backoff) is asserted
+ * against `QueueService.referralRewardBackoff()` in
+ * `queue.service.referral-backoff.spec.ts` — that's where the schedule
+ * lives, and the processor doesn't need to know about it.
+ * =============================================================================
+ */
+describe('ReferralRewardProcessor', () => {
+  let processor: ReferralRewardProcessor;
+  let rewardService: jest.Mocked<ReferralRewardService>;
+  let ambassadorService: jest.Mocked<AmbassadorService>;
+  let queueService: jest.Mocked<QueueService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReferralRewardProcessor,
+        {
+          provide: ReferralRewardService,
+          useValue: { applyReward: jest.fn() },
+        },
+        {
+          provide: AmbassadorService,
+          useValue: { recalculateTier: jest.fn() },
+        },
+        {
+          provide: QueueService,
+          useValue: { registerWorker: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    processor = module.get(ReferralRewardProcessor);
+    rewardService = module.get(ReferralRewardService) as jest.Mocked<ReferralRewardService>;
+    ambassadorService = module.get(AmbassadorService) as jest.Mocked<AmbassadorService>;
+    queueService = module.get(QueueService) as jest.Mocked<QueueService>;
+
+    jest.clearAllMocks();
+  });
+
+  function buildJob(
+    data: ReferralRewardJobData['payload'],
+    overrides: Partial<{ id: string; attemptsMade: number; opts: { attempts?: number } }> = {}
+  ): Job<ReferralRewardJobData['payload']> {
+    return {
+      id: overrides.id ?? 'job-1',
+      data,
+      attemptsMade: overrides.attemptsMade ?? 0,
+      opts: overrides.opts ?? { attempts: 4 },
+    } as unknown as Job<ReferralRewardJobData['payload']>;
+  }
+
+  const samplePayload: ReferralRewardJobData['payload'] = {
+    rewardId: 'reward-abc',
+    recipientUserId: 'user-1',
+    rewardType: 'credit_grant',
+    referralId: 'KRF-ABCD1234',
+  };
+
+  describe('process()', () => {
+    it('should apply the reward and recalculate the recipient tier', async () => {
+      rewardService.applyReward.mockResolvedValue({ applied: true });
+      ambassadorService.recalculateTier.mockResolvedValue({
+        previousTier: 'none',
+        newTier: 'bronze',
+        promoted: true,
+      });
+
+      const result = await processor.process(buildJob(samplePayload));
+
+      expect(result.applied).toBe(true);
+      expect(rewardService.applyReward).toHaveBeenCalledWith('reward-abc');
+      expect(ambassadorService.recalculateTier).toHaveBeenCalledWith('user-1');
+    });
+
+    it('should throw when applyReward returns applied=false (transient — let BullMQ retry)', async () => {
+      rewardService.applyReward.mockResolvedValue({ applied: false });
+
+      await expect(processor.process(buildJob(samplePayload))).rejects.toThrow(
+        /apply returned applied=false/
+      );
+      // Tier recalculation must NOT run when the reward did not apply.
+      expect(ambassadorService.recalculateTier).not.toHaveBeenCalled();
+    });
+
+    it('should propagate exceptions thrown by applyReward', async () => {
+      rewardService.applyReward.mockRejectedValue(new Error('stripe outage'));
+
+      await expect(processor.process(buildJob(samplePayload))).rejects.toThrow('stripe outage');
+      expect(ambassadorService.recalculateTier).not.toHaveBeenCalled();
+    });
+
+    it('should not poison reward success when tier recalc fails', async () => {
+      rewardService.applyReward.mockResolvedValue({ applied: true, actionId: 'ext_user_1m' });
+      ambassadorService.recalculateTier.mockRejectedValue(new Error('tier db blip'));
+
+      const result = await processor.process(buildJob(samplePayload));
+
+      // Reward result preserved — tier recalc is best-effort.
+      expect(result).toEqual({ applied: true, actionId: 'ext_user_1m' });
+    });
+
+    it('should reflect the upcoming attempt number in logs / Sentry context (final attempt branch)', async () => {
+      // attemptsMade=3 with attempts=4 means we're on attempt 4 — the
+      // last try. The processor should still throw on applied=false so
+      // BullMQ moves the job to the failed set (and downstream into
+      // QueueService's dead letter queue).
+      rewardService.applyReward.mockResolvedValue({ applied: false });
+
+      await expect(
+        processor.process(buildJob(samplePayload, { attemptsMade: 3, opts: { attempts: 4 } }))
+      ).rejects.toThrow(/applied=false on attempt 4\/4/);
+    });
+  });
+
+  describe('onModuleInit()', () => {
+    it('should register a worker against the referral-rewards queue', () => {
+      processor.onModuleInit();
+
+      expect(queueService.registerWorker).toHaveBeenCalledTimes(1);
+      const [queueName, fn] = queueService.registerWorker.mock.calls[0];
+      expect(queueName).toBe('referral-rewards');
+      expect(typeof fn).toBe('function');
+    });
+
+    it('should swallow registerWorker failures in test envs (NODE_ENV=test)', () => {
+      const prev = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'test';
+      queueService.registerWorker.mockImplementation(() => {
+        throw new Error('queue not initialised');
+      });
+
+      expect(() => processor.onModuleInit()).not.toThrow();
+
+      process.env.NODE_ENV = prev;
+    });
+  });
+});

--- a/apps/api/src/modules/referral/__tests__/referral-reward.service.spec.ts
+++ b/apps/api/src/modules/referral/__tests__/referral-reward.service.spec.ts
@@ -1,0 +1,166 @@
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { PrismaService } from '../../../core/prisma/prisma.service';
+import { StripeService } from '../../billing/stripe.service';
+import { ReferralRewardService } from '../referral-reward.service';
+
+/**
+ * =============================================================================
+ * ReferralRewardService.applyReward — fallback paths
+ * =============================================================================
+ * Most of the apply behaviour is covered indirectly via the processor + cron
+ * tests. This suite focuses on the "Stripe unavailable" fallback the audit
+ * called out: when StripeService.isConfigured() === false (or the user
+ * has no stripeCustomerId), the local-DB subscription extension path
+ * must still run cleanly and the reward must end up applied=true.
+ * =============================================================================
+ */
+describe('ReferralRewardService — Stripe-unavailable fallback', () => {
+  let service: ReferralRewardService;
+  let prisma: any;
+  let stripe: jest.Mocked<StripeService>;
+
+  beforeEach(async () => {
+    prisma = {
+      referralReward: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+      },
+      user: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+      },
+      creditBalance: {
+        update: jest.fn(),
+        upsert: jest.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReferralRewardService,
+        { provide: PrismaService, useValue: prisma },
+        {
+          provide: StripeService,
+          useValue: { isConfigured: jest.fn() },
+        },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get(ReferralRewardService);
+    stripe = module.get(StripeService) as jest.Mocked<StripeService>;
+  });
+
+  it('marks subscription_extension reward as applied even when Stripe is not configured', async () => {
+    // Stripe stub returns false → the service should skip Stripe and
+    // still write applied=true via the local-DB extension path.
+    stripe.isConfigured.mockReturnValue(false);
+
+    prisma.referralReward.findUnique.mockResolvedValue({
+      id: 'reward-sub-1',
+      recipientUserId: 'user-1',
+      rewardType: 'subscription_extension',
+      amount: 1,
+      applied: false,
+      stripeActionId: null,
+    });
+    prisma.referralReward.update.mockResolvedValue({});
+
+    const result = await service.applyReward('reward-sub-1');
+
+    expect(result.applied).toBe(true);
+    // Reward row marked applied=true with applied_at timestamp.
+    expect(prisma.referralReward.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'reward-sub-1' },
+        data: expect.objectContaining({
+          applied: true,
+          appliedAt: expect.any(Date),
+        }),
+      })
+    );
+  });
+
+  it('marks subscription_extension reward as applied when user has no Stripe customer id', async () => {
+    stripe.isConfigured.mockReturnValue(true);
+
+    prisma.referralReward.findUnique.mockResolvedValue({
+      id: 'reward-sub-2',
+      recipientUserId: 'user-2',
+      rewardType: 'subscription_extension',
+      amount: 1,
+      applied: false,
+      stripeActionId: null,
+    });
+
+    // First user lookup (Stripe customer id check) → no Stripe customer.
+    prisma.user.findUnique.mockResolvedValueOnce({ stripeCustomerId: null });
+    prisma.referralReward.update.mockResolvedValue({});
+
+    const result = await service.applyReward('reward-sub-2');
+
+    expect(result.applied).toBe(true);
+    expect(prisma.referralReward.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'reward-sub-2' },
+        data: expect.objectContaining({ applied: true }),
+      })
+    );
+  });
+
+  it('extends user.subscriptionExpiresAt locally when no expiry is set yet', async () => {
+    stripe.isConfigured.mockReturnValue(true);
+
+    prisma.referralReward.findUnique.mockResolvedValue({
+      id: 'reward-sub-3',
+      recipientUserId: 'user-3',
+      rewardType: 'subscription_extension',
+      amount: 2, // 2 months
+      applied: false,
+      stripeActionId: null,
+    });
+
+    prisma.user.findUnique
+      .mockResolvedValueOnce({ stripeCustomerId: 'cus_x' })
+      .mockResolvedValueOnce({ subscriptionExpiresAt: null });
+    prisma.user.update.mockResolvedValue({});
+    prisma.referralReward.update.mockResolvedValue({});
+
+    const result = await service.applyReward('reward-sub-3');
+
+    expect(result.applied).toBe(true);
+    expect(prisma.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'user-3' },
+        data: expect.objectContaining({
+          subscriptionExpiresAt: expect.any(Date),
+        }),
+      })
+    );
+  });
+
+  it('short-circuits when reward is already applied (idempotent re-run)', async () => {
+    prisma.referralReward.findUnique.mockResolvedValue({
+      id: 'reward-already',
+      recipientUserId: 'user-1',
+      rewardType: 'credit_grant',
+      amount: 50,
+      applied: true,
+      stripeActionId: null,
+    });
+
+    const result = await service.applyReward('reward-already');
+
+    expect(result.applied).toBe(true);
+    // No further mutations.
+    expect(prisma.referralReward.update).not.toHaveBeenCalled();
+    expect(prisma.user.update).not.toHaveBeenCalled();
+    expect(prisma.creditBalance.update).not.toHaveBeenCalled();
+    expect(prisma.creditBalance.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/referral/__tests__/referral.service.spec.ts
+++ b/apps/api/src/modules/referral/__tests__/referral.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { PrismaService } from '../../../core/prisma/prisma.service';
+import { QueueService } from '../../jobs/queue.service';
 import { AmbassadorService } from '../ambassador.service';
 import { ReferralService } from '../referral.service';
 
@@ -8,6 +9,7 @@ describe('ReferralService', () => {
   let service: ReferralService;
   let prisma: jest.Mocked<PrismaService>;
   let ambassadorService: jest.Mocked<AmbassadorService>;
+  let queueService: jest.Mocked<QueueService>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -19,8 +21,13 @@ describe('ReferralService', () => {
             referralReward: {
               findMany: jest.fn(),
               findFirst: jest.fn(),
-              createMany: jest.fn(),
+              create: jest.fn(),
             },
+            // $transaction(array) returns the resolved values of each
+            // promise in order — mock by awaiting the input.
+            $transaction: jest
+              .fn()
+              .mockImplementation((ops: Promise<unknown>[]) => Promise.all(ops)),
           },
         },
         {
@@ -30,14 +37,22 @@ describe('ReferralService', () => {
             recalculateTier: jest.fn(),
           },
         },
+        {
+          provide: QueueService,
+          useValue: {
+            addReferralRewardJob: jest.fn().mockResolvedValue({ id: 'job-stub' }),
+          },
+        },
       ],
     }).compile();
 
     service = module.get<ReferralService>(ReferralService);
     prisma = module.get(PrismaService) as jest.Mocked<PrismaService>;
     ambassadorService = module.get(AmbassadorService) as jest.Mocked<AmbassadorService>;
+    queueService = module.get(QueueService) as jest.Mocked<QueueService>;
 
     jest.clearAllMocks();
+    queueService.addReferralRewardJob.mockResolvedValue({ id: 'job-stub' } as any);
   });
 
   it('should be defined', () => {
@@ -57,9 +72,26 @@ describe('ReferralService', () => {
       revenue_cents: 1199,
     };
 
+    /**
+     * Stub `prisma.referralReward.create` so each call resolves to a row
+     * matching the input plus a synthetic id. The test then asserts on
+     * call args via the standard jest mock instance.
+     */
+    function mockCreateRewardsWithIds(): void {
+      let counter = 0;
+      (prisma.referralReward.create as jest.Mock).mockImplementation((args: any) => {
+        counter += 1;
+        return Promise.resolve({
+          id: `reward-${counter}`,
+          recipientUserId: args.data.recipientUserId,
+          rewardType: args.data.rewardType,
+        });
+      });
+    }
+
     it('should create 3 rewards and recalculate tier', async () => {
       prisma.referralReward.findFirst.mockResolvedValue(null);
-      prisma.referralReward.createMany.mockResolvedValue({ count: 3 });
+      mockCreateRewardsWithIds();
       ambassadorService.recalculateTier.mockResolvedValue({
         previousTier: 'none',
         newTier: 'bronze',
@@ -71,8 +103,12 @@ describe('ReferralService', () => {
       expect(result.rewards_created).toBe(3);
       expect(result.ambassador_tier).toBe('bronze');
 
-      expect(prisma.referralReward.createMany).toHaveBeenCalledWith({
-        data: expect.arrayContaining([
+      expect(prisma.referralReward.create).toHaveBeenCalledTimes(3);
+      const createCalls = (prisma.referralReward.create as jest.Mock).mock.calls.map(
+        (c: any[]) => c[0]
+      );
+      expect(createCalls.map((c: any) => c.data)).toEqual(
+        expect.arrayContaining([
           expect.objectContaining({
             referralId: 'KRF-ABCD1234',
             recipientUserId: 'referrer-1',
@@ -91,8 +127,8 @@ describe('ReferralService', () => {
             rewardType: 'credit_grant',
             amount: 50,
           }),
-        ]),
-      });
+        ])
+      );
 
       expect(ambassadorService.recalculateTier).toHaveBeenCalledWith('referrer-1');
     });
@@ -123,13 +159,15 @@ describe('ReferralService', () => {
 
       expect(result.rewards_created).toBe(0);
       expect(result.ambassador_tier).toBe('silver');
-      expect(prisma.referralReward.createMany).not.toHaveBeenCalled();
+      expect(prisma.referralReward.create).not.toHaveBeenCalled();
       expect(ambassadorService.recalculateTier).not.toHaveBeenCalled();
+      // Idempotency: a duplicate webhook MUST NOT enqueue any apply jobs.
+      expect(queueService.addReferralRewardJob).not.toHaveBeenCalled();
     });
 
     it('should include source and target product in reward metadata', async () => {
       prisma.referralReward.findFirst.mockResolvedValue(null);
-      prisma.referralReward.createMany.mockResolvedValue({ count: 3 });
+      mockCreateRewardsWithIds();
       ambassadorService.recalculateTier.mockResolvedValue({
         previousTier: 'bronze',
         newTier: 'bronze',
@@ -138,13 +176,89 @@ describe('ReferralService', () => {
 
       await service.handleConversionWebhook(conversionData);
 
-      const createManyCall = prisma.referralReward.createMany.mock.calls[0][0];
-      for (const reward of (createManyCall as any).data) {
-        expect(reward.metadata).toEqual({
+      const createCalls = (prisma.referralReward.create as jest.Mock).mock.calls.map(
+        (c: any[]) => c[0]
+      );
+      for (const call of createCalls) {
+        expect(call.data.metadata).toEqual({
           source_product: 'karafiel',
           target_product: 'dhanam',
         });
       }
+    });
+
+    // ─── Auto-enqueue contract ────────────────────────────────────────
+
+    it('should enqueue one BullMQ job per created reward', async () => {
+      prisma.referralReward.findFirst.mockResolvedValue(null);
+      mockCreateRewardsWithIds();
+      ambassadorService.recalculateTier.mockResolvedValue({
+        previousTier: 'none',
+        newTier: 'bronze',
+        promoted: true,
+      });
+
+      await service.handleConversionWebhook(conversionData);
+
+      expect(queueService.addReferralRewardJob).toHaveBeenCalledTimes(3);
+      const enqueueCalls = queueService.addReferralRewardJob.mock.calls.map((c) => c[0]);
+      expect(enqueueCalls).toEqual(
+        expect.arrayContaining([
+          {
+            rewardId: 'reward-1',
+            recipientUserId: 'referrer-1',
+            rewardType: 'subscription_extension',
+            referralId: 'KRF-ABCD1234',
+          },
+          {
+            rewardId: 'reward-2',
+            recipientUserId: 'referrer-1',
+            rewardType: 'credit_grant',
+            referralId: 'KRF-ABCD1234',
+          },
+          {
+            rewardId: 'reward-3',
+            recipientUserId: 'referred-1',
+            rewardType: 'credit_grant',
+            referralId: 'KRF-ABCD1234',
+          },
+        ])
+      );
+    });
+
+    it('should not throw when the queue is unreachable — cron sweep is the safety net', async () => {
+      prisma.referralReward.findFirst.mockResolvedValue(null);
+      mockCreateRewardsWithIds();
+      ambassadorService.recalculateTier.mockResolvedValue({
+        previousTier: 'none',
+        newTier: 'bronze',
+        promoted: true,
+      });
+      queueService.addReferralRewardJob.mockRejectedValue(new Error('redis unreachable'));
+
+      const result = await service.handleConversionWebhook(conversionData);
+
+      // Reward rows still created + tier still recalculated. The cron
+      // sweep (ReferralRewardJob) will pick up the unapplied rewards.
+      expect(result.rewards_created).toBe(3);
+      expect(result.ambassador_tier).toBe('bronze');
+      expect(ambassadorService.recalculateTier).toHaveBeenCalledWith('referrer-1');
+    });
+
+    it('should treat a null queue response as a benign skip (test/no-redis env)', async () => {
+      prisma.referralReward.findFirst.mockResolvedValue(null);
+      mockCreateRewardsWithIds();
+      ambassadorService.recalculateTier.mockResolvedValue({
+        previousTier: 'none',
+        newTier: 'bronze',
+        promoted: false,
+      });
+      queueService.addReferralRewardJob.mockResolvedValue(null);
+
+      const result = await service.handleConversionWebhook(conversionData);
+
+      expect(result.rewards_created).toBe(3);
+      expect(queueService.addReferralRewardJob).toHaveBeenCalledTimes(3);
     });
   });
 

--- a/apps/api/src/modules/referral/jobs/referral-reward.processor.ts
+++ b/apps/api/src/modules/referral/jobs/referral-reward.processor.ts
@@ -1,0 +1,153 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import * as Sentry from '@sentry/node';
+import { Job, Worker } from 'bullmq';
+
+import { QueueService, ReferralRewardJobData } from '@modules/jobs/queue.service';
+
+import { AmbassadorService } from '../ambassador.service';
+import { ReferralRewardService } from '../referral-reward.service';
+
+/**
+ * =============================================================================
+ * Referral Reward Processor (BullMQ worker)
+ * =============================================================================
+ * Worker for the `referral-rewards` queue. Each job applies one
+ * `ReferralReward` row by delegating to `ReferralRewardService.applyReward()`,
+ * then triggers ambassador-tier recalculation for the recipient.
+ *
+ * Lives inside the ReferralModule (rather than JobsModule) to avoid a
+ * dependency cycle: ReferralModule already imports JobsModule for
+ * `QueueService.addReferralRewardJob`. Co-locating the worker keeps the
+ * graph one-way.
+ *
+ * Enqueue site: `ReferralService.handleConversionWebhook()` after the
+ * reward rows are committed. JobId is the reward id, so duplicate
+ * webhooks (PhyneCRM retry, manual replay) are silently de-duplicated by
+ * BullMQ.
+ *
+ * Retry policy lives on the queue (`attempts: 4`, custom backoff
+ * 1m / 5m / 30m). Final failures fall through to QueueService's existing
+ * dead letter queue handling.
+ *
+ * Failure semantics:
+ *   - `applyReward` returning `{ applied: false }` is treated as a
+ *     transient failure (typically a Stripe API hiccup) and re-thrown so
+ *     BullMQ retries.
+ *   - `applyReward` throwing (network, DB) bubbles up untouched.
+ *   - The "already applied" short-circuit in `applyReward` makes the
+ *     worker fully idempotent on its own — even if BullMQ ran the same
+ *     job twice past the dedup, the underlying mutation is a no-op.
+ * =============================================================================
+ */
+@Injectable()
+export class ReferralRewardProcessor implements OnModuleInit {
+  private readonly logger = new Logger(ReferralRewardProcessor.name);
+  private worker: Worker | null = null;
+
+  constructor(
+    private readonly queueService: QueueService,
+    private readonly rewardService: ReferralRewardService,
+    private readonly ambassadorService: AmbassadorService
+  ) {}
+
+  onModuleInit(): void {
+    // QueueService initialises queues lazily on its own onModuleInit. In
+    // test envs without Redis it gracefully no-ops, and registerWorker
+    // would throw — guard with the same NODE_ENV signal it uses.
+    try {
+      this.worker = this.queueService.registerWorker('referral-rewards', (job: Job) =>
+        this.process(job as Job<ReferralRewardJobData['payload']>)
+      );
+      this.logger.log('Referral reward worker registered');
+    } catch (error) {
+      const isTestEnv = process.env.NODE_ENV === 'test';
+      if (isTestEnv) {
+        this.logger.warn('Skipping referral reward worker in test environment');
+        return;
+      }
+      throw error;
+    }
+  }
+
+  async process(job: Job<ReferralRewardJobData['payload']>): Promise<{
+    applied: boolean;
+    actionId?: string;
+  }> {
+    const { rewardId, recipientUserId, rewardType, referralId } = job.data;
+    const startTime = Date.now();
+
+    Sentry.withScope((scope) => {
+      scope.setTag('job_type', 'referral-reward-apply');
+      scope.setTag('job_id', job.id || 'unknown');
+      scope.setTag('reward_type', rewardType);
+      scope.setUser({ id: recipientUserId });
+      scope.setContext('reward', {
+        rewardId,
+        referralId,
+        attempt: job.attemptsMade + 1,
+        maxAttempts: job.opts.attempts,
+      });
+    });
+
+    this.logger.log(
+      `Applying referral reward ${rewardId} (${rewardType}) for user ${recipientUserId}`
+    );
+
+    let result: { applied: boolean; actionId?: string };
+
+    try {
+      result = await this.rewardService.applyReward(rewardId);
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      const attemptsMade = job.attemptsMade + 1;
+      const maxAttempts = job.opts.attempts ?? 1;
+
+      this.logger.error(
+        `Reward ${rewardId} apply threw on attempt ${attemptsMade}/${maxAttempts}: ${err.message}`
+      );
+
+      Sentry.withScope((scope) => {
+        scope.setTag('job_type', 'referral-reward-apply');
+        scope.setTag('reward_id', rewardId);
+        scope.setLevel(attemptsMade >= maxAttempts ? 'error' : 'warning');
+        Sentry.captureException(err);
+      });
+
+      throw err;
+    }
+
+    if (!result.applied) {
+      // Stripe outage or other recoverable condition. Throw so BullMQ
+      // retries per the queue's backoff policy. Final failure → DLQ.
+      const attemptsMade = job.attemptsMade + 1;
+      const maxAttempts = job.opts.attempts ?? 1;
+      const message = `Reward ${rewardId} apply returned applied=false on attempt ${attemptsMade}/${maxAttempts}`;
+      this.logger.warn(message);
+
+      Sentry.withScope((scope) => {
+        scope.setTag('job_type', 'referral-reward-apply');
+        scope.setTag('reward_id', rewardId);
+        scope.setLevel(attemptsMade >= maxAttempts ? 'error' : 'warning');
+        Sentry.captureMessage(message, 'warning');
+      });
+
+      throw new Error(message);
+    }
+
+    // Tier recalculation is best-effort — its failure must not poison the
+    // reward's success. The reward row is already marked applied=true.
+    try {
+      await this.ambassadorService.recalculateTier(recipientUserId);
+    } catch (tierError) {
+      const err = tierError instanceof Error ? tierError : new Error(String(tierError));
+      this.logger.warn(
+        `Reward ${rewardId} applied, but tier recalc for ${recipientUserId} failed: ${err.message}. The next conversion or the cron sweep will heal this.`
+      );
+    }
+
+    const durationMs = Date.now() - startTime;
+    this.logger.log(`Reward ${rewardId} applied in ${durationMs}ms`);
+
+    return result;
+  }
+}

--- a/apps/api/src/modules/referral/referral.module.ts
+++ b/apps/api/src/modules/referral/referral.module.ts
@@ -16,20 +16,30 @@
  * - ReferralRewardJob: Processes pending rewards every 15 minutes
  * =============================================================================
  */
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 
 import { BillingModule } from '../billing/billing.module';
+import { JobsModule } from '../jobs/jobs.module';
 
 import { AmbassadorService } from './ambassador.service';
 import { ReferralHmacGuard } from './guards/referral-hmac.guard';
 import { ReferralRewardJob } from './jobs/referral-reward.job';
+import { ReferralRewardProcessor } from './jobs/referral-reward.processor';
 import { ReferralRewardService } from './referral-reward.service';
 import { ReferralController } from './referral.controller';
 import { ReferralService } from './referral.service';
 
 @Module({
-  imports: [ConfigModule, BillingModule],
+  imports: [
+    ConfigModule,
+    BillingModule,
+    // forwardRef on JobsModule because JobsModule pulls in a long
+    // dependency chain (Spaces → Billing → Monitoring → Jobs) and we
+    // only need QueueService here. Mirrors the same pattern used by
+    // MonitoringModule per the comment in monitoring.module.ts.
+    forwardRef(() => JobsModule),
+  ],
   controllers: [ReferralController],
   providers: [
     // Core services
@@ -39,6 +49,7 @@ import { ReferralService } from './referral.service';
 
     // Jobs
     ReferralRewardJob,
+    ReferralRewardProcessor,
 
     // Guards
     ReferralHmacGuard,

--- a/apps/api/src/modules/referral/referral.service.ts
+++ b/apps/api/src/modules/referral/referral.service.ts
@@ -1,6 +1,7 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger, forwardRef } from '@nestjs/common';
 
 import { PrismaService } from '../../core/prisma/prisma.service';
+import { QueueService } from '../jobs/queue.service';
 
 import { AmbassadorService } from './ambassador.service';
 import { ReferralConversionDataDto } from './dto/referral-event.dto';
@@ -28,7 +29,13 @@ export class ReferralService {
 
   constructor(
     private readonly prisma: PrismaService,
-    private readonly ambassadorService: AmbassadorService
+    private readonly ambassadorService: AmbassadorService,
+    // forwardRef matches the ReferralModule → JobsModule edge that is
+    // already wrapped to break the Spaces → Billing → Monitoring → Jobs
+    // → Referral cycle. QueueService itself has no dependency back into
+    // ReferralModule.
+    @Inject(forwardRef(() => QueueService))
+    private readonly queueService: QueueService
   ) {}
 
   /**
@@ -72,39 +79,92 @@ export class ReferralService {
       return { rewards_created: 0, ambassador_tier: profile.tier };
     }
 
-    // Create rewards in a transaction
-    const rewards = await this.prisma.referralReward.createMany({
-      data: [
-        {
-          referralId,
-          recipientUserId: referrer_user_id,
-          rewardType: 'subscription_extension',
-          amount: 1,
-          description: 'Referral reward: 1 free month for successful referral',
-          metadata: { source_product, target_product },
-        },
-        {
-          referralId,
-          recipientUserId: referrer_user_id,
-          rewardType: 'credit_grant',
-          amount: 50,
-          description: 'Referral bonus: 50 credits for referrer',
-          metadata: { source_product, target_product },
-        },
-        {
-          referralId,
-          recipientUserId: referred_user_id,
-          rewardType: 'credit_grant',
-          amount: 50,
-          description: 'Welcome bonus: 50 credits for being referred',
-          metadata: { source_product, target_product },
-        },
-      ],
-    });
+    // Create rewards atomically. We use individual `create` calls inside
+    // a transaction (rather than `createMany`) because `createMany` does
+    // not return generated ids — and we need them to drive the BullMQ
+    // enqueue with a stable jobId for idempotency.
+    const rewardSpecs: Array<{
+      recipientUserId: string;
+      rewardType: 'subscription_extension' | 'credit_grant';
+      amount: number;
+      description: string;
+    }> = [
+      {
+        recipientUserId: referrer_user_id,
+        rewardType: 'subscription_extension',
+        amount: 1,
+        description: 'Referral reward: 1 free month for successful referral',
+      },
+      {
+        recipientUserId: referrer_user_id,
+        rewardType: 'credit_grant',
+        amount: 50,
+        description: 'Referral bonus: 50 credits for referrer',
+      },
+      {
+        recipientUserId: referred_user_id,
+        rewardType: 'credit_grant',
+        amount: 50,
+        description: 'Welcome bonus: 50 credits for being referred',
+      },
+    ];
+
+    const createdRewards = await this.prisma.$transaction(
+      rewardSpecs.map((spec) =>
+        this.prisma.referralReward.create({
+          data: {
+            referralId,
+            recipientUserId: spec.recipientUserId,
+            rewardType: spec.rewardType,
+            amount: spec.amount,
+            description: spec.description,
+            metadata: { source_product, target_product },
+          },
+          select: {
+            id: true,
+            recipientUserId: true,
+            rewardType: true,
+          },
+        })
+      )
+    );
 
     this.logger.log(
-      `Created ${rewards.count} rewards for conversion: code=${referral_code} referrer=${referrer_user_id} referred=${referred_user_id}`
+      `Created ${createdRewards.length} rewards for conversion: code=${referral_code} referrer=${referrer_user_id} referred=${referred_user_id}`
     );
+
+    // Auto-enqueue an apply job per reward. JobId = reward.id makes the
+    // enqueue idempotent: a duplicate webhook (PhyneCRM retry, manual
+    // replay) cannot create a duplicate job, and the worker also short-
+    // circuits if reward.applied is already true.
+    //
+    // Failures here are logged but never thrown — the reward rows are
+    // already in the DB, and the existing 15-min cron sweep
+    // (ReferralRewardJob) will pick them up as a safety net.
+    for (const reward of createdRewards) {
+      try {
+        const job = await this.queueService.addReferralRewardJob({
+          rewardId: reward.id,
+          recipientUserId: reward.recipientUserId,
+          rewardType: reward.rewardType,
+          referralId,
+        });
+
+        if (job) {
+          this.logger.debug(`Enqueued reward apply job for ${reward.id} (${reward.rewardType})`);
+        } else {
+          this.logger.warn(
+            `Reward ${reward.id} created but enqueue returned null (queue not ready). Cron sweep will pick it up.`
+          );
+        }
+      } catch (enqueueError) {
+        const err = enqueueError instanceof Error ? enqueueError : new Error(String(enqueueError));
+        this.logger.error(
+          `Reward ${reward.id} created but enqueue failed: ${err.message}. Cron sweep will pick it up.`,
+          err.stack
+        );
+      }
+    }
 
     // Recalculate ambassador tier
     const tierResult = await this.ambassadorService.recalculateTier(referrer_user_id);
@@ -116,7 +176,7 @@ export class ReferralService {
     }
 
     return {
-      rewards_created: rewards.count,
+      rewards_created: createdRewards.length,
       ambassador_tier: tierResult.newTier,
     };
   }


### PR DESCRIPTION
## Diagnosis

Per the **2026-05-04 referral audit**: when PhyneCRM delivered a `referral.converted` webhook to `POST /v1/referral/reward`, `ReferralService.handleConversionWebhook()` created the three `ReferralReward` rows but never enqueued the BullMQ job that calls `ReferralRewardService.applyReward()`. So rewards sat at `applied=false` until either the 15-min cron sweep (`ReferralRewardJob`) ran or an SRE invoked `applyReward()` manually. End-to-end latency could exceed 15 minutes; on Redis blips the cron sweep was the single point of recovery.

## Webhook → queue → apply contract

| Step | Where | Behaviour |
|---|---|---|
| 1. Webhook arrives | `referral.controller.ts::handleConversionWebhook` | HMAC-verified, dispatches to service |
| 2. Dedup check | `referral.service.ts` | `findFirst` on `(referralId, recipientUserId, rewardType=subscription_extension)` — duplicate webhooks short-circuit |
| 3. Create reward rows | `prisma.$transaction([...create])` | 3 rows: 1× subscription_extension + 2× credit_grant. `create` (not `createMany`) so we get the generated ids |
| 4. Enqueue jobs | `queueService.addReferralRewardJob({ rewardId, ... })` | One job per reward, **`jobId = reward.id`** |
| 5. Tier recalc | `ambassadorService.recalculateTier` | Same as before |
| 6. Worker picks up | `referral-reward.processor.ts::process` | Calls `applyReward(rewardId)`, then best-effort tier recalc |

## Idempotency

- **Webhook re-delivery**: dedup `findFirst` blocks duplicate row creation. The `recalculateTier` and `addReferralRewardJob` calls also do not run.
- **Job re-enqueue**: BullMQ rejects duplicate `jobId`s silently. `jobId = reward.id` (UUID, stable for the lifetime of the reward) means a manual replay or a webhook retry past the dedup window cannot create a second job.
- **Worker re-execution**: `applyReward()` itself short-circuits on `reward.applied === true` (`referral-reward.service.ts:51-54`) — fully idempotent at the mutation site too.

## Retry policy

- **Queue**: `referral-rewards` (new), `attempts: 4` (initial + 3 retries).
- **Backoff**: custom `referral-reward-backoff` strategy (`QueueService.referralRewardBackoff`): **1 minute → 5 minutes → 30 minutes** before retries 2, 3, and 4 respectively. Matches the audit-mandated schedule exactly.
- **Failure modes the worker treats as transient (retried)**: `applyReward()` returning `{ applied: false }` (Stripe outage, bad config), or any thrown exception (DB blip, network).
- **Final failure** (after retry #4): falls into BullMQ's `failed` set, which `QueueService.handlePotentialDLQJob` already routes to the existing dead letter queue (`dhanam:dlq:jobs` Redis list + Sentry breadcrumb). Operator-facing controls in `admin.controller.ts` cover replay/inspect.

## Safety net

If the queue is unreachable at webhook time (Redis down, NestJS bootstrap order, test envs), the enqueue is **logged but never thrown** — the reward rows are already in the DB, and the existing 15-min cron sweep (`ReferralRewardJob`) will heal them. The webhook still returns 200.

## Tests

96 referral + jobs tests pass on this branch (vs. the pre-existing 24 unrelated billing failures + 8 unrelated kyc/marketplace/migration failures that exist on `main` too — confirmed by stash-and-rerun).

| Suite | Coverage |
|---|---|
| `referral.service.spec.ts` | Webhook → 3 rows + 3 enqueues with stable ids; duplicate webhook → 0 rows + 0 enqueues; queue unreachable → rows still committed; queue returns null → benign |
| `referral-reward.processor.spec.ts` | Happy path (applied → tier recalc); `applied=false` re-throws (BullMQ retries); thrown exceptions propagate; tier failure does not poison reward success; final-attempt error message branch; worker registration on the correct queue |
| `referral-reward.service.spec.ts` *(new)* | **Stripe-unavailable fallback**: `subscription_extension` still reaches `applied=true` via the local-DB extension path (audit out-of-scope verification) |
| `queue.service.referral-backoff.spec.ts` *(new)* | 1m / 5m / 30m schedule asserted at upcoming-attempt 2 / 3 / 4 |

## Audit reference

`internal-devops` referral audit, 2026-05-04. The audit pointed at `referral-reward.service.ts:42-101` (working `applyReward`) and `referral.service.ts::handleConversionWebhook` (missing enqueue). This PR closes the gap without changing reward semantics, retry semantics observable to PhyneCRM, or the existing cron sweep behaviour.

## Out of scope (per task)

- Stripe `trial_end` extension path remains stubbed at `referral-reward.service.ts:109-166`. Local-DB fallback is verified by the new `referral-reward.service.spec.ts`.
- No frontend or PhyneCRM-side changes.
- DLQ inspection UI improvements: out of scope. Existing admin controller already exposes the DLQ via `QueueService.getDeadLetterJobs()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)