### PR TITLE
fix(ci): preflight Production secrets before live catalog sync

### DIFF
--- a/.github/workflows/sync-catalog-prod.yml
+++ b/.github/workflows/sync-catalog-prod.yml
@@ -3,7 +3,7 @@
 # Runs scripts/sync-catalog.ts with production secrets from the GitHub
 # `production` environment. Idempotent — safe to re-run after catalog.yaml merges.
 #
-# Required secrets (production environment):
+# Required secrets (GitHub Settings → Environments → Production):
 #   DATABASE_URL
 #   STRIPE_SECRET_KEY
 #   STRIPE_MX_SECRET_KEY
@@ -32,7 +32,7 @@ jobs:
   sync:
     name: sync-catalog.ts
     runs-on: ubuntu-latest
-    environment: production
+    environment: Production
     steps:
       - uses: actions/checkout@v4
 
@@ -59,6 +59,23 @@ jobs:
         env:
           DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
         run: pnpm install --frozen-lockfile
+
+      - name: Preflight production secrets
+        if: inputs.dry_run == false
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_MX_SECRET_KEY: ${{ secrets.STRIPE_MX_SECRET_KEY }}
+        run: |
+          missing=()
+          [ -z "$DATABASE_URL" ] && missing+=("DATABASE_URL")
+          [ -z "$STRIPE_SECRET_KEY" ] && missing+=("STRIPE_SECRET_KEY")
+          [ -z "$STRIPE_MX_SECRET_KEY" ] && missing+=("STRIPE_MX_SECRET_KEY")
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "ERROR: GitHub Production environment is missing secrets: ${missing[*]}"
+            echo "Add them under Settings → Environments → Production (from Enclii Lockbox)."
+            exit 1
+          fi
 
       - name: Run catalog sync
         env:


### PR DESCRIPTION
## Summary
- Use `environment: Production` (matches existing GitHub environment name).
- Add preflight step on live runs that lists missing secrets before invoking `sync-catalog.ts`.

## Context
Live sync after PR #495 failed with empty `DATABASE_URL` because the Production environment has zero secrets configured.

## Test plan
- [ ] Dry-run still passes
- [ ] Live run fails at preflight with clear secret list until operator adds Production env secrets


Made with [Cursor](https://cursor.com)