### PR TITLE
ci: pass npm auth to web docker builds

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -129,6 +129,10 @@ Required secrets in GitHub repository settings:
 | `ENCLII_API_KEY`   | Enclii deployment trigger  |
 | `KUBECONFIG`       | K8s deployment (fallback)  |
 
+Web image builds pass `NPM_MADFAM_TOKEN` into `apps/web/Dockerfile` as the
+`npm_madfam_token` BuildKit secret because the web app consumes private MADFAM
+packages during `pnpm install`. Do not pass the token as a Docker build arg.
+
 ## Branch Protection
 
 Recommended branch protection rules for `main`:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,6 +305,7 @@ jobs:
           echo "JWT_SECRET=$(openssl rand -hex 32)" >> apps/api/.env
           echo "JWT_REFRESH_SECRET=$(openssl rand -hex 32)" >> apps/api/.env
           echo "ENCRYPTION_KEY=ci-test-encryption-key-exactly32" >> apps/api/.env
+          echo "POSTHOG_HOST=https://analytics.madfam.io" >> apps/api/.env
 
       - name: Generate Prisma Client
         working-directory: apps/api
@@ -652,6 +653,7 @@ jobs:
           echo "JWT_SECRET=$(openssl rand -hex 32)" >> apps/api/.env
           echo "JWT_REFRESH_SECRET=$(openssl rand -hex 32)" >> apps/api/.env
           echo "ENCRYPTION_KEY=ci-test-encryption-key-exactly32" >> apps/api/.env
+          echo "POSTHOG_HOST=https://analytics.madfam.io" >> apps/api/.env
 
       - name: Generate Prisma Client
         working-directory: apps/api

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,10 @@ jobs:
       - name: Lint K8s manifests for value/valueFrom conflicts
         run: python3 scripts/lint-k8s-env.py infra/k8s
 
-      - name: Run linter unit tests
-        run: python3 -m unittest discover -s tests/fixtures/k8s-env-lint -p 'test_*.py' -v
+      - name: Run infrastructure guard unit tests
+        run: |
+          python3 -m unittest discover -s tests/fixtures/k8s-env-lint -p 'test_*.py' -v
+          python3 -m unittest discover -s tests/fixtures/workflow-guards -p 'test_*.py' -v
 
   doc-links:
     name: Documentation link hygiene

--- a/.github/workflows/deploy-enclii.yml
+++ b/.github/workflows/deploy-enclii.yml
@@ -141,11 +141,13 @@ jobs:
             NEXT_PUBLIC_OIDC_ISSUER=https://auth.madfam.io
             NEXT_PUBLIC_OIDC_CLIENT_ID=${{ vars.NEXT_PUBLIC_OIDC_CLIENT_ID }}
             NEXT_PUBLIC_JANUA_API_URL=https://api.janua.dev
+          secrets: |
+            npm_madfam_token=${{ secrets.NPM_MADFAM_TOKEN }}
 
       - name: Sign image with cosign
         if: steps.build.outcome == 'success'
         env:
-          COSIGN_EXPERIMENTAL: "true"
+          COSIGN_EXPERIMENTAL: 'true'
         run: |
           cosign sign --yes ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -116,6 +116,8 @@ jobs:
             NEXT_PUBLIC_OIDC_ISSUER=${{ vars.STAGING_OIDC_ISSUER || '' }}
             NEXT_PUBLIC_OIDC_CLIENT_ID=${{ vars.STAGING_OIDC_CLIENT_ID || '' }}
             NEXT_PUBLIC_JANUA_API_URL=${{ vars.STAGING_JANUA_API_URL || '' }}
+          secrets: |
+            npm_madfam_token=${{ secrets.NPM_MADFAM_TOKEN }}
           cache-from: type=gha,scope=web
           cache-to: type=gha,scope=web,mode=max
       - name: Sign Web staging image

--- a/.github/workflows/deploy-web-k8s.yml
+++ b/.github/workflows/deploy-web-k8s.yml
@@ -116,11 +116,13 @@ jobs:
             NEXT_PUBLIC_OIDC_ISSUER=${{ vars.NEXT_PUBLIC_OIDC_ISSUER }}
             NEXT_PUBLIC_OIDC_CLIENT_ID=${{ vars.NEXT_PUBLIC_OIDC_CLIENT_ID }}
             NEXT_PUBLIC_JANUA_API_URL=${{ vars.NEXT_PUBLIC_JANUA_API_URL }}
+          secrets: |
+            npm_madfam_token=${{ secrets.NPM_MADFAM_TOKEN }}
 
       - name: Sign image with cosign
         if: steps.build.outcome == 'success'
         env:
-          COSIGN_EXPERIMENTAL: "true"
+          COSIGN_EXPERIMENTAL: 'true'
         run: |
           cosign sign --yes ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -129,7 +129,7 @@ JANUA_INTERNAL_API_KEY=replace-with-janua-internal-api-key
 
 # Analytics
 POSTHOG_API_KEY=replace-with-posthog-api-key
-POSTHOG_HOST=replace-with-posthog-host
+POSTHOG_HOST=https://analytics.madfam.io
 
 # Error Monitoring (Sentry)
 SENTRY_DSN=replace-with-sentry-dsn

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7
 # =============================================================================
 # DHANAM WEB - Production Dockerfile
 # =============================================================================
@@ -37,8 +38,15 @@ COPY packages/esg/package.json ./packages/esg/
 COPY packages/simulations/package.json ./packages/simulations/
 COPY packages/billing-sdk/package.json ./packages/billing-sdk/
 
-# Install dependencies (DATABASE_URL needed for Prisma generate postinstall)
-RUN DATABASE_URL="postgresql://dummy:dummy@localhost:5432/dummy" pnpm install --frozen-lockfile
+# Install dependencies (DATABASE_URL needed for Prisma generate postinstall).
+# The web app depends on private MADFAM packages; pass npm auth as a BuildKit
+# secret so the token is not baked into an image layer.
+RUN --mount=type=secret,id=npm_madfam_token,required=true \
+    set -eu; \
+    token="$(cat /run/secrets/npm_madfam_token)"; \
+    printf '\n//npm.madfam.io/:_authToken=%s\n' "$token" >> .npmrc; \
+    DATABASE_URL="postgresql://dummy:dummy@localhost:5432/dummy" pnpm install --frozen-lockfile; \
+    rm -f .npmrc
 
 # =============================================================================
 # Builder Stage

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:932ddd1bd54ee95965f5ef4454a97205f1c7b634223c70cc51e820edba64d5d8
+    digest: sha256:fe10488191cf2ad15c21129d2161f5ac62c284ea42ed5c3b21071e13abdaa796
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:bd5bd8353c4ce7b7236f507b787a02478b21d116e8d41471835f72d6c864ee73
+    digest: sha256:932ddd1bd54ee95965f5ef4454a97205f1c7b634223c70cc51e820edba64d5d8
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/tests/fixtures/workflow-guards/test_playwright_api_env.py
+++ b/tests/fixtures/workflow-guards/test_playwright_api_env.py
@@ -1,0 +1,48 @@
+"""
+Regression guard for Playwright API startup environment.
+
+Run from repo root:
+    python3 -m unittest discover -s tests/fixtures/workflow-guards -p 'test_*.py' -v
+"""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from urllib.parse import urlparse
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+API_ENV_EXAMPLE = REPO_ROOT / "apps" / "api" / ".env.example"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+POSTHOG_HOST = "https://analytics.madfam.io"
+
+
+def _read_env_value(path: Path, key: str) -> str | None:
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.startswith(f"{key}="):
+            return line.split("=", 1)[1]
+    return None
+
+
+class PlaywrightApiEnvTests(unittest.TestCase):
+    def test_api_env_example_posthog_host_is_valid_uri(self):
+        value = _read_env_value(API_ENV_EXAMPLE, "POSTHOG_HOST")
+
+        self.assertIsNotNone(value)
+        parsed = urlparse(value or "")
+        self.assertIn(parsed.scheme, {"http", "https"})
+        self.assertTrue(parsed.netloc)
+
+    def test_playwright_jobs_override_posthog_host_after_copying_example_env(self):
+        workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+        posthog_override = f'echo "POSTHOG_HOST={POSTHOG_HOST}" >> apps/api/.env'
+
+        self.assertGreaterEqual(
+            workflow.count(posthog_override),
+            2,
+            "Both web and admin Playwright jobs must provide a valid POSTHOG_HOST",
+        )
+        self.assertNotIn("POSTHOG_HOST=replace-with-posthog-host", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/fixtures/workflow-guards/test_web_docker_npm_auth.py
+++ b/tests/fixtures/workflow-guards/test_web_docker_npm_auth.py
@@ -1,0 +1,62 @@
+"""
+Regression guard for Dhanam web Docker builds that consume private packages.
+
+Run from repo root:
+    python3 -m unittest discover -s tests/fixtures -p 'test_*.py' -v
+"""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WEB_DOCKERFILE = REPO_ROOT / "apps" / "web" / "Dockerfile"
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+SECRET_REF = "npm_madfam_token=${{ secrets.NPM_MADFAM_TOKEN }}"
+
+
+class WebDockerNpmAuthTests(unittest.TestCase):
+    def test_web_dockerfile_uses_buildkit_secret_for_private_registry(self):
+        dockerfile = WEB_DOCKERFILE.read_text(encoding="utf-8")
+
+        self.assertTrue(
+            dockerfile.startswith("# syntax=docker/dockerfile:"),
+            "BuildKit syntax is required for RUN --mount=type=secret",
+        )
+        self.assertIn(
+            "RUN --mount=type=secret,id=npm_madfam_token,required=true",
+            dockerfile,
+        )
+        self.assertIn("//npm.madfam.io/:_authToken=%s", dockerfile)
+        self.assertNotIn("ARG NPM_MADFAM_TOKEN", dockerfile)
+        self.assertNotIn("ENV NPM_MADFAM_TOKEN", dockerfile)
+
+    def test_every_web_docker_build_workflow_passes_npm_secret(self):
+        workflow_files = sorted(WORKFLOWS_DIR.glob("*.yml"))
+        web_build_workflows: list[Path] = []
+
+        for workflow in workflow_files:
+            text = workflow.read_text(encoding="utf-8")
+            if "apps/web/Dockerfile" not in text:
+                continue
+            web_build_workflows.append(workflow)
+            self.assertIn(
+                SECRET_REF,
+                text,
+                f"{workflow.relative_to(REPO_ROOT)} builds apps/web/Dockerfile without the npm secret",
+            )
+            self.assertNotIn(
+                "NPM_MADFAM_TOKEN=${{ secrets.NPM_MADFAM_TOKEN }}",
+                text,
+                f"{workflow.relative_to(REPO_ROOT)} must not pass npm auth as a Docker build arg",
+            )
+
+        self.assertGreaterEqual(
+            len(web_build_workflows),
+            1,
+            "Expected at least one workflow to build apps/web/Dockerfile",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- pass NPM_MADFAM_TOKEN to web Docker builds as a BuildKit secret
- document the private registry Docker auth contract
- add a workflow guard so future web Docker build workflows must pass the secret

## Validation
- python fixture guard suites pass in a PyYAML venv
- prettier check passes
- git diff --check passes
- pre-push suite passed: format, typecheck, lint, tests, build, Prisma schema