### PR TITLE
fix(ci): sync-catalog workflow pnpm pin

### DIFF
--- a/.github/workflows/sync-catalog-prod.yml
+++ b/.github/workflows/sync-catalog-prod.yml
@@ -36,8 +36,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Fixes ERR_PNPM_BAD_PM_VERSION in Sync production catalog workflow.

Made with [Cursor](https://cursor.com)