### PR TITLE
chore: sanitize public repo fixtures

### DIFF
--- a/apps/api/src/modules/billing/__tests__/billing.controller.spec.ts
+++ b/apps/api/src/modules/billing/__tests__/billing.controller.spec.ts
@@ -67,7 +67,7 @@ describe('BillingController', () => {
           provide: ConfigService,
           useValue: {
             get: jest.fn((key: string) => {
-              if (key === 'STRIPE_WEBHOOK_SECRET') return 'whsec_test_secret';
+              if (key === 'STRIPE_WEBHOOK_SECRET') return 'DUMMY_WEBHOOK_SECRET_DO_NOT_USE';
               return null;
             }),
           },
@@ -452,7 +452,7 @@ describe('BillingController', () => {
       expect(stripeService.constructWebhookEvent).toHaveBeenCalledWith(
         mockRequest.rawBody,
         signature,
-        'whsec_test_secret'
+        'DUMMY_WEBHOOK_SECRET_DO_NOT_USE'
       );
       expect(billingService.handleSubscriptionCreated).toHaveBeenCalledWith(mockEvent);
       expect(result).toEqual({ received: true });

--- a/apps/api/src/modules/billing/__tests__/billing.service.spec.ts
+++ b/apps/api/src/modules/billing/__tests__/billing.service.spec.ts
@@ -1045,7 +1045,7 @@ describe('BillingService', () => {
     it('should not flag legitimate secret values', async () => {
       const svc = await buildServiceWithConfig((key: string, defaultValue?: any) => {
         if (key === 'NODE_ENV') return 'production';
-        if (key === 'STRIPE_MX_WEBHOOK_SECRET') return 'whsec_abc123realvalue';
+        if (key === 'STRIPE_MX_WEBHOOK_SECRET') return 'DUMMY_WEBHOOK_SECRET_DO_NOT_USE';
         if (key === 'PADDLE_API_KEY') return 'pdl_live_abc123';
         if (key === 'PADDLE_VENDOR_ID') return '12345';
         if (key === 'PADDLE_CLIENT_TOKEN') return 'ctok_live_abc';

--- a/apps/api/src/modules/billing/__tests__/conekta.service.spec.ts
+++ b/apps/api/src/modules/billing/__tests__/conekta.service.spec.ts
@@ -46,7 +46,7 @@ describe('ConektaService', () => {
 
   const CONEKTA_PRIVATE_KEY = 'key_test_private_xxx';
   const CONEKTA_PUBLIC_KEY = 'key_test_public_xxx';
-  const CONEKTA_WEBHOOK_SIGNING_KEY = 'whsec_test_signing_key_abc123';
+  const CONEKTA_WEBHOOK_SIGNING_KEY = 'DUMMY_WEBHOOK_SECRET_DO_NOT_USE';
   const CONEKTA_API_VERSION = '2.1.0';
 
   const buildModule = async (overrides: Partial<Record<string, string>> = {}) => {

--- a/apps/api/src/modules/billing/__tests__/stripe-mx.service.spec.ts
+++ b/apps/api/src/modules/billing/__tests__/stripe-mx.service.spec.ts
@@ -10,7 +10,7 @@ describe('StripeMxService', () => {
   let configService: jest.Mocked<ConfigService>;
 
   const STRIPE_MX_SECRET_KEY = 'sk_test_mx_mock_key';
-  const STRIPE_MX_WEBHOOK_SECRET = 'whsec_mx_test_secret';
+  const STRIPE_MX_WEBHOOK_SECRET = 'DUMMY_WEBHOOK_SECRET_DO_NOT_USE';
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({

--- a/apps/api/src/modules/billing/__tests__/stripe.service.spec.ts
+++ b/apps/api/src/modules/billing/__tests__/stripe.service.spec.ts
@@ -9,7 +9,7 @@ describe('StripeService', () => {
   let configService: jest.Mocked<ConfigService>;
 
   const STRIPE_SECRET_KEY = 'sk_test_mock_key';
-  const STRIPE_WEBHOOK_SECRET = 'whsec_test_secret';
+  const STRIPE_WEBHOOK_SECRET = 'DUMMY_WEBHOOK_SECRET_DO_NOT_USE';
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({

--- a/docs/MIGRATION_CHECKLIST.md
+++ b/docs/MIGRATION_CHECKLIST.md
@@ -55,12 +55,12 @@
 
 - [ ] **Generate API Keys**
   - STRIPE_MX_PUBLISHABLE_KEY: `pk_live_____________`
-  - STRIPE_MX_SECRET_KEY: `sk_live_____________`
+  - STRIPE_MX_SECRET_KEY: `DUMMY_STRIPE_LIVE_KEY_DO_NOT_USE`
 
 - [ ] **Configure Webhook**
   - Endpoint: `https://api.dhan.am/billing/webhooks/stripe`
   - Events: `checkout.session.completed`, `invoice.paid`, `customer.subscription.*`
-  - STRIPE_MX_WEBHOOK_SECRET: `whsec_____________`
+  - STRIPE_MX_WEBHOOK_SECRET: `DUMMY_WEBHOOK_SECRET_DO_NOT_USE`
 
 - [ ] **Enable Payment Methods**
   - [x] Card payments

--- a/docs/PUBLIC_REPO_SANITIZATION_2026-06-01.md
+++ b/docs/PUBLIC_REPO_SANITIZATION_2026-06-01.md
@@ -1,0 +1,28 @@
+# Dhanam Public Repo Sanitization Contract
+
+Date: 2026-06-01
+Status: launch-blocking for any SKU relying on Dhanam financial evidence, payments, FX, payouts, or BBVA settlement paths
+
+## Position
+
+Dhanam is the canonical financial source of truth. Public GitHub readiness for Dhanam must be stricter than ordinary app repos because mistakes can affect payment trust, settlement claims, BBVA payout handling, and Tulana financial evidence.
+
+## Current remediation posture
+
+- `apps/web/.env.production` contains only `NEXT_PUBLIC_*` build-time keys by key-name review. These are public browser-bundled constants, not server-side secrets, but the file still requires owner approval as intentionally public production config.
+- Scanner-valid dummy credential strings in the identified billing test file were normalized to non-credential-shaped placeholders.
+- No repo-level pass is granted until current-tree scan, history scan, public artifact review, and owner approval are recorded in Tulana.
+
+## Launch-blocking checks
+
+Dhanam-linked SKUs cannot pass Product/Offer GA public-repo sanitization until evidence confirms:
+
+- No real BBVA, CLABE, payout, webhook, payment-provider, account, or customer financial data is present.
+- Public examples use synthetic values only.
+- `NEXT_PUBLIC_*` build-time config is intentional and approved.
+- Server-only financial secrets live only in the approved runtime secret store.
+- Dhanam-mediated evidence remains the only accepted financial evidence path for Tulana dashboards.
+
+## Required Tulana evidence
+
+Use `PUBLIC_GITHUB_REPO_SANITIZED` evidence attached to `P4`, `P8`, and `P9`; attach to `P0` when public Dhanam docs are used as buyer-facing proof.

--- a/docs/PUBLIC_REPO_SANITIZATION_OWNER_DECISION_2026-06-01.md
+++ b/docs/PUBLIC_REPO_SANITIZATION_OWNER_DECISION_2026-06-01.md
@@ -1,0 +1,42 @@
+# Dhanam Public Repo Sanitization Owner Decision
+
+Date: 2026-06-01
+Current status: blocked, not sanitized
+
+## Evidence summary
+
+- Current-tree exact credential-signature paths: 0
+- Git-history matched paths: 9
+- GitHub Actions artifacts reported: 2013
+- Releases page count: 1
+
+## Required owner decisions
+
+- Choose `history_rewrite` or `risk_acceptance_plus_revocation` for history matches.
+- Choose `artifact_body_review`, `artifact_retention_cleanup`, or `artifact_risk_acceptance` for public artifacts.
+- Confirm no BBVA, CLABE, payout, payment-provider, webhook, customer financial data, or production financial secret exists in public source/history/artifacts.
+- Approve or reject whether Dhanam can produce `PUBLIC_GITHUB_REPO_SANITIZED` Tulana evidence.
+
+## Recommended decision
+
+Keep status blocked until artifact review and history disposition are complete. Prefer risk acceptance plus revocation only if every history match is confirmed synthetic/test-only.
+
+## Artifact retention evidence update
+
+Current-tree workflow audit found zero checked workflows using `actions/upload-artifact`, so no current workflow retention edit was applied in this pass. Existing GitHub artifact volume remains launch-blocking.
+
+Full metadata-only artifact evidence for Dhanam is captured centrally in Tulana at `docs/evidence/public-github-artifact-full-metadata-dhanam-janua-2026-06-01.tsv`.
+
+Owner still needs to choose artifact body review, artifact retention cleanup, or explicit time-bounded artifact risk acceptance.
+
+## Full artifact metadata update
+
+- Total artifacts: 2013
+- Active artifacts: 1691
+- Expired artifacts: 322
+- Total artifact bytes: 335,981,214
+- Risk-name artifacts: 251
+- Active risk-name artifacts: 13
+- Risk-name artifact bytes: 223,039,753
+
+Owner review should start with active risk-name artifacts, then remaining risk-name artifacts, then release-linked artifacts.

--- a/packages/billing-sdk/src/webhook.spec.ts
+++ b/packages/billing-sdk/src/webhook.spec.ts
@@ -21,7 +21,7 @@ const samplePayload = JSON.stringify({
 });
 
 describe('verifyWebhookSignature', () => {
-  const secret = 'whsec_test_secret_key';
+  const secret = 'DUMMY_WEBHOOK_SECRET_DO_NOT_USE';
 
   it('returns true for a valid signature', async () => {
     const sig = sign(samplePayload, secret);
@@ -49,7 +49,7 @@ describe('verifyWebhookSignature', () => {
 });
 
 describe('parseWebhookPayload', () => {
-  const secret = 'whsec_parse_test';
+  const secret = 'DUMMY_WEBHOOK_SECRET_DO_NOT_USE';
 
   it('parses and verifies a valid payload', async () => {
     const sig = sign(samplePayload, secret);


### PR DESCRIPTION
Adds Dhanam public repo sanitization contract and owner decision packet, and normalizes scanner-shaped test/doc fixtures to non-credential placeholders.\n\nNo artifact bodies were downloaded and no git history was rewritten.