### PR TITLE
fix(ci): remove duplicate env in sync-catalog-prod workflow

### DIFF
--- a/.github/workflows/sync-catalog-prod.yml
+++ b/.github/workflows/sync-catalog-prod.yml
@@ -57,8 +57,6 @@ jobs:
         env:
           DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
         run: pnpm install --frozen-lockfile
-        env:
-          DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
 
       - name: Run catalog sync
         env:


### PR DESCRIPTION
Fixes HTTP 422 workflow parse error from duplicate env key.

Made with [Cursor](https://cursor.com)