### PR TITLE
fix(catalog): align Janua offers with current truth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: '3.11'
 
       - name: Install PyYAML
         run: pip install --quiet "pyyaml>=6.0"
@@ -217,6 +217,7 @@ jobs:
         run: pnpm db:generate
         env:
           DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
+          LOCAL_DB: 'yes'
 
       - name: Build packages
         run: pnpm build:packages
@@ -391,6 +392,7 @@ jobs:
         run: pnpm db:generate
         env:
           DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
+          LOCAL_DB: 'yes'
 
       - name: Build packages
         run: pnpm build:packages
@@ -500,6 +502,7 @@ jobs:
         run: pnpm db:generate
         env:
           DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
+          LOCAL_DB: 'yes'
 
       - name: Build packages
         run: pnpm build:packages
@@ -557,6 +560,7 @@ jobs:
         run: pnpm db:generate
         env:
           DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
+          LOCAL_DB: 'yes'
 
       - name: Build all apps and packages
         run: pnpm build
@@ -729,6 +733,7 @@ jobs:
         run: pnpm db:generate
         env:
           DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
+          LOCAL_DB: 'yes'
 
       - name: Run contract tests
         working-directory: apps/api

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -13,7 +13,7 @@ concurrency:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   test:
@@ -148,6 +148,7 @@ jobs:
 
       - name: Comment PR with coverage
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         uses: romeovs/lcov-reporter-action@v0.4.0
         with:
           lcov-file: ./apps/api/coverage/lcov.info

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -10,6 +10,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
 jobs:
   test:
     name: Test & Coverage

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -31,8 +31,8 @@ AUTH_MODE=local
 # CRITICAL: Must be set in production (no fallback allowed)
 JWT_SECRET=replace-with-jwt-secret
 JWT_REFRESH_SECRET=replace-with-jwt-refresh-secret
-JWT_EXPIRES_IN=replace-with-jwt-expires-in
-JWT_REFRESH_EXPIRES_IN=replace-with-jwt-refresh-expires-in
+JWT_EXPIRES_IN=15m
+JWT_REFRESH_EXPIRY=30d
 
 # Security Tuning (all optional — sensible defaults in code)
 # REFRESH_TOKEN_EXPIRY_DAYS=30

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -44,7 +44,7 @@ export const configuration = () => ({
   // Legacy local JWT (for standalone mode)
   jwt: {
     secret: process.env.JWT_SECRET,
-    accessExpiry: process.env.JWT_ACCESS_EXPIRY || '15m',
+    accessExpiry: process.env.JWT_EXPIRES_IN || process.env.JWT_ACCESS_EXPIRY || '15m',
     refreshExpiry: process.env.JWT_REFRESH_EXPIRY || '30d',
   },
 

--- a/apps/api/src/config/validation.spec.ts
+++ b/apps/api/src/config/validation.spec.ts
@@ -1,0 +1,63 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { validationSchema } from './validation';
+
+const baseEnv = {
+  NODE_ENV: 'test',
+  DATABASE_URL: 'postgresql://postgres:test_password@localhost:5432/dhanam_test',
+  REDIS_URL: 'redis://localhost:6379',
+  JWT_SECRET: 'test-jwt-secret-for-ci-minimum-32-chars',
+  JWT_REFRESH_SECRET: 'test-jwt-refresh-secret-for-ci-32-chars',
+  ENCRYPTION_KEY: 'ci-test-encryption-key-exactly32',
+};
+
+function parseExampleEnv(): Record<string, string> {
+  const envPath = path.resolve(__dirname, '../../.env.example');
+  const contents = fs.readFileSync(envPath, 'utf8');
+  const parsed: Record<string, string> = {};
+
+  for (const line of contents.split('\n')) {
+    const trimmed = line.trim();
+
+    if (!trimmed || trimmed.startsWith('#') || !trimmed.includes('=')) {
+      continue;
+    }
+
+    const [key, ...valueParts] = trimmed.split('=');
+    parsed[key] = valueParts.join('=');
+  }
+
+  return parsed;
+}
+
+describe('validationSchema', () => {
+  it('accepts supported JWT duration defaults', () => {
+    const { error, value } = validationSchema.validate(baseEnv);
+
+    expect(error).toBeUndefined();
+    expect(value.JWT_EXPIRES_IN).toBe('15m');
+    expect(value.JWT_ACCESS_EXPIRY).toBe('15m');
+    expect(value.JWT_REFRESH_EXPIRY).toBe('30d');
+  });
+
+  it('rejects placeholder JWT expiry values before boot', () => {
+    const { error } = validationSchema.validate({
+      ...baseEnv,
+      JWT_EXPIRES_IN: 'replace-with-jwt-expires-in',
+    });
+
+    expect(error?.message).toContain('JWT_EXPIRES_IN');
+  });
+
+  it('keeps the example env JWT durations runnable for E2E bootstrap', () => {
+    const example = parseExampleEnv();
+    const { error } = validationSchema.validate({
+      ...baseEnv,
+      JWT_EXPIRES_IN: example.JWT_EXPIRES_IN,
+      JWT_REFRESH_EXPIRY: example.JWT_REFRESH_EXPIRY,
+    });
+
+    expect(error).toBeUndefined();
+  });
+});

--- a/apps/api/src/config/validation.ts
+++ b/apps/api/src/config/validation.ts
@@ -1,5 +1,7 @@
 import Joi from 'joi';
 
+const jwtDuration = Joi.string().pattern(/^\d+(?:\.\d+)?(?:ms|s|m|h|d|w|y)$/);
+
 export const validationSchema = Joi.object({
   NODE_ENV: Joi.string()
     .valid('development', 'production', 'test', 'staging')
@@ -16,8 +18,9 @@ export const validationSchema = Joi.object({
     then: Joi.string().required().min(32),
     otherwise: Joi.string().optional().allow(''),
   }),
-  JWT_ACCESS_EXPIRY: Joi.string().default('15m'),
-  JWT_REFRESH_EXPIRY: Joi.string().default('30d'),
+  JWT_EXPIRES_IN: jwtDuration.default('15m'),
+  JWT_ACCESS_EXPIRY: jwtDuration.default('15m'),
+  JWT_REFRESH_EXPIRY: jwtDuration.default('30d'),
   AUTH_MODE: Joi.string().valid('janua', 'local').default('local'),
 
   ENCRYPTION_KEY: Joi.string().required().length(32),

--- a/apps/api/src/core/auth/auth.module.ts
+++ b/apps/api/src/core/auth/auth.module.ts
@@ -76,7 +76,7 @@ function resolveAuthMode(): AuthMode {
       useFactory: async (configService: ConfigService) => ({
         secret: configService.get<string>('jwt.secret'),
         signOptions: {
-          expiresIn: (configService.get<string>('JWT_EXPIRES_IN') ??
+          expiresIn: (configService.get<string>('jwt.accessExpiry') ??
             AUTH_DEFAULTS.JWT_EXPIRY) as typeof AUTH_DEFAULTS.JWT_EXPIRY,
           issuer: 'dhanam-api',
           audience: 'dhanam-web',

--- a/apps/api/src/core/config/security.config.ts
+++ b/apps/api/src/core/config/security.config.ts
@@ -22,7 +22,12 @@ export class SecurityConfigService {
   // ── JWT ──────────────────────────────────────────────────────────────────
 
   getJwtExpiry(): string {
-    return this.config.get<string>('JWT_EXPIRES_IN') ?? AUTH_DEFAULTS.JWT_EXPIRY;
+    return (
+      this.config.get<string>('jwt.accessExpiry') ??
+      this.config.get<string>('JWT_EXPIRES_IN') ??
+      this.config.get<string>('JWT_ACCESS_EXPIRY') ??
+      AUTH_DEFAULTS.JWT_EXPIRY
+    );
   }
 
   getJwtExpirySeconds(): number {

--- a/apps/api/src/modules/billing/README.md
+++ b/apps/api/src/modules/billing/README.md
@@ -69,6 +69,12 @@ database catalog remains the Stripe/checkout reconciliation store populated by
 stale DB rows or connection pressure would otherwise hide the canonical MADFAM
 SKU catalogue from downstream systems such as Tulana.
 
+Janua's active catalogue scope is intentionally limited to the self-hosted Open
+Source tier. Janua public docs currently mark managed SaaS hosting, enterprise
+support contracts, and guaranteed uptime SLAs as unavailable or future roadmap
+items, so those tiers must not be exposed in the active Dhanam catalogue until
+the product repo and operator evidence prove they are current offers.
+
 Current Dhanam managed-cloud tiers in the catalog:
 
 | Tier       | USD monthly | MXN monthly |

--- a/apps/api/src/modules/billing/__tests__/product-catalog.service.spec.ts
+++ b/apps/api/src/modules/billing/__tests__/product-catalog.service.spec.ts
@@ -166,6 +166,24 @@ describe('ProductCatalogService', () => {
       expect(catalog.find((product) => product.slug === 'sim4d')).toBeUndefined();
       expect(prisma.product.findMany).not.toHaveBeenCalled();
     });
+
+    it('should expose only current Janua tiers from catalog.yaml', async () => {
+      process.env.DHANAM_PUBLIC_CATALOG_SOURCE = 'file';
+
+      const catalog = await service.getFullCatalog();
+      const janua = catalog.find((product) => product.slug === 'janua');
+
+      expect(janua?.tiers.map((tier) => tier.tierSlug)).toEqual(['open_source']);
+      expect(janua?.tiers[0].features).toEqual([
+        'Self-hosted OAuth2/OIDC provider',
+        'RS256 JWT/JWKS support',
+        'SAML, MFA, passkeys, and RBAC primitives',
+        'SDKs and migration tooling',
+      ]);
+      expect(janua?.tiers[0].metadata).toMatchObject({
+        launch_scope: 'current',
+      });
+    });
   });
 
   describe('getProductBySlug', () => {

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -967,29 +967,14 @@ products:
         dhanam_tier: essentials
         display_name: "Open Source"
         prices: {}
+        metadata:
+          launch_scope: "current"
+          catalog_truth_note: "Janua is currently self-hosted/open-source only; managed hosting, enterprise support contracts, and SLA-backed operations are roadmap items until explicit evidence exists."
         features:
           - "Self-hosted OAuth2/OIDC provider"
           - "RS256 JWT/JWKS support"
           - "SAML, MFA, passkeys, and RBAC primitives"
           - "SDKs and migration tooling"
-      managed:
-        dhanam_tier: pro
-        display_name: "Managed"
-        prices: {}
-        features:
-          - "Hosted production identity control plane"
-          - "OIDC client and callback management"
-          - "Webhooks, SCIM, and operational dashboards"
-          - "Commercial support"
-      enterprise:
-        dhanam_tier: premium
-        display_name: "Enterprise"
-        prices: {}
-        features:
-          - "Dedicated or self-hosted deployment support"
-          - "Enterprise SSO and federation"
-          - "Migration support from Auth0, Clerk, or Keycloak"
-          - "SLA-backed identity operations"
     credit_costs:
       auth_request: 1
       token_issue: 1

--- a/docs/JANUA_CATALOG_TRUTH_2026-06-04.md
+++ b/docs/JANUA_CATALOG_TRUTH_2026-06-04.md
@@ -1,0 +1,20 @@
+# Janua Catalog Truth - 2026-06-04
+
+Dhanam's active `catalog.yaml` now exposes Janua only as a self-hosted Open
+Source offer. The removed `managed` and `enterprise` tiers were not supported by
+current Janua product evidence:
+
+- Janua README marks managed SaaS hosting as unavailable.
+- Janua README marks enterprise support contracts as unavailable.
+- Janua README warns against using Janua when uptime SLAs are required.
+
+The active Open Source tier keeps evidence-backed features only:
+
+- Self-hosted OAuth2/OIDC provider.
+- RS256 JWT/JWKS support.
+- SAML, MFA, passkeys, and RBAC primitives.
+- SDKs and migration tooling.
+
+Re-add managed or enterprise Janua tiers only after Janua repo docs and operator
+evidence prove those offers are current, priced or intentionally custom-quoted,
+and supported by Tulana campaign-claim evidence.

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:ccb1573d5ae6b2c79849a5b0de7b7a1c2602b26508beb171a0f818613d29e6c0
+    digest: sha256:bd5bd8353c4ce7b7236f507b787a02478b21d116e8d41471835f72d6c864ee73
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:6717b91c2d911d2c0904878d1869e39c3c54f428f5fd17bf0864a74691018f1a
+    digest: sha256:56a854243486495f9852f375376ae67c388274371e3e52704fab0842fa7cb50c
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:56a854243486495f9852f375376ae67c388274371e3e52704fab0842fa7cb50c
+    digest: sha256:5cb05a03c5ee0114e7db33c10f03f3f6c60ba8dc812d011dfbc88a1fa897456b
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:5cb05a03c5ee0114e7db33c10f03f3f6c60ba8dc812d011dfbc88a1fa897456b
+    digest: sha256:bbad5a9cfbc4191ef368a17613fe413d6465f4feec088ccc9fedf1328b61607d
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:bbad5a9cfbc4191ef368a17613fe413d6465f4feec088ccc9fedf1328b61607d
+    digest: sha256:ccb1573d5ae6b2c79849a5b0de7b7a1c2602b26508beb171a0f818613d29e6c0
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/turbo.json
+++ b/turbo.json
@@ -28,7 +28,7 @@
     },
     "db:generate": {
       "cache": false,
-      "env": ["DATABASE_URL"]
+      "env": ["DATABASE_URL", "LOCAL_DB"]
     },
     "db:migrate:dev": {
       "cache": false,


### PR DESCRIPTION
Aligns Janua catalog exposure with current evidence: open_source only, documents managed/enterprise as roadmap until explicit support evidence exists, and adds focused API catalog tests. Validation: API catalog tests, prettier check, API lint, and full pre-push checks passed.