### PR TITLE
fix(ci): standalone pnpm for prod catalog sync workflow

### DIFF
--- a/.github/workflows/sync-catalog-prod.yml
+++ b/.github/workflows/sync-catalog-prod.yml
@@ -36,15 +36,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+          standalone: true
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: "20"
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          run_install: false
+          cache: pnpm
 
       - name: Configure npm registry
         run: |


### PR DESCRIPTION
## Summary
- Use `standalone: true` on `pnpm/action-setup@v6` to avoid flaky `@pnpm/linux-x64` npm downloads during version downgrade (v11 → v9.15.0).
- Reorder setup to pnpm-before-node with `cache: pnpm`, matching lint/test-coverage workflows.

## Context
Latest `sync-catalog-prod.yml` dry-run failed at Install pnpm with ENOENT after network retries on `@pnpm/linux-x64-9.15.0.tgz`.

## Test plan
- [ ] Merge and dispatch dry-run workflow
- [ ] If green, dispatch live sync and verify `voxa` on `GET /v1/billing/catalog`


Made with [Cursor](https://cursor.com)