### PR TITLE
fix(catalog): normalize Voxa yearly prices for Prisma BillingInterval

### DIFF
--- a/apps/api/src/modules/billing/services/product-catalog.service.ts
+++ b/apps/api/src/modules/billing/services/product-catalog.service.ts
@@ -48,7 +48,10 @@ interface YamlTier {
   display_name?: string;
   description?: string;
   metadata?: Record<string, unknown>;
-  prices?: Record<string, { monthly?: number | null; yearly?: number | null }>;
+  prices?: Record<
+    string,
+    { monthly?: number | null; yearly?: number | null; annual?: number | null }
+  >;
   features?: string[];
 }
 
@@ -586,7 +589,7 @@ export class ProductCatalogService {
             currency,
             {
               monthly: price.monthly ?? null,
-              yearly: price.yearly ?? null,
+              yearly: price.yearly ?? price.annual ?? null,
             },
           ])
         ) as CatalogProduct['tiers'][number]['prices'],

--- a/apps/api/test/e2e/helpers/catalog.helper.ts
+++ b/apps/api/test/e2e/helpers/catalog.helper.ts
@@ -23,7 +23,7 @@ interface YamlTier {
   dhanam_tier: string;
   display_name?: string;
   description?: string;
-  prices: Record<string, { monthly?: number; yearly?: number }>;
+  prices: Record<string, { monthly?: number; yearly?: number; annual?: number }>;
   metadata?: Record<string, unknown>;
   features?: string[];
 }
@@ -49,6 +49,29 @@ function featureSlug(feature: string): string {
     .replace(/[^a-z0-9]+/g, '_')
     .replace(/^_|_$/g, '')
     .slice(0, 80);
+}
+
+function normalizeBillingInterval(interval: string): 'monthly' | 'yearly' {
+  if (interval === 'annual') {
+    return 'yearly';
+  }
+  if (interval === 'monthly' || interval === 'yearly') {
+    return interval;
+  }
+  throw new Error(`Unsupported billing interval in catalog.yaml: ${interval}`);
+}
+
+function priceAmountForInterval(
+  prices: { monthly?: number; yearly?: number; annual?: number },
+  interval: string
+): number | undefined {
+  if (interval === 'monthly') {
+    return prices.monthly;
+  }
+  if (interval === 'yearly' || interval === 'annual') {
+    return prices.yearly ?? prices.annual;
+  }
+  return undefined;
 }
 
 export async function seedCatalogForE2E(prisma: PrismaService): Promise<void> {
@@ -108,10 +131,13 @@ export async function seedCatalogForE2E(prisma: PrismaService): Promise<void> {
       });
 
       for (const [currency, prices] of Object.entries(tierConfig.prices ?? {})) {
-        for (const [interval, amount] of Object.entries(prices)) {
+        for (const intervalKey of ['monthly', 'yearly'] as const) {
+          const amount = priceAmountForInterval(prices, intervalKey);
           if (!amount || amount === 0) {
             continue;
           }
+
+          const interval = normalizeBillingInterval(intervalKey);
 
           await prisma.productPrice.upsert({
             where: {
@@ -119,7 +145,7 @@ export async function seedCatalogForE2E(prisma: PrismaService): Promise<void> {
                 productId: product.id,
                 tierSlug,
                 currency,
-                interval: interval as any,
+                interval,
               },
             },
             create: {
@@ -127,7 +153,7 @@ export async function seedCatalogForE2E(prisma: PrismaService): Promise<void> {
               tierSlug,
               dhanamTier: tierConfig.dhanam_tier as any,
               currency,
-              interval: interval as any,
+              interval,
               amountCents: amount,
               displayName: tierConfig.display_name,
               metadata: tierConfig.metadata as any,

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -1299,8 +1299,8 @@ products:
         # Tulana v0.1 anchor (2026-06-12): 0.8× AAC sub median ≈177 MXN;
         # operator value-anchored at 199 MXN (Tezca Essentials peer).
         prices:
-          USD: { monthly: 1176, annual: 11176 }
-          MXN: { monthly: 19900, annual: 189900 }
+          USD: { monthly: 1176, yearly: 11176 }
+          MXN: { monthly: 19900, yearly: 189900 }
         metadata:
           boards: 10
           team_seats: 3


### PR DESCRIPTION
## Summary
- Fixes main CI E2E failures caused by Voxa tier prices using `annual` instead of Prisma's `yearly` interval.
- Normalizes `annual` → `yearly` in E2E catalog seeding and file-backed catalog mapping as a defensive alias.

## Test plan
- [x] `pnpm --filter @dhanam/api typecheck`
- [ ] CI E2E suite green on main after merge


Made with [Cursor](https://cursor.com)