### PR TITLE
feat(catalog): add Voxa AAC product tiers

### DIFF
--- a/catalog.yaml
+++ b/catalog.yaml
@@ -1274,6 +1274,63 @@ products:
       loyalty_event: 1
       credential_issue: 2
 
+  voxa:
+    name: "Voxa"
+    description: "Cross-platform AAC — OBF, cloud sync, consent-gated AI, WCAG-native web"
+    category: platform
+    website: "https://voxa.madfam.io"
+    sort_order: 29
+    tiers:
+      free:
+        dhanam_tier: essentials
+        display_name: "Parent"
+        prices: {}
+        metadata:
+          boards: 1
+          team_seats: 1
+        features:
+          - "1 communication board"
+          - "Cloud sync & OBF import/export"
+          - "CVI themes & access methods"
+          - "Basic AI (consent-gated)"
+      family:
+        dhanam_tier: pro
+        display_name: "Family"
+        # Tulana v0.1 anchor (2026-06-12): 0.8× AAC sub median ≈177 MXN;
+        # operator value-anchored at 199 MXN (Tezca Essentials peer).
+        prices:
+          USD: { monthly: 1176, annual: 11176 }
+          MXN: { monthly: 19900, annual: 189900 }
+        metadata:
+          boards: 10
+          team_seats: 3
+        features:
+          - "Up to 10 boards"
+          - "3 team editors"
+          - "Cloud sync & OBF"
+          - "Basic AI"
+      clinic:
+        dhanam_tier: premium
+        display_name: "Institutional"
+        # Sales-assisted: org base + per-seat; checkout via operator quote.
+        prices:
+          USD: { monthly: 8999 }
+          MXN: { monthly: 149900 }
+        metadata:
+          boards: unlimited
+          team_seats: unlimited
+          per_seat_mxn_centavos: 34900
+          min_seats: 3
+        features:
+          - "Unlimited boards & team roles"
+          - "Full AI + usage reports"
+          - "SSO via Janua"
+          - "CFDI invoicing"
+          - "Priority onboarding"
+    credit_costs:
+      ai_completion: 1
+      symbol_generation: 2
+
 coupons:
   founding_member_mx:
     # Year-1 onboarding deal (was "40% forever" — PRICING_OVERHAUL_20260417.md

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:fe10488191cf2ad15c21129d2161f5ac62c284ea42ed5c3b21071e13abdaa796
+    digest: sha256:520a845b82929653355d8a31c7191ecb46baf41fb1900e79e29885f4e707e11a
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin


### PR DESCRIPTION
## Summary
- Register **Voxa** in `catalog.yaml` with Parent (free), Family (199 MXN/mo, 1,899/yr), and Institutional tiers
- Enables Tulana SKUs `voxa__family` / `voxa__clinic` and checkout plan IDs `voxa_family` / `voxa_clinic`

## Test plan
- [ ] Merge PR
- [ ] Run `npx tsx scripts/sync-catalog.ts` on Enclii
- [ ] `./tulana/scripts/voxa-pricing-bootstrap.sh --persist`


Made with [Cursor](https://cursor.com)