### PR TITLE
fix(ci): dummy DATABASE_URL for sync-catalog install

### DIFF
--- a/.github/workflows/sync-catalog-prod.yml
+++ b/.github/workflows/sync-catalog-prod.yml
@@ -43,6 +43,8 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
+        env:
+          DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
         run: pnpm install --frozen-lockfile
 
       - name: Run catalog sync


### PR DESCRIPTION
Fixes prisma generate during pnpm install in Sync production catalog workflow.

Made with [Cursor](https://cursor.com)