### PR TITLE
fix(catalog): enclii-first prod catalog ops and db source of truth

### DIFF
--- a/.github/workflows/catalog-drift-prod.yml
+++ b/.github/workflows/catalog-drift-prod.yml
@@ -1,0 +1,54 @@
+# Read-only production catalog truth gate.
+#
+# Compares repo catalog.yaml with GET https://api.dhan.am/v1/billing/catalog.
+# No production credentials required. Fails when products/tiers/prices drift.
+#
+# See docs/CATALOG_TRUTH_2026-05-20.md and scripts/check-catalog-drift.ts.
+
+name: Production catalog drift
+
+on:
+  schedule:
+    - cron: "0 12 * * 1"
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why run drift check now? (audit log)"
+        required: false
+        default: "manual"
+        type: string
+
+concurrency:
+  group: catalog-drift-prod
+  cancel-in-progress: false
+
+jobs:
+  drift:
+    name: catalog.yaml vs live API
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+          standalone: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: pnpm
+
+      - name: Install dependencies
+        env:
+          DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
+        run: pnpm install --frozen-lockfile
+
+      - name: Run catalog drift check
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Reason: ${{ inputs.reason }}"
+          fi
+          pnpm catalog:drift -- --json

--- a/.github/workflows/prod-argocd-refresh.yml
+++ b/.github/workflows/prod-argocd-refresh.yml
@@ -1,7 +1,9 @@
-# Break-glass: hard-refresh the production ArgoCD Application after a prod
-# digest promotion so GitOps reconciles without waiting for the poll interval.
+# Break-glass only: hard-refresh the production ArgoCD Application.
 #
-# Requires repo secret KUBECONFIG_PRODUCTION (same as deploy-staging digest proof).
+# Prefer the best-effort refresh in promote-to-prod.yml after digest promotion.
+# Routine reconciliation is Enclii-first; record an adapter gap when this path is used.
+#
+# Requires repo secret KUBECONFIG_PRODUCTION (often unreachable from GitHub-hosted runners).
 
 name: Refresh production ArgoCD
 

--- a/.github/workflows/promote-to-prod.yml
+++ b/.github/workflows/promote-to-prod.yml
@@ -362,3 +362,121 @@ jobs:
           fi
       - name: Compare live ArgoCD digests to production manifest
         run: node scripts/production-rollout-proof.js dhanam-services
+
+  notify-enclii:
+    name: Notify Enclii of prod promotion
+    needs: [validate, promote]
+    if: needs.validate.outputs.should_promote == 'true'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Report promotion lifecycle event
+        env:
+          PROMOTE_REASON: ${{ needs.validate.outputs.reason }}
+          API_DIGEST: ${{ needs.validate.outputs.api_digest }}
+          WEB_DIGEST: ${{ needs.validate.outputs.web_digest }}
+          ADMIN_DIGEST: ${{ needs.validate.outputs.admin_digest }}
+        run: |
+          set -euo pipefail
+          if [ -z "${{ secrets.ENCLII_CALLBACK_TOKEN }}" ]; then
+            echo "::warning::ENCLII_CALLBACK_TOKEN not configured — skipping Enclii promotion callback."
+            exit 0
+          fi
+          payload="$(python3 - <<'PY'
+          import json, os, subprocess
+          print(json.dumps({
+              "repo_full_name": "madfam-org/dhanam",
+              "commit_sha": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+              "branch": "main",
+              "ref": "refs/heads/main",
+              "event_type": "promotion_completed",
+              "source": "promote_to_prod_workflow",
+              "message": f"Production digest promotion: {os.environ.get('PROMOTE_REASON', '')}",
+              "metadata": {
+                  "workflow": "promote-to-prod",
+                  "api_digest": os.environ.get("API_DIGEST", ""),
+                  "web_digest": os.environ.get("WEB_DIGEST", ""),
+                  "admin_digest": os.environ.get("ADMIN_DIGEST", ""),
+              },
+          }))
+          PY
+          )"
+          if ! curl -sf -X POST "https://api.enclii.dev/v1/callbacks/lifecycle-event" \
+            -H "Authorization: Bearer ${{ secrets.ENCLII_CALLBACK_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d "$payload"; then
+            echo "::warning::Enclii lifecycle callback failed — record Enclii adapter gap for prod promotion reconcile."
+          fi
+
+  argocd-refresh-best-effort:
+    name: Best-effort ArgoCD refresh (break-glass)
+    needs: [validate, promote]
+    if: needs.validate.outputs.should_promote == 'true'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: azure/setup-kubectl@v5
+
+      - name: Configure kubeconfig
+        env:
+          KUBECONFIG_B64: ${{ secrets.KUBECONFIG_PRODUCTION }}
+        run: |
+          set -euo pipefail
+          if [ -z "${KUBECONFIG_B64:-}" ]; then
+            echo "::warning::KUBECONFIG_PRODUCTION not configured; skipping ArgoCD refresh."
+            exit 0
+          fi
+          mkdir -p "$HOME/.kube"
+          echo "$KUBECONFIG_B64" | base64 -d > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+
+      - name: Refresh dhanam Application
+        run: |
+          set -euo pipefail
+          if ! kubectl version --request-timeout=10s >/dev/null 2>&1; then
+            echo "::warning::Cluster API unreachable from GitHub Actions — ArgoCD refresh skipped."
+            echo "::warning::Enclii adapter gap: prod GitOps reconcile must be triggered from Enclii or in-cluster."
+            exit 0
+          fi
+          kubectl -n argocd annotate application dhanam argocd.argoproj.io/refresh=hard --overwrite || true
+          kubectl -n dhanam rollout status deployment/dhanam-api --timeout=300s || \
+            echo "::warning::dhanam-api rollout did not complete within timeout — verify via Enclii/ArgoCD."
+
+  catalog-drift-gate:
+    name: Catalog drift gate (informational)
+    needs: [validate, promote]
+    if: needs.validate.outputs.should_promote == 'true'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+          standalone: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: pnpm
+
+      - name: Install dependencies
+        env:
+          DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
+        run: pnpm install --frozen-lockfile
+
+      - name: Check live catalog vs catalog.yaml
+        run: |
+          set -euo pipefail
+          if ! pnpm catalog:drift -- --json; then
+            echo "::warning::Catalog drift detected after promotion."
+            echo "::warning::Run Sync production catalog (dry_run=false) after Production env secrets are configured."
+            exit 1
+          fi

--- a/.github/workflows/sync-catalog-prod.yml
+++ b/.github/workflows/sync-catalog-prod.yml
@@ -1,14 +1,16 @@
 # Operator workflow: sync catalog.yaml → Dhanam DB + Stripe (production).
 #
-# Runs scripts/sync-catalog.ts with production secrets from the GitHub
-# `production` environment. Idempotent — safe to re-run after catalog.yaml merges.
+# Enclii-first: production credentials live in the GitHub Production environment
+# (copy from Enclii Lockbox / Vault). Do not duplicate secrets into repo secrets.
 #
-# Required for live sync (first match wins):
-#   1. GitHub Settings → Environments → Production:
-#        DATABASE_URL, STRIPE_SECRET_KEY, STRIPE_MX_SECRET_KEY
-#   2. Break-glass fallback via repo secret KUBECONFIG_PRODUCTION → kubectl read
-#        dhanam-secrets + dhanam-billing-secrets in namespace dhanam
+# Required secrets (Settings → Environments → Production):
+#   DATABASE_URL
+#   STRIPE_SECRET_KEY
+#   STRIPE_MX_SECRET_KEY
 #   NPM_MADFAM_TOKEN (repo/org secret — needed for pnpm install)
+#
+# After live sync, catalog:drift verifies the public API matches catalog.yaml.
+# See scripts/sync-catalog-prod.md and docs/CATALOG_TRUTH_2026-05-20.md.
 
 name: Sync production catalog
 
@@ -61,69 +63,24 @@ jobs:
           DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
         run: pnpm install --frozen-lockfile
 
-      - name: Setup kubectl
-        if: inputs.dry_run == false
-        uses: azure/setup-kubectl@v5
-
-      - name: Resolve production credentials
+      - name: Preflight Production secrets
         if: inputs.dry_run == false
         env:
-          GH_DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          GH_STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
-          GH_STRIPE_MX_SECRET_KEY: ${{ secrets.STRIPE_MX_SECRET_KEY }}
-          KUBECONFIG_B64: ${{ secrets.KUBECONFIG_PRODUCTION }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_MX_SECRET_KEY: ${{ secrets.STRIPE_MX_SECRET_KEY }}
         run: |
           set -euo pipefail
-          DATABASE_URL="$GH_DATABASE_URL"
-          STRIPE_SECRET_KEY="$GH_STRIPE_SECRET_KEY"
-          STRIPE_MX_SECRET_KEY="$GH_STRIPE_MX_SECRET_KEY"
-
-          if [ -z "$DATABASE_URL" ] || [ -z "$STRIPE_SECRET_KEY" ] || [ -z "$STRIPE_MX_SECRET_KEY" ]; then
-            if [ -z "$KUBECONFIG_B64" ]; then
-              echo "ERROR: Production credentials missing and KUBECONFIG_PRODUCTION is not configured."
-              echo "Add DATABASE_URL, STRIPE_SECRET_KEY, and STRIPE_MX_SECRET_KEY under Settings → Environments → Production."
-              exit 1
-            fi
-            echo "GitHub Production secrets unavailable — loading from cluster (break-glass)."
-            mkdir -p ~/.kube
-            echo "$KUBECONFIG_B64" | base64 -d > ~/.kube/config
-            chmod 600 ~/.kube/config
-
-            ready=false
-            for attempt in 1 2 3 4 5; do
-              if kubectl version --request-timeout=10s >/dev/null 2>&1; then
-                ready=true
-                break
-              fi
-              echo "Cluster API not reachable yet (attempt ${attempt}/5); retrying in 15s..."
-              sleep 15
-            done
-            if [ "$ready" != "true" ]; then
-              echo "ERROR: Cluster API unreachable from GitHub Actions."
-              echo "Add Production environment secrets or run scripts/sync-catalog.ts from an operator workstation (see scripts/sync-catalog-prod.md)."
-              exit 1
-            fi
-
-            if [ -z "$DATABASE_URL" ]; then
-              DATABASE_URL=$(kubectl get secret dhanam-secrets -n dhanam -o jsonpath='{.data.DATABASE_URL}' | base64 -d)
-            fi
-            if [ -z "$STRIPE_SECRET_KEY" ]; then
-              STRIPE_SECRET_KEY=$(kubectl get secret dhanam-secrets -n dhanam -o jsonpath='{.data.STRIPE_SECRET_KEY}' | base64 -d)
-            fi
-            if [ -z "$STRIPE_MX_SECRET_KEY" ]; then
-              STRIPE_MX_SECRET_KEY=$(kubectl get secret dhanam-billing-secrets -n dhanam -o jsonpath='{.data.STRIPE_MX_SECRET_KEY}' | base64 -d)
-            fi
-          fi
-
           missing=()
-          [ -z "$DATABASE_URL" ] && missing+=("DATABASE_URL")
-          [ -z "$STRIPE_SECRET_KEY" ] && missing+=("STRIPE_SECRET_KEY")
-          [ -z "$STRIPE_MX_SECRET_KEY" ] && missing+=("STRIPE_MX_SECRET_KEY")
+          [ -z "${DATABASE_URL:-}" ] && missing+=("DATABASE_URL")
+          [ -z "${STRIPE_SECRET_KEY:-}" ] && missing+=("STRIPE_SECRET_KEY")
+          [ -z "${STRIPE_MX_SECRET_KEY:-}" ] && missing+=("STRIPE_MX_SECRET_KEY")
           if [ "${#missing[@]}" -gt 0 ]; then
-            echo "ERROR: Missing production credentials: ${missing[*]}"
+            echo "ERROR: GitHub Production environment is missing secrets: ${missing[*]}"
+            echo "Add them under Settings → Environments → Production (from Enclii Lockbox)."
+            echo "Operator fallback: scripts/sync-catalog-prod.md → internal-devops runbook."
             exit 1
           fi
-
           echo "::add-mask::$DATABASE_URL"
           echo "::add-mask::$STRIPE_SECRET_KEY"
           echo "::add-mask::$STRIPE_MX_SECRET_KEY"
@@ -145,19 +102,6 @@ jobs:
           echo "Reason: ${{ inputs.reason }}"
           pnpm --filter @dhanam/api exec tsx ../../scripts/sync-catalog.ts
 
-      - name: Verify voxa in live catalog API
+      - name: Verify catalog drift (live)
         if: inputs.dry_run == false
-        run: |
-          python3 - <<'PY'
-          import json, sys, urllib.request
-          with urllib.request.urlopen("https://api.dhan.am/v1/billing/catalog") as resp:
-              data = json.load(resp)
-          products = data.get("products", data if isinstance(data, list) else [])
-          slugs = {p.get("slug") for p in products}
-          if "voxa" not in slugs:
-              print("ERROR: voxa still missing from live catalog after sync", file=sys.stderr)
-              sys.exit(1)
-          voxa = next(p for p in products if p.get("slug") == "voxa")
-          tiers = [t.get("tierSlug") for t in voxa.get("tiers") or []]
-          print(f"OK: voxa tiers={tiers}")
-          PY
+        run: pnpm catalog:drift -- --json

--- a/apps/api/src/modules/billing/README.md
+++ b/apps/api/src/modules/billing/README.md
@@ -69,12 +69,10 @@ Commercial plan truth lives in [`catalog.yaml`](../../../../../catalog.yaml) and
 is synced into Dhanam's product catalog. Do not hard-code commercial pricing in
 new billing code or docs.
 
-The public catalog endpoints serve `catalog.yaml` directly in production
-(`DHANAM_PUBLIC_CATALOG_SOURCE=file` or unset with `NODE_ENV=production`). The
-database catalog remains the Stripe/checkout reconciliation store populated by
-`scripts/sync-catalog.ts`; it must not be the only public catalog source because
-stale DB rows or connection pressure would otherwise hide the canonical MADFAM
-SKU catalogue from downstream systems such as Tulana.
+The public catalog endpoints read the **database catalog** in production
+(`DHANAM_PUBLIC_CATALOG_SOURCE=db`). Repo `catalog.yaml` is the authoring source;
+`scripts/sync-catalog.ts` materialises it into Postgres and Stripe. Verify with
+`pnpm catalog:drift -- --json` against `GET /v1/billing/catalog`.
 
 Janua's active catalogue scope is intentionally limited to the self-hosted Open
 Source tier. Janua public docs currently mark managed SaaS hosting, enterprise

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -1,6 +1,6 @@
 # Dhanam Tech Debt Register
 
-Last updated: 2026-06-12
+Last updated: 2026-06-13
 
 This is the current technical-debt register for Dhanam. It tracks debt that
 still affects stability, operations, development velocity, or release safety.
@@ -23,20 +23,21 @@ For execution order and milestone targets, read the
 
 ## Active Debt
 
-| ID      | Area                         | Severity | Status   | Current impact                                                                                                                                                                            | Primary reference                                                       |
-| ------- | ---------------------------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| TD-1002 | Staging activation           | Medium   | Active   | Staging API/web/admin smoke is green; remaining debt is repeated proof and Enclii-owned namespace-aware route apply.                                                                      | [Deployment Guide](DEPLOYMENT.md)                                       |
-| TD-1003 | Production rollout truth     | High     | Active   | `production-rollout-proof.js` proves ArgoCD live digests, but Enclii `prod` records still do not own public rollout truth.                                                                | [Stability Wrap-Up](STABILITY_WRAP_UP_2026-05-20.md)                    |
-| TD-1004 | Enclii adapter coverage      | Medium   | Active   | Migration repair, policy waiver apply, staging tunnel route apply, and queue remediation adapters are not fully wired.                                                                    | [Stability Wrap-Up](STABILITY_WRAP_UP_2026-05-20.md)                    |
-| TD-1005 | Provider health semantics    | Medium   | Active   | Plaid/Bitso/Banxico intentional unconfigured states need explicit operational classification.                                                                                             | [Credential Onboarding](CREDENTIAL_ONBOARDING.md)                       |
-| TD-1006 | React 18 global pin          | Low      | Deferred | Root pnpm overrides keep web/admin on React 18 until Expo/mobile can move safely.                                                                                                         | [package.json](../package.json)                                         |
-| TD-1007 | Mobile test depth            | Low      | Active   | Mobile still has a small foundation test set relative to app surface area.                                                                                                                | [Mobile Guide](MOBILE.md)                                               |
-| TD-1008 | Historical docs cleanup      | Low      | Active   | Phase summaries archived under `docs/reports/historical/`; GA banners on guides; OpenAPI export script verified locally. Long-term: generate `API.md` sections from OpenAPI.              | [Documentation Audit](DOCUMENTATION_AUDIT_2026-05-22.md)                |
-| TD-1009 | Billing router unification   | Medium   | Active   | Fee-aware routing + schedule maintenance shipped in source. Remaining: production staging smoke proof and close legacy bypass audit.                                                      | [Commercial GA Execution](COMMERCIAL_GA_EXECUTION.md)                   |
-| TD-1010 | Internal POS completeness    | Medium   | Active   | Charge, refund, timeline, reconciliation, route override, fee schedule admin, SDK, and golden probe CI are source-landed. Remaining: staging Karafiel CFDI proof, DLQ drill, G2 sign-off. | [Commercial GA Execution](COMMERCIAL_GA_EXECUTION.md)                   |
-| TD-1011 | Janua commercial readiness   | High     | Active   | Janua billing secrets were present with zero length in production proof; Janua-routed billing must not be claimed live.                                                                   | [Stability Wrap-Up](STABILITY_WRAP_UP_2026-05-20.md)                    |
-| TD-1012 | Public repo security hygiene | High     | Active   | ~48%: P0 + A6 + DEPLOYMENT redaction + PR checklist. AGENTS diet (P2) remains.                                                                                                            | [Public Repo Security Remediation](PUBLIC_REPO_SECURITY_REMEDIATION.md) |
-| TD-1013 | MADFAM operator prod slice   | High     | Active   | ~65%: ledger + budget metadata + admin MADFAM Import UI. Belvo + prod PlatformConfig seed remain.                                                                                         | [Full Remediation Plan](FULL_REMEDIATION_PLAN_G4_AND_OPERATOR_SLICE.md) |
+| ID      | Area                         | Severity | Status   | Current impact                                                                                                                                                                                       | Primary reference                                                       |
+| ------- | ---------------------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| TD-1002 | Staging activation           | Medium   | Active   | Staging API/web/admin smoke is green; remaining debt is repeated proof and Enclii-owned namespace-aware route apply.                                                                                 | [Deployment Guide](DEPLOYMENT.md)                                       |
+| TD-1003 | Production rollout truth     | High     | Active   | `production-rollout-proof.js` proves ArgoCD live digests, but Enclii `prod` records still do not own public rollout truth.                                                                           | [Stability Wrap-Up](STABILITY_WRAP_UP_2026-05-20.md)                    |
+| TD-1004 | Enclii adapter coverage      | Medium   | Active   | Migration repair, policy waiver apply, staging tunnel route apply, and queue remediation adapters are not fully wired.                                                                               | [Stability Wrap-Up](STABILITY_WRAP_UP_2026-05-20.md)                    |
+| TD-1005 | Provider health semantics    | Medium   | Active   | Plaid/Bitso/Banxico intentional unconfigured states need explicit operational classification.                                                                                                        | [Credential Onboarding](CREDENTIAL_ONBOARDING.md)                       |
+| TD-1006 | React 18 global pin          | Low      | Deferred | Root pnpm overrides keep web/admin on React 18 until Expo/mobile can move safely.                                                                                                                    | [package.json](../package.json)                                         |
+| TD-1007 | Mobile test depth            | Low      | Active   | Mobile still has a small foundation test set relative to app surface area.                                                                                                                           | [Mobile Guide](MOBILE.md)                                               |
+| TD-1008 | Historical docs cleanup      | Low      | Active   | Phase summaries archived under `docs/reports/historical/`; GA banners on guides; OpenAPI export script verified locally. Long-term: generate `API.md` sections from OpenAPI.                         | [Documentation Audit](DOCUMENTATION_AUDIT_2026-05-22.md)                |
+| TD-1009 | Billing router unification   | Medium   | Active   | Fee-aware routing + schedule maintenance shipped in source. Remaining: production staging smoke proof and close legacy bypass audit.                                                                 | [Commercial GA Execution](COMMERCIAL_GA_EXECUTION.md)                   |
+| TD-1010 | Internal POS completeness    | Medium   | Active   | Charge, refund, timeline, reconciliation, route override, fee schedule admin, SDK, and golden probe CI are source-landed. Remaining: staging Karafiel CFDI proof, DLQ drill, G2 sign-off.            | [Commercial GA Execution](COMMERCIAL_GA_EXECUTION.md)                   |
+| TD-1011 | Janua commercial readiness   | High     | Active   | Janua billing secrets were present with zero length in production proof; Janua-routed billing must not be claimed live.                                                                              | [Stability Wrap-Up](STABILITY_WRAP_UP_2026-05-20.md)                    |
+| TD-1012 | Public repo security hygiene | High     | Active   | ~48%: P0 + A6 + DEPLOYMENT redaction + PR checklist. AGENTS diet (P2) remains.                                                                                                                       | [Public Repo Security Remediation](PUBLIC_REPO_SECURITY_REMEDIATION.md) |
+| TD-1013 | MADFAM operator prod slice   | High     | Active   | ~65%: ledger + budget metadata + admin MADFAM Import UI. Belvo + prod PlatformConfig seed remain.                                                                                                    | [Full Remediation Plan](FULL_REMEDIATION_PLAN_G4_AND_OPERATOR_SLICE.md) |
+| TD-1014 | Production catalog sync ops  | High     | Active   | GitHub Production environment lacks `DATABASE_URL`/Stripe secrets; live catalog drift (e.g. missing `voxa`) until `sync-catalog.ts` runs. Weekly drift workflow + hardened operator runbook shipped. | [Catalog Truth](CATALOG_TRUTH_2026-05-20.md)                            |
 
 ## Remediation Notes
 
@@ -203,6 +204,19 @@ Phase summaries (`PHASE2-SUMMARY`, `IMPLEMENTATION_SUMMARY`, `PHASE3-PLAN`),
 dogfooding quick wins, audit summary, and `architecture/IMPLEMENTATION_PROGRESS`
 now live under `docs/reports/historical/` with GA-linked banners. Remaining
 low-priority work: long-term `API.md` generation from OpenAPI export.
+
+### TD-1014: Production Catalog Sync Ops
+
+Close this by configuring GitHub **Production** environment secrets from Enclii
+Lockbox (`DATABASE_URL`, `STRIPE_SECRET_KEY`, `STRIPE_MX_SECRET_KEY`), then:
+
+1. Run **Sync production catalog** with `dry_run=false`.
+2. Confirm `pnpm catalog:drift -- --json` returns `"ok": true`.
+3. Keep the weekly **Production catalog drift** workflow green.
+
+Production API now sets `DHANAM_PUBLIC_CATALOG_SOURCE=db` so public catalog and
+checkout share one reconciled store. Image-only `catalog.yaml` updates without
+DB sync will not surface new products (e.g. `voxa`).
 
 ## Recently Closed Debt
 

--- a/infra/k8s/production/api-deployment.yaml
+++ b/infra/k8s/production/api-deployment.yaml
@@ -96,6 +96,10 @@ spec:
             # this var becomes load-bearing.
             - name: WEB_URL
               value: "https://app.dhan.am"
+            # Public GET /billing/catalog reads the DB catalog populated by
+            # scripts/sync-catalog.ts. Keeps checkout and public API aligned.
+            - name: DHANAM_PUBLIC_CATALOG_SOURCE
+              value: "db"
 
             # =================================================================
             # Janua OIDC (Galaxy Ecosystem Authentication)

--- a/scripts/sync-catalog-prod.md
+++ b/scripts/sync-catalog-prod.md
@@ -1,7 +1,7 @@
 # Production Catalog Sync — Runbook (public stub)
 
 > **Operator-only:** Full Vault paths, live `DATABASE_URL` formats, and
-> break-glass kubectl steps live in **`madfam-org/internal-devops`**
+> break-glass steps live in **`madfam-org/internal-devops`**
 > (`runbooks/dhanam-catalog-sync-prod.md`). Do not copy production credentials
 > into this public repository.
 
@@ -10,31 +10,48 @@
 Run after a merged change to `catalog.yaml` when Stripe prices and the
 production Dhanam DB must be reconciled. Idempotent; safe to re-run.
 
+Production serves `GET /v1/billing/catalog` from the **database catalog**
+(`DHANAM_PUBLIC_CATALOG_SOURCE=db`). Checkout price resolution also reads the
+DB. A catalog merge is not complete until `sync-catalog.ts` has run and
+`pnpm catalog:drift -- --json` returns `"ok": true`.
+
 ## Prerequisites (Enclii-first)
 
 1. Confirm production migrations are applied (`pnpm --filter @dhanam/api db:migrate:deploy`).
-2. Load secrets from Enclii Lockbox / Vault — never from git:
+2. Configure GitHub **Settings → Environments → Production** secrets (from Enclii Lockbox):
    - `DATABASE_URL` (prod Postgres)
    - `STRIPE_SECRET_KEY` (USD)
    - `STRIPE_MX_SECRET_KEY` (Mexico)
-3. Use admin.dhan.am or audited CLI from a trusted operator workstation.
+3. Repo secret `NPM_MADFAM_TOKEN` must remain available for workflow installs.
 
-## Dry-run first
+## GitHub Actions (preferred)
+
+1. **Sync production catalog** workflow — `dry_run=true` first, review logs.
+2. Re-run with `dry_run=false` and an audit `reason`.
+3. Workflow runs `pnpm catalog:drift -- --json` after live sync.
+
+## Local fallback
 
 ```bash
 cd apps/api
-DRY_RUN=true pnpm tsx scripts/sync-catalog.ts
+# Load DATABASE_URL + Stripe keys from Enclii Lockbox / Vault first.
+pnpm exec tsx ../../scripts/sync-catalog.ts --dry-run
+pnpm exec tsx ../../scripts/sync-catalog.ts
+cd ../..
+pnpm catalog:drift -- --json
 ```
 
-Review output, then run without `DRY_RUN`.
+## Monitoring
+
+- **Production catalog drift** workflow runs weekly (Mondays 12:00 UTC) and on
+  `workflow_dispatch`. It compares `catalog.yaml` to the live API without secrets.
+- After **Promote staging → prod**, the promotion workflow runs an informational
+  drift check. Drift after promote usually means catalog sync is still pending.
 
 ## Private runbook
 
 For the full procedure (Vault `kv get`, digest verification, rollback), see
 **internal-devops** `runbooks/dhanam-catalog-sync-prod.md`.
 
-For the **Voxa activation path** (GitHub Production env secrets, Enclii break-glass,
-Tulana bootstrap, WTP gates), see **internal-devops**
-`runbooks/voxa-pricing-activation-2026-06.md`.
-
-See also [Public Repo Security Remediation](../docs/PUBLIC_REPO_SECURITY_REMEDIATION.md).
+See also [Catalog Truth 2026-05-20](../docs/CATALOG_TRUTH_2026-05-20.md) and
+[Public Repo Security Remediation](../docs/PUBLIC_REPO_SECURITY_REMEDIATION.md).


### PR DESCRIPTION
## Summary
- Set `DHANAM_PUBLIC_CATALOG_SOURCE=db` on production API so public catalog and checkout share the DB store populated by `sync-catalog.ts`.
- Harden `sync-catalog-prod.yml`: Production environment secrets only, verify with `pnpm catalog:drift` after live sync.
- Add weekly `catalog-drift-prod.yml` workflow (read-only truth gate, no secrets).
- Extend `promote-to-prod.yml` with Enclii lifecycle callback, best-effort ArgoCD refresh, and informational drift gate.
- Update operator runbook, billing README, and TD-1014.

## Test plan
- [x] `pnpm catalog:drift -- --json` locally (expected fail until sync: missing voxa)
- [ ] Dispatch Production catalog drift workflow after merge
- [ ] Operator adds Production env secrets and runs live catalog sync


Made with [Cursor](https://cursor.com)