### PR TITLE
fix(catalog): normalize annual intervals and add prod sync workflow

### DIFF
--- a/.github/workflows/sync-catalog-prod.yml
+++ b/.github/workflows/sync-catalog-prod.yml
@@ -1,0 +1,79 @@
+# Operator workflow: sync catalog.yaml → Dhanam DB + Stripe (production).
+#
+# Runs scripts/sync-catalog.ts with production secrets from the GitHub
+# `production` environment. Idempotent — safe to re-run after catalog.yaml merges.
+#
+# Required secrets (production environment):
+#   DATABASE_URL
+#   STRIPE_SECRET_KEY
+#   STRIPE_MX_SECRET_KEY
+
+name: Sync production catalog
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Preview only (no DB/Stripe writes)"
+        required: false
+        default: true
+        type: boolean
+      reason:
+        description: "Why are you syncing now? (audit log)"
+        required: true
+        type: string
+
+concurrency:
+  group: sync-catalog-prod
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: sync-catalog.ts
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run catalog sync
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_MX_SECRET_KEY: ${{ secrets.STRIPE_MX_SECRET_KEY }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          echo "Reason: ${{ inputs.reason }}"
+          if [ "$DRY_RUN" = "true" ]; then
+            pnpm tsx scripts/sync-catalog.ts --dry-run
+          else
+            pnpm tsx scripts/sync-catalog.ts
+          fi
+
+      - name: Verify voxa in live catalog API
+        if: inputs.dry_run == false
+        run: |
+          python3 - <<'PY'
+          import json, sys, urllib.request
+          with urllib.request.urlopen("https://api.dhan.am/v1/billing/catalog") as resp:
+              data = json.load(resp)
+          products = data.get("products", data if isinstance(data, list) else [])
+          slugs = {p.get("slug") for p in products}
+          if "voxa" not in slugs:
+              print("ERROR: voxa still missing from live catalog after sync", file=sys.stderr)
+              sys.exit(1)
+          voxa = next(p for p in products if p.get("slug") == "voxa")
+          tiers = [t.get("tierSlug") for t in voxa.get("tiers") or []]
+          print(f"OK: voxa tiers={tiers}")
+          PY

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:e30b6cf817b070b78622e9c79c69725232f0f530e9691b4461f9f9b910c822a9
+    digest: sha256:b088d6ab62532422ea9c1ad06c04da99161345abb73b2677b51f580173ec1502
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/scripts/sync-catalog.ts
+++ b/scripts/sync-catalog.ts
@@ -75,9 +75,35 @@ interface YamlTier {
   dhanam_tier: string;
   display_name?: string;
   description?: string;
-  prices: Record<string, { monthly?: number; yearly?: number }>;
+  prices: Record<string, { monthly?: number; yearly?: number; annual?: number }>;
   metadata?: Record<string, unknown>;
   features?: string[];
+}
+
+function normalizeBillingInterval(interval: string): 'monthly' | 'yearly' {
+  if (interval === 'annual') {
+    return 'yearly';
+  }
+  if (interval === 'monthly' || interval === 'yearly') {
+    return interval;
+  }
+  throw new Error(`Unsupported billing interval in catalog.yaml: ${interval}`);
+}
+
+function priceEntries(priceConfig: {
+  monthly?: number;
+  yearly?: number;
+  annual?: number;
+}): Array<['monthly' | 'yearly', number]> {
+  const entries: Array<['monthly' | 'yearly', number]> = [];
+  if (priceConfig.monthly) {
+    entries.push(['monthly', priceConfig.monthly]);
+  }
+  const yearlyAmount = priceConfig.yearly ?? priceConfig.annual;
+  if (yearlyAmount) {
+    entries.push(['yearly', yearlyAmount]);
+  }
+  return entries;
 }
 
 interface YamlCoupon {
@@ -258,9 +284,10 @@ async function syncProduct(slug: string, config: YamlProduct): Promise<void> {
 
     // Sync prices
     for (const [currency, priceConfig] of Object.entries(tier.prices)) {
-      for (const [interval, amount] of Object.entries(priceConfig)) {
+      for (const [interval, amount] of priceEntries(priceConfig)) {
         if (!amount || amount === 0) continue;
-        desiredPriceKeys.add(catalogPriceKey(tierSlug, currency, interval));
+        const billingInterval = normalizeBillingInterval(interval);
+        desiredPriceKeys.add(catalogPriceKey(tierSlug, currency, billingInterval));
 
         // DB upsert
         if (!DRY_RUN) {
@@ -270,7 +297,7 @@ async function syncProduct(slug: string, config: YamlProduct): Promise<void> {
                 productId: dbProduct.id,
                 tierSlug,
                 currency,
-                interval: interval as any,
+                interval: billingInterval as any,
               },
             },
             create: {
@@ -278,7 +305,7 @@ async function syncProduct(slug: string, config: YamlProduct): Promise<void> {
               tierSlug,
               dhanamTier: tier.dhanam_tier as any,
               currency,
-              interval: interval as any,
+              interval: billingInterval as any,
               amountCents: amount,
               displayName: tier.display_name,
               metadata: tier.metadata,
@@ -300,28 +327,31 @@ async function syncProduct(slug: string, config: YamlProduct): Promise<void> {
               stripe,
               stripeProductId,
               currency,
-              interval,
+              billingInterval,
               tierSlug
             );
 
             if (stripePrice) {
-              log('Price', `Found ${slug}/${tierSlug} ${currency} ${interval}: ${stripePrice.id}`);
+              log(
+                'Price',
+                `Found ${slug}/${tierSlug} ${currency} ${billingInterval}: ${stripePrice.id}`
+              );
             } else {
               stripePrice = await stripe.prices.create({
                 product: stripeProductId,
                 unit_amount: amount,
                 currency: currency.toLowerCase(),
-                recurring: { interval: interval === 'yearly' ? 'year' : 'month' },
+                recurring: { interval: billingInterval === 'yearly' ? 'year' : 'month' },
                 metadata: {
                   madfam_slug: slug,
                   madfam_tier: tierSlug,
                   madfam_currency: currency,
-                  madfam_interval: interval,
+                  madfam_interval: billingInterval,
                 },
               });
               log(
                 'Price',
-                `Created ${slug}/${tierSlug} ${currency} ${interval}: ${stripePrice.id}`
+                `Created ${slug}/${tierSlug} ${currency} ${billingInterval}: ${stripePrice.id}`
               );
             }
 
@@ -334,7 +364,7 @@ async function syncProduct(slug: string, config: YamlProduct): Promise<void> {
         } else {
           log(
             'Price',
-            `Would sync ${slug}/${tierSlug} ${currency} ${interval}: ${amount} centavos`
+            `Would sync ${slug}/${tierSlug} ${currency} ${billingInterval}: ${amount} centavos`
           );
         }
       }


### PR DESCRIPTION
## Summary
- Maps `catalog.yaml` `annual` price keys to Prisma `yearly` in `sync-catalog.ts` so Voxa Family annual SKUs sync correctly.
- Adds `Sync production catalog` workflow_dispatch for operator runs against production `DATABASE_URL` + Stripe keys (includes post-sync `voxa` API check).

## Test plan
- [ ] Merge PR
- [ ] Run **Sync production catalog** workflow with `dry_run=true`, verify Voxa prices in output
- [ ] Re-run with `dry_run=false` and confirm `GET https://api.dhan.am/v1/billing/catalog` includes `voxa`
- [ ] Run `./scripts/voxa-pricing-bootstrap.sh --persist` on Tulana Enclii


Made with [Cursor](https://cursor.com)