### PR TITLE
fix(web): skip env validation during Docker build and prevent main drift

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,13 @@
 echo "Running pre-push checks..."
 
+current_branch="$(git symbolic-ref --short HEAD 2>/dev/null || true)"
+if [ "$current_branch" = "main" ]; then
+  echo "❌ Direct pushes from main are blocked."
+  echo "   Branch from main, open a PR, and merge via GitHub."
+  echo "   To refresh local main: git fetch origin && git reset --hard origin/main"
+  exit 1
+fi
+
 ORIGINAL_DATABASE_URL="${DATABASE_URL:-}"
 HOOK_DATABASE_URL="${DATABASE_URL:-postgresql://dummy:dummy@localhost:5432/dhanam_hook?schema=public}"
 export DATABASE_URL="$HOOK_DATABASE_URL"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,32 @@ We use a trunk-based development model:
 - `chore/` - Maintenance tasks
 - `docs/` - Documentation updates
 
+### Keeping local `main` in sync
+
+Never commit directly on `main`. Always branch first:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git checkout -b fix/your-change
+```
+
+After a PR merges, refresh local `main`:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+```
+
+If `git pull --ff-only` fails, local `main` has diverged (usually from an old direct commit). Reset it:
+
+```bash
+git fetch origin
+git reset --hard origin/main
+```
+
+Then recreate your work on a feature branch. The pre-push hook blocks pushes from `main` to prevent repeat drift.
+
 ## Commit Messages
 
 We follow [Conventional Commits](https://www.conventionalcommits.org/):

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -62,8 +62,12 @@ ARG NEXT_PUBLIC_ADMIN_URL
 ARG NEXT_PUBLIC_OIDC_ISSUER
 ARG NEXT_PUBLIC_OIDC_CLIENT_ID
 ARG NEXT_PUBLIC_JANUA_API_URL
+# next.config.js validates env at build time; Enclii/Kaniko injects NEXT_PUBLIC_*
+# via ARG above but must not fail when optional vars are absent during image build.
+ARG SKIP_ENV_VALIDATION=true
 
 # Persist build-args as ENV for Next.js build process
+ENV SKIP_ENV_VALIDATION=$SKIP_ENV_VALIDATION
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 ENV NEXT_PUBLIC_BASE_URL=$NEXT_PUBLIC_BASE_URL
 ENV NEXT_PUBLIC_ADMIN_URL=$NEXT_PUBLIC_ADMIN_URL

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -91,6 +91,12 @@ export type Env = z.infer<typeof envSchema>;
 
 let cachedEnv: Env | null = null;
 
+function shouldSkipEnvValidation(): boolean {
+  const flag = process.env.SKIP_ENV_VALIDATION;
+  // Build-time (next.config.js + Dockerfile) uses 'true'; runtime break-glass uses '1'.
+  return flag === '1' || flag === 'true';
+}
+
 export function getEnv(): Env {
   if (cachedEnv) return cachedEnv;
 
@@ -99,9 +105,9 @@ export function getEnv(): Env {
   // entirely and recover the web tier in seconds. The schema is still parsed
   // partially via getEnvUnsafe() at use sites, so type narrowing still works.
   // Use only as a break-glass — log loudly so it's visible in incident review.
-  if (process.env.SKIP_ENV_VALIDATION === '1') {
+  if (shouldSkipEnvValidation()) {
     console.warn(
-      '[dhanam-web] SKIP_ENV_VALIDATION=1 — Zod env schema bypassed. ' +
+      '[dhanam-web] SKIP_ENV_VALIDATION set — Zod env schema bypassed. ' +
         'This is a break-glass for prod incidents only; remove it once recovered.'
     );
     cachedEnv = envSchemaBase.partial().parse(process.env) as Env;

--- a/docs/STABILITY_AUDIT_2026-05-19.md
+++ b/docs/STABILITY_AUDIT_2026-05-19.md
@@ -70,7 +70,11 @@ hardening, production migration recovery, and failed-job cleanup.
    deployment records, until the Enclii namespace mapping gap is repaired.
 7. Web Docker builds must not depend on external font downloads; the app now
    uses a local system font stack instead of `next/font/google`.
-8. Local test startup still warns when optional local SMTP/PostHog/Sentry and
+8. Web Docker builds set `SKIP_ENV_VALIDATION=true` during the builder stage so
+   `next.config.js` env checks do not fail Enclii/Kaniko when only build-args
+   are injected. Runtime validation still runs in the production container unless
+   operators use the break-glass `SKIP_ENV_VALIDATION=1` ConfigMap escape hatch.
+9. Local test startup still warns when optional local SMTP/PostHog/Sentry and
    provider credentials are absent; production should treat required
    observability and email credentials as deploy-time checks.
 

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:7ce80603312d2d82592d4a00d990ed494344cf1a28e0d733974243cc9ee45243
+    digest: sha256:a95b47816f2f93cf80a097c4e035338cba7a47eecbee1567135385267e51304f
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin


### PR DESCRIPTION
## Summary
- Wire `SKIP_ENV_VALIDATION=true` through the web Dockerfile builder stage so Enclii/Kaniko builds align with `next.config.js` build-time env checks.
- Accept both `true` (build) and `1` (runtime break-glass) in `env.ts` for consistent bypass semantics.
- Block direct pushes from local `main` in the pre-push hook and document the local main sync workflow in `CONTRIBUTING.md`.

## Context
Local `main` had diverged after a direct commit (`ea47a313`) that was never opened as a PR. This restores a clean `main == origin/main` baseline and lands the fix through the normal PR path.

## Test plan
- [x] Pre-commit typecheck passes
- [x] Pre-push format/lint/test/build passes
- [ ] CI green on PR
- [ ] Enclii web image build succeeds after merge


Made with [Cursor](https://cursor.com)