### PR TITLE
fix(web): hostname-aware public surface and prod web rebuild on promote

### DIFF
--- a/.github/workflows/promote-to-prod.yml
+++ b/.github/workflows/promote-to-prod.yml
@@ -10,6 +10,11 @@
 # .enclii.yml declares `promotion.pattern: manual`, and the repo variable
 # AUTO_PROMOTE_ENABLED defaults to "false". To enable auto-promote in the
 # future, flip the repo variable + update .enclii.yml.
+#
+# IMPORTANT: web and admin bake NEXT_PUBLIC_* at build time. Promoting the
+# staging web/admin digest would leak staging hostnames on prod domains.
+# This workflow rebuilds web/admin with production build-args; only API
+# reuses the staging digest pointer.
 
 name: Promote staging -> prod
 
@@ -52,6 +57,11 @@ concurrency:
   group: prod-promote
   cancel-in-progress: false
 
+env:
+  REGISTRY: ghcr.io
+  WEB_IMAGE: madfam-org/dhanam/web
+  ADMIN_IMAGE: madfam-org/dhanam/admin
+
 jobs:
   validate:
     name: Validate promotion candidate(s)
@@ -67,6 +77,8 @@ jobs:
       admin_digest: ${{ steps.resolve.outputs.admin_digest }}
       short: ${{ steps.resolve.outputs.short }}
       reason: ${{ steps.resolve.outputs.reason }}
+      build_web: ${{ steps.resolve.outputs.build_web }}
+      build_admin: ${{ steps.resolve.outputs.build_admin }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -242,17 +254,31 @@ jobs:
             REASON="${REASON}; smoke-run=${INPUT_STAGING_SMOKE_RUN_ID}"
           }
 
+          verify_staging_promote_candidate() {
+            resolve_one "$1" >/dev/null
+          }
+
           API_D=""
           WEB_D=""
           ADMIN_D=""
+          BUILD_WEB=false
+          BUILD_ADMIN=false
           case "$COMPONENT" in
             api)   API_D=$(resolve_one api) ;;
-            web)   WEB_D=$(resolve_one web) ;;
-            admin) ADMIN_D=$(resolve_one admin) ;;
+            web)
+              verify_staging_promote_candidate web
+              BUILD_WEB=true
+              ;;
+            admin)
+              verify_staging_promote_candidate admin
+              BUILD_ADMIN=true
+              ;;
             all)
               API_D=$(resolve_one api)
-              WEB_D=$(resolve_one web)
-              ADMIN_D=$(resolve_one admin)
+              verify_staging_promote_candidate web
+              verify_staging_promote_candidate admin
+              BUILD_WEB=true
+              BUILD_ADMIN=true
               ;;
             *)
               echo "::error::Unknown component $COMPONENT"; exit 1 ;;
@@ -265,15 +291,114 @@ jobs:
             echo "api_digest=$API_D"
             echo "web_digest=$WEB_D"
             echo "admin_digest=$ADMIN_D"
+            echo "build_web=$BUILD_WEB"
+            echo "build_admin=$BUILD_ADMIN"
             echo "short=$SHORT"
             echo "reason=$REASON"
             echo "should_promote=true"
           } >> "$GITHUB_OUTPUT"
 
+  build-prod-web:
+    name: Build production web image
+    needs: validate
+    if: needs.validate.outputs.should_promote == 'true' && needs.validate.outputs.build_web == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: 'v2.2.4'
+      - id: sha
+        run: echo "short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+      - id: push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: apps/web/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.WEB_IMAGE }}:prod-${{ steps.sha.outputs.short }}
+          build-args: |
+            NEXT_PUBLIC_API_URL=https://api.dhan.am/v1
+            NEXT_PUBLIC_BASE_URL=https://app.dhan.am
+            NEXT_PUBLIC_ADMIN_URL=https://admin.dhan.am
+            NEXT_PUBLIC_OIDC_ISSUER=https://auth.madfam.io
+            NEXT_PUBLIC_OIDC_CLIENT_ID=${{ vars.NEXT_PUBLIC_OIDC_CLIENT_ID || 'jnc_uE2zp9ume_Fd6jMl1elL6wqjiECM711t' }}
+            NEXT_PUBLIC_JANUA_API_URL=https://auth.madfam.io
+          secrets: |
+            npm_madfam_token=${{ secrets.NPM_MADFAM_TOKEN }}
+          cache-from: type=gha,scope=web-prod
+          cache-to: type=gha,scope=web-prod,mode=max
+      - name: Sign production web image
+        if: steps.push.outcome == 'success'
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: cosign sign --yes ${{ env.REGISTRY }}/${{ env.WEB_IMAGE }}@${{ steps.push.outputs.digest }}
+
+  build-prod-admin:
+    name: Build production admin image
+    needs: validate
+    if: needs.validate.outputs.should_promote == 'true' && needs.validate.outputs.build_admin == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: 'v2.2.4'
+      - id: sha
+        run: echo "short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+      - id: push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: apps/admin/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.ADMIN_IMAGE }}:prod-${{ steps.sha.outputs.short }}
+          build-args: |
+            NEXT_PUBLIC_API_URL=https://api.dhan.am/v1
+            NEXT_PUBLIC_APP_URL=https://app.dhan.am
+            NEXT_PUBLIC_OIDC_ISSUER=https://auth.madfam.io
+          cache-from: type=gha,scope=admin-prod
+          cache-to: type=gha,scope=admin-prod,mode=max
+      - name: Sign production admin image
+        if: steps.push.outcome == 'success'
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: cosign sign --yes ${{ env.REGISTRY }}/${{ env.ADMIN_IMAGE }}@${{ steps.push.outputs.digest }}
+
   promote:
     name: Write prod kustomization
-    needs: validate
-    if: needs.validate.outputs.should_promote == 'true'
+    needs: [validate, build-prod-web, build-prod-admin]
+    if: |
+      always() &&
+      needs.validate.outputs.should_promote == 'true' &&
+      (needs.build-prod-web.result == 'success' || needs.build-prod-web.result == 'skipped') &&
+      (needs.build-prod-admin.result == 'success' || needs.build-prod-admin.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -285,8 +410,8 @@ jobs:
       - name: Patch prod kustomization digests
         env:
           API_DIGEST: ${{ needs.validate.outputs.api_digest }}
-          WEB_DIGEST: ${{ needs.validate.outputs.web_digest }}
-          ADMIN_DIGEST: ${{ needs.validate.outputs.admin_digest }}
+          WEB_DIGEST: ${{ needs.build-prod-web.outputs.digest }}
+          ADMIN_DIGEST: ${{ needs.build-prod-admin.outputs.digest }}
           SHORT: ${{ needs.validate.outputs.short }}
           REASON: ${{ needs.validate.outputs.reason }}
           ACTOR: ${{ github.actor }}
@@ -332,7 +457,8 @@ jobs:
           git commit -m "deploy(prod): promote $SHORT
 
           Reason: $REASON
-          Promoted-by: $ACTOR" || {
+          Promoted-by: $ACTOR
+          Note: web/admin digests are prod-rebuilt (NEXT_PUBLIC_*); api may reuse staging digest." || {
             echo "No digest change — already at target"
             exit 0
           }
@@ -378,8 +504,8 @@ jobs:
         env:
           PROMOTE_REASON: ${{ needs.validate.outputs.reason }}
           API_DIGEST: ${{ needs.validate.outputs.api_digest }}
-          WEB_DIGEST: ${{ needs.validate.outputs.web_digest }}
-          ADMIN_DIGEST: ${{ needs.validate.outputs.admin_digest }}
+          WEB_DIGEST: ${{ needs.build-prod-web.outputs.digest }}
+          ADMIN_DIGEST: ${{ needs.build-prod-admin.outputs.digest }}
         run: |
           set -euo pipefail
           if [ -z "${{ secrets.ENCLII_CALLBACK_TOKEN }}" ]; then

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -93,26 +93,8 @@ const nextConfig = {
             key: 'Permissions-Policy',
             value: 'camera=(), microphone=(), geolocation=()',
           },
-          {
-            key: 'Content-Security-Policy',
-            value: [
-              "default-src 'self'",
-              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://analytics.madfam.io https://challenges.cloudflare.com https://static.cloudflareinsights.com",
-              "style-src 'self' 'unsafe-inline'",
-              "img-src 'self' data: https:",
-              "font-src 'self' data:",
-              `connect-src 'self' ${(() => {
-                try {
-                  return new URL(defaultApiUrl).origin;
-                } catch {
-                  return 'https://api.dhan.am';
-                }
-              })()} https://analytics.madfam.io ${process.env.NEXT_PUBLIC_OIDC_ISSUER || 'https://auth.madfam.io'} https://challenges.cloudflare.com https://cloudflareinsights.com https://*.ingest.sentry.io`,
-              "frame-ancestors 'none'",
-              "base-uri 'self'",
-              "form-action 'self'",
-            ].join('; '),
-          },
+          // Content-Security-Policy is set at runtime in middleware from the
+          // request hostname so prod hosts never inherit staging connect-src.
         ],
       },
     ];

--- a/apps/web/src/app/(admin)/layout.tsx
+++ b/apps/web/src/app/(admin)/layout.tsx
@@ -5,10 +5,13 @@ import { useEffect } from 'react';
 import { AdminHeader } from '~/components/admin/admin-header';
 import { AdminNav } from '~/components/admin/admin-nav';
 import { AdminProvider } from '~/contexts/AdminContext';
+import { usePublicAdminUrl, usePublicAppUrl } from '~/hooks/usePublicSurface';
 import { useAuth } from '~/lib/hooks/use-auth';
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
   const { user, isAuthenticated } = useAuth();
+  const appUrl = usePublicAppUrl();
+  const adminUrl = usePublicAdminUrl();
 
   useEffect(() => {
     // In production, redirect to standalone admin app at admin.dhan.am
@@ -17,15 +20,14 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
       process.env.NODE_ENV === 'production' &&
       window.location.hostname !== 'admin.dhan.am'
     ) {
-      const adminUrl = process.env.NEXT_PUBLIC_ADMIN_URL || 'https://admin.dhan.am';
+      const adminUrlResolved = adminUrl;
       const path = window.location.pathname.replace(/^\/(admin)/, '');
-      window.location.href = `${adminUrl}${path || '/dashboard'}`;
+      window.location.href = `${adminUrlResolved}${path || '/dashboard'}`;
       return;
     }
 
     if (!isAuthenticated) {
       // Redirect to app subdomain login with return URL for cross-subdomain auth
-      const appUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://app.dhan.am';
       const returnUrl =
         typeof window !== 'undefined' ? encodeURIComponent(window.location.href) : '';
       window.location.href = `${appUrl}/login?from=${returnUrl}`;
@@ -41,10 +43,9 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
 
     if (!hasAdminAccess) {
       // Redirect non-admins to app subdomain dashboard
-      const appUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://app.dhan.am';
       window.location.href = `${appUrl}/dashboard`;
     }
-  }, [isAuthenticated, user]);
+  }, [adminUrl, appUrl, isAuthenticated, user]);
 
   if (!isAuthenticated || !user) {
     return null;

--- a/apps/web/src/app/[locale]/landing/page.tsx
+++ b/apps/web/src/app/[locale]/landing/page.tsx
@@ -18,6 +18,7 @@ import { ProblemSolution } from '@/components/landing/problem-solution';
 import { SecurityTrust } from '@/components/landing/security-trust';
 import { SocialProof } from '@/components/landing/social-proof';
 import { useAnalytics } from '@/hooks/useAnalytics';
+import { usePublicAppUrl } from '@/hooks/usePublicSurface';
 import { useAuth } from '@/lib/hooks/use-auth';
 
 export default function LocaleLandingPage() {
@@ -28,7 +29,7 @@ export default function LocaleLandingPage() {
   const { t } = useTranslation('landing');
 
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const appUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://app.dhan.am';
+  const appUrl = usePublicAppUrl();
 
   useEffect(() => {
     if (isAuthenticated) {

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -15,6 +15,7 @@ import { Pricing } from '@/components/landing/pricing';
 import { ProblemSolution } from '@/components/landing/problem-solution';
 import { SocialProof } from '@/components/landing/social-proof';
 import { useAnalytics } from '@/hooks/useAnalytics';
+import { usePublicAppUrl } from '@/hooks/usePublicSurface';
 import { useAuth } from '@/lib/hooks/use-auth';
 
 function HomePageContent() {
@@ -22,12 +23,7 @@ function HomePageContent() {
   const analytics = useAnalytics();
   const { t } = useTranslation('landing');
 
-  const appUrl = process.env.NEXT_PUBLIC_BASE_URL;
-
-  if (!appUrl && process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== 'test') {
-    throw new Error('NEXT_PUBLIC_BASE_URL is missing in non-development environment');
-  }
-
+  const appUrl = usePublicAppUrl();
   const resolvedAppUrl = appUrl || 'https://app.dhan.am';
 
   useEffect(() => {

--- a/apps/web/src/components/admin/admin-header.tsx
+++ b/apps/web/src/components/admin/admin-header.tsx
@@ -3,21 +3,21 @@
 import { Button } from '@dhanam/ui';
 import { Shield, LogOut, Home } from 'lucide-react';
 
+import { usePublicAppUrl } from '~/hooks/usePublicSurface';
 import { useAuth } from '~/lib/hooks/use-auth';
 
 export function AdminHeader() {
   const { user, logout } = useAuth();
+  const appUrl = usePublicAppUrl();
 
   const handleLogout = async () => {
     await logout();
     // Redirect to app subdomain login after logout for cross-subdomain consistency
-    const appUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://app.dhan.am';
     window.location.href = `${appUrl}/login`;
   };
 
   const handleBackToDashboard = () => {
     // Navigate to app subdomain dashboard for cross-subdomain navigation
-    const appUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://app.dhan.am';
     window.location.href = `${appUrl}/dashboard`;
   };
 

--- a/apps/web/src/hooks/usePublicSurface.ts
+++ b/apps/web/src/hooks/usePublicSurface.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import {
+  resolvePublicAdminUrl,
+  resolvePublicApiUrl,
+  resolvePublicAppUrl,
+} from '@/lib/routing/public-surface';
+
+function resolveFromBrowser<T>(
+  resolver: (hostname: string, baked?: string) => T,
+  baked?: string
+): T {
+  if (typeof window === 'undefined') {
+    return resolver('', baked);
+  }
+
+  return resolver(window.location.hostname, baked);
+}
+
+export function usePublicAppUrl(): string {
+  return useMemo(
+    () => resolveFromBrowser(resolvePublicAppUrl, process.env.NEXT_PUBLIC_BASE_URL),
+    []
+  );
+}
+
+export function usePublicApiUrl(): string {
+  return useMemo(
+    () => resolveFromBrowser(resolvePublicApiUrl, process.env.NEXT_PUBLIC_API_URL),
+    []
+  );
+}
+
+export function usePublicAdminUrl(): string {
+  return useMemo(
+    () =>
+      resolveFromBrowser(
+        resolvePublicAdminUrl,
+        process.env.NEXT_PUBLIC_ADMIN_URL || 'https://admin.dhan.am'
+      ),
+    []
+  );
+}

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -10,8 +10,10 @@ export class ApiError extends Error {
   }
 }
 
+import { resolvePublicApiUrl } from '../routing/public-surface';
+
 export class ApiClient {
-  private baseUrl: string;
+  private configuredBaseUrl: string;
   private accessToken?: string;
   private onTokenRefresh?: (tokens: { accessToken: string }) => void;
 
@@ -19,8 +21,17 @@ export class ApiClient {
     baseUrl?: string;
     onTokenRefresh?: (tokens: { accessToken: string }) => void;
   }) {
-    this.baseUrl = config.baseUrl || process.env.NEXT_PUBLIC_API_URL || 'https://api.dhan.am/v1';
+    this.configuredBaseUrl =
+      config.baseUrl || process.env.NEXT_PUBLIC_API_URL || 'https://api.dhan.am/v1';
     this.onTokenRefresh = config.onTokenRefresh;
+  }
+
+  private getBaseUrl(): string {
+    if (typeof window !== 'undefined') {
+      return resolvePublicApiUrl(window.location.hostname, this.configuredBaseUrl);
+    }
+
+    return this.configuredBaseUrl;
   }
 
   setTokens(tokens: { accessToken: string }) {
@@ -32,7 +43,7 @@ export class ApiClient {
   }
 
   private async request<T>(path: string, options: RequestInit = {}): Promise<T> {
-    const url = `${this.baseUrl}${path}`;
+    const url = `${this.getBaseUrl()}${path}`;
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
       ...(options.headers as Record<string, string>),
@@ -87,7 +98,7 @@ export class ApiClient {
   }
 
   private async refreshTokens(): Promise<{ accessToken: string; expiresIn: number }> {
-    const response = await fetch(`${this.baseUrl}/auth/refresh`, {
+    const response = await fetch(`${this.getBaseUrl()}/auth/refresh`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/apps/web/src/lib/routing/csp.ts
+++ b/apps/web/src/lib/routing/csp.ts
@@ -1,0 +1,28 @@
+import { getPublicApiOrigin, resolvePublicApiUrl } from './public-surface';
+
+const STATIC_CONNECT_SRC = [
+  'https://analytics.madfam.io',
+  'https://challenges.cloudflare.com',
+  'https://cloudflareinsights.com',
+  'https://*.ingest.sentry.io',
+];
+
+export function buildContentSecurityPolicy(hostname: string, bakedApiUrl?: string): string {
+  const apiUrl = resolvePublicApiUrl(hostname, bakedApiUrl);
+  const apiOrigin = getPublicApiOrigin(apiUrl);
+  const oidcIssuer = process.env.NEXT_PUBLIC_OIDC_ISSUER || 'https://auth.madfam.io';
+
+  const connectSrc = ["'self'", apiOrigin, oidcIssuer, ...STATIC_CONNECT_SRC].join(' ');
+
+  return [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://analytics.madfam.io https://challenges.cloudflare.com https://static.cloudflareinsights.com",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: https:",
+    "font-src 'self' data:",
+    `connect-src ${connectSrc}`,
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+  ].join('; ');
+}

--- a/apps/web/src/lib/routing/public-surface.test.ts
+++ b/apps/web/src/lib/routing/public-surface.test.ts
@@ -1,0 +1,95 @@
+import {
+  getPublicSurfaceTier,
+  isMarketingHostname,
+  resolvePublicApiUrl,
+  resolvePublicAppUrl,
+  resolvePublicSurfacesFromHostHeader,
+} from './public-surface';
+
+describe('public-surface', () => {
+  describe('getPublicSurfaceTier', () => {
+    it('classifies production hosts', () => {
+      expect(getPublicSurfaceTier('dhan.am')).toBe('production');
+      expect(getPublicSurfaceTier('app.dhan.am')).toBe('production');
+    });
+
+    it('classifies staging hosts', () => {
+      expect(getPublicSurfaceTier('staging.dhan.am')).toBe('staging');
+      expect(getPublicSurfaceTier('staging-api.dhan.am')).toBe('staging');
+    });
+
+    it('classifies preview hosts', () => {
+      expect(getPublicSurfaceTier('pr-42.web.preview.dhan.am')).toBe('preview');
+    });
+  });
+
+  describe('resolvePublicAppUrl', () => {
+    it('maps marketing apex to app.dhan.am even when build args are staging', () => {
+      expect(resolvePublicAppUrl('dhan.am', 'https://staging.dhan.am')).toBe('https://app.dhan.am');
+      expect(resolvePublicAppUrl('www.dhan.am', 'https://staging.dhan.am')).toBe(
+        'https://app.dhan.am'
+      );
+    });
+
+    it('keeps staging URLs on staging hosts', () => {
+      expect(resolvePublicAppUrl('staging.dhan.am', 'https://app.dhan.am')).toBe(
+        'https://staging.dhan.am'
+      );
+    });
+
+    it('corrects app.dhan.am when baked URL is staging', () => {
+      expect(resolvePublicAppUrl('app.dhan.am', 'https://staging.dhan.am')).toBe(
+        'https://app.dhan.am'
+      );
+    });
+
+    it('resolves preview app URLs from hostname', () => {
+      expect(resolvePublicAppUrl('pr-7.web.preview.dhan.am', 'https://app.dhan.am')).toBe(
+        'https://pr-7.web.preview.dhan.am'
+      );
+    });
+  });
+
+  describe('resolvePublicApiUrl', () => {
+    it('maps production hosts to api.dhan.am when build args are staging', () => {
+      expect(resolvePublicApiUrl('dhan.am', 'https://staging-api.dhan.am/v1')).toBe(
+        'https://api.dhan.am/v1'
+      );
+      expect(resolvePublicApiUrl('app.dhan.am', 'https://staging-api.dhan.am/v1')).toBe(
+        'https://api.dhan.am/v1'
+      );
+    });
+
+    it('keeps staging API on staging hosts', () => {
+      expect(resolvePublicApiUrl('staging.dhan.am', 'https://api.dhan.am/v1')).toBe(
+        'https://staging-api.dhan.am/v1'
+      );
+    });
+
+    it('resolves preview API URLs from hostname', () => {
+      expect(resolvePublicApiUrl('pr-3.web.preview.dhan.am', 'https://api.dhan.am/v1')).toBe(
+        'https://pr-3.api.preview.dhan.am/v1'
+      );
+    });
+  });
+
+  describe('resolvePublicSurfacesFromHostHeader', () => {
+    it('strips internal service ports from forwarded host headers', () => {
+      const surfaces = resolvePublicSurfacesFromHostHeader('dhan.am:4200', {
+        appUrl: 'https://staging.dhan.am',
+        apiUrl: 'https://staging-api.dhan.am/v1',
+      });
+
+      expect(surfaces.appUrl).toBe('https://app.dhan.am');
+      expect(surfaces.apiUrl).toBe('https://api.dhan.am/v1');
+    });
+  });
+
+  describe('isMarketingHostname', () => {
+    it('detects apex marketing hosts only', () => {
+      expect(isMarketingHostname('dhan.am')).toBe(true);
+      expect(isMarketingHostname('www.dhan.am')).toBe(true);
+      expect(isMarketingHostname('app.dhan.am')).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/lib/routing/public-surface.ts
+++ b/apps/web/src/lib/routing/public-surface.ts
@@ -1,0 +1,177 @@
+import { getHostnameFromHostHeader } from './hosts';
+
+export type PublicSurfaceTier = 'local' | 'preview' | 'staging' | 'production';
+
+const SURFACE_URLS = {
+  production: {
+    app: 'https://app.dhan.am',
+    api: 'https://api.dhan.am/v1',
+    admin: 'https://admin.dhan.am',
+  },
+  staging: {
+    app: 'https://staging.dhan.am',
+    api: 'https://staging-api.dhan.am/v1',
+    admin: 'https://staging-admin.dhan.am',
+  },
+  local: {
+    app: 'http://localhost:3040',
+    api: 'http://localhost:4010/v1',
+    admin: 'http://localhost:3400',
+  },
+} as const;
+
+export function getPreviewPrNumber(hostname: string): string | null {
+  const match = hostname.toLowerCase().match(/^pr-(\d+)\./);
+  return match?.[1] ?? null;
+}
+
+export function getPublicSurfaceTier(hostname: string): PublicSurfaceTier {
+  const host = hostname.toLowerCase();
+
+  if (!host || host === 'localhost' || host.endsWith('.localhost')) {
+    return 'local';
+  }
+
+  if (host.includes('.preview.dhan.am')) {
+    return 'preview';
+  }
+
+  if (host === 'staging.dhan.am' || host.startsWith('staging-') || host.startsWith('staging.')) {
+    return 'staging';
+  }
+
+  return 'production';
+}
+
+export function isMarketingHostname(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  return host === 'dhan.am' || host === 'www.dhan.am';
+}
+
+function tierFromPublicUrl(url: string | undefined): PublicSurfaceTier | null {
+  if (!url) {
+    return null;
+  }
+
+  const normalized = url.toLowerCase();
+
+  if (normalized.includes('localhost')) {
+    return 'local';
+  }
+
+  if (normalized.includes('.preview.dhan.am')) {
+    return 'preview';
+  }
+
+  if (normalized.includes('staging-api') || normalized.includes('staging.dhan.am')) {
+    return 'staging';
+  }
+
+  if (normalized.includes('dhan.am')) {
+    return 'production';
+  }
+
+  return null;
+}
+
+function resolvePreviewSurface(hostname: string, surface: 'app' | 'api' | 'admin'): string | null {
+  const pr = getPreviewPrNumber(hostname);
+  if (!pr) {
+    return null;
+  }
+
+  const suffix =
+    surface === 'app'
+      ? 'web.preview.dhan.am'
+      : surface === 'api'
+        ? 'api.preview.dhan.am/v1'
+        : 'admin.preview.dhan.am';
+
+  return `https://pr-${pr}.${suffix}`;
+}
+
+function resolveCanonicalSurface(
+  tier: PublicSurfaceTier,
+  surface: 'app' | 'api' | 'admin'
+): string {
+  if (tier === 'local') {
+    return SURFACE_URLS.local[surface];
+  }
+
+  if (tier === 'staging') {
+    return SURFACE_URLS.staging[surface];
+  }
+
+  return SURFACE_URLS.production[surface];
+}
+
+function resolveSurfaceUrl(
+  hostname: string,
+  surface: 'app' | 'api' | 'admin',
+  bakedUrl?: string
+): string {
+  const previewUrl = resolvePreviewSurface(hostname, surface);
+  if (previewUrl) {
+    return previewUrl;
+  }
+
+  const tier = getPublicSurfaceTier(hostname);
+  const canonical = resolveCanonicalSurface(tier, surface);
+
+  if (surface === 'app' && isMarketingHostname(hostname)) {
+    return canonical;
+  }
+
+  const bakedTier = tierFromPublicUrl(bakedUrl);
+  if (bakedTier && bakedTier !== tier) {
+    return canonical;
+  }
+
+  if (surface === 'app') {
+    if (hostname === 'app.dhan.am' || hostname === 'staging.dhan.am') {
+      return `https://${hostname}`;
+    }
+  }
+
+  if (surface === 'admin') {
+    if (hostname === 'admin.dhan.am' || hostname === 'staging-admin.dhan.am') {
+      return `https://${hostname}`;
+    }
+  }
+
+  return bakedUrl || canonical;
+}
+
+export function resolvePublicAppUrl(hostname: string, bakedUrl?: string): string {
+  return resolveSurfaceUrl(hostname, 'app', bakedUrl);
+}
+
+export function resolvePublicApiUrl(hostname: string, bakedUrl?: string): string {
+  return resolveSurfaceUrl(hostname, 'api', bakedUrl);
+}
+
+export function resolvePublicAdminUrl(hostname: string, bakedUrl?: string): string {
+  return resolveSurfaceUrl(hostname, 'admin', bakedUrl);
+}
+
+export function resolvePublicSurfacesFromHostHeader(
+  hostHeader: string | null | undefined,
+  baked?: { appUrl?: string; apiUrl?: string; adminUrl?: string }
+) {
+  const hostname = getHostnameFromHostHeader(hostHeader);
+
+  return {
+    hostname,
+    appUrl: resolvePublicAppUrl(hostname, baked?.appUrl),
+    apiUrl: resolvePublicApiUrl(hostname, baked?.apiUrl),
+    adminUrl: resolvePublicAdminUrl(hostname, baked?.adminUrl),
+  };
+}
+
+export function getPublicApiOrigin(apiUrl: string): string {
+  try {
+    return new URL(apiUrl).origin;
+  } catch {
+    return SURFACE_URLS.production.api.replace(/\/v1$/, '');
+  }
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -2,7 +2,9 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
 import { AUTH_CONSTANTS } from './lib/constants';
+import { buildContentSecurityPolicy } from './lib/routing/csp';
 import { getHostnameFromHostHeader, getWwwApexRedirectUrl } from './lib/routing/hosts';
+import { resolvePublicAdminUrl, resolvePublicAppUrl } from './lib/routing/public-surface';
 
 // Paths that don't require authentication
 const publicPaths = [
@@ -53,6 +55,14 @@ function getLocaleFromCountry(country: string | null): string {
   return COUNTRY_LOCALE[country.toUpperCase()] || 'es';
 }
 
+function withPublicSurfaceHeaders(response: NextResponse, hostname: string): NextResponse {
+  response.headers.set(
+    'Content-Security-Policy',
+    buildContentSecurityPolicy(hostname, process.env.NEXT_PUBLIC_API_URL)
+  );
+  return response;
+}
+
 export function middleware(request: NextRequest) {
   const path = request.nextUrl.pathname;
   const hostHeader =
@@ -75,23 +85,32 @@ export function middleware(request: NextRequest) {
       if (token) {
         return NextResponse.redirect(new URL('/dashboard', request.url));
       }
-      const appUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://app.dhan.am';
-      return NextResponse.redirect(new URL(`/login?from=https://admin.dhan.am`, appUrl));
+      const appUrl = resolvePublicAppUrl(hostname, process.env.NEXT_PUBLIC_BASE_URL);
+      return withPublicSurfaceHeaders(
+        NextResponse.redirect(new URL(`/login?from=https://admin.dhan.am`, appUrl)),
+        hostname
+      );
     }
 
     // Unauthenticated users on admin subdomain → redirect to app login
     const isPublicPath = publicPaths.some((p) => path.startsWith(p));
     if (!token && !isPublicPath) {
-      const appUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://app.dhan.am';
-      return NextResponse.redirect(new URL(`/login?from=https://admin.dhan.am${path}`, appUrl));
+      const appUrl = resolvePublicAppUrl(hostname, process.env.NEXT_PUBLIC_BASE_URL);
+      return withPublicSurfaceHeaders(
+        NextResponse.redirect(new URL(`/login?from=https://admin.dhan.am${path}`, appUrl)),
+        hostname
+      );
     }
 
     // Rewrite admin subdomain paths to internal /admin/* routes
     if (adminPages.some((p) => path === p || path.startsWith(p + '/'))) {
-      return NextResponse.rewrite(new URL(`/admin${path}`, request.url));
+      return withPublicSurfaceHeaders(
+        NextResponse.rewrite(new URL(`/admin${path}`, request.url)),
+        hostname
+      );
     }
 
-    return NextResponse.next();
+    return withPublicSurfaceHeaders(NextResponse.next(), hostname);
   }
 
   // === REDIRECT /dashboard/<subpath> to /<subpath> ===
@@ -104,9 +123,9 @@ export function middleware(request: NextRequest) {
 
   // === REDIRECT OLD /admin PATHS TO ADMIN SUBDOMAIN ===
   if (path.startsWith('/admin')) {
-    const adminUrl = process.env.NEXT_PUBLIC_ADMIN_URL || 'https://admin.dhan.am';
+    const adminUrl = resolvePublicAdminUrl(hostname, process.env.NEXT_PUBLIC_ADMIN_URL);
     const newPath = path.replace(/^\/admin/, '') || '/';
-    return NextResponse.redirect(new URL(newPath, adminUrl));
+    return withPublicSurfaceHeaders(NextResponse.redirect(new URL(newPath, adminUrl)), hostname);
   }
 
   // === DEMO MODE HANDLING ===
@@ -118,7 +137,7 @@ export function middleware(request: NextRequest) {
       maxAge: AUTH_CONSTANTS.DEMO_COOKIE_MAX_AGE_S,
       sameSite: 'lax',
     });
-    return response;
+    return withPublicSurfaceHeaders(response, hostname);
   }
 
   // === GEO DETECTION (for all routes) ===
@@ -182,7 +201,7 @@ export function middleware(request: NextRequest) {
           sameSite: 'lax',
         });
       }
-      return rewrite;
+      return withPublicSurfaceHeaders(rewrite, hostname);
     }
   }
 
@@ -197,7 +216,7 @@ export function middleware(request: NextRequest) {
         return NextResponse.redirect(new URL('/login', request.url));
       }
     }
-    return response;
+    return withPublicSurfaceHeaders(response, hostname);
   }
 
   const isPublicPath = publicPaths.some((p) => path.startsWith(p));
@@ -214,7 +233,7 @@ export function middleware(request: NextRequest) {
     return NextResponse.redirect(url);
   }
 
-  return response;
+  return withPublicSurfaceHeaders(response, hostname);
 }
 
 export const config = {

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -23,21 +23,22 @@ For execution order and milestone targets, read the
 
 ## Active Debt
 
-| ID      | Area                         | Severity | Status   | Current impact                                                                                                                                                                                       | Primary reference                                                       |
-| ------- | ---------------------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| TD-1002 | Staging activation           | Medium   | Active   | Staging API/web/admin smoke is green; remaining debt is repeated proof and Enclii-owned namespace-aware route apply.                                                                                 | [Deployment Guide](DEPLOYMENT.md)                                       |
-| TD-1003 | Production rollout truth     | High     | Active   | `production-rollout-proof.js` proves ArgoCD live digests, but Enclii `prod` records still do not own public rollout truth.                                                                           | [Stability Wrap-Up](STABILITY_WRAP_UP_2026-05-20.md)                    |
-| TD-1004 | Enclii adapter coverage      | Medium   | Active   | Migration repair, policy waiver apply, staging tunnel route apply, and queue remediation adapters are not fully wired.                                                                               | [Stability Wrap-Up](STABILITY_WRAP_UP_2026-05-20.md)                    |
-| TD-1005 | Provider health semantics    | Medium   | Active   | Plaid/Bitso/Banxico intentional unconfigured states need explicit operational classification.                                                                                                        | [Credential Onboarding](CREDENTIAL_ONBOARDING.md)                       |
-| TD-1006 | React 18 global pin          | Low      | Deferred | Root pnpm overrides keep web/admin on React 18 until Expo/mobile can move safely.                                                                                                                    | [package.json](../package.json)                                         |
-| TD-1007 | Mobile test depth            | Low      | Active   | Mobile still has a small foundation test set relative to app surface area.                                                                                                                           | [Mobile Guide](MOBILE.md)                                               |
-| TD-1008 | Historical docs cleanup      | Low      | Active   | Phase summaries archived under `docs/reports/historical/`; GA banners on guides; OpenAPI export script verified locally. Long-term: generate `API.md` sections from OpenAPI.                         | [Documentation Audit](DOCUMENTATION_AUDIT_2026-05-22.md)                |
-| TD-1009 | Billing router unification   | Medium   | Active   | Fee-aware routing + schedule maintenance shipped in source. Remaining: production staging smoke proof and close legacy bypass audit.                                                                 | [Commercial GA Execution](COMMERCIAL_GA_EXECUTION.md)                   |
-| TD-1010 | Internal POS completeness    | Medium   | Active   | Charge, refund, timeline, reconciliation, route override, fee schedule admin, SDK, and golden probe CI are source-landed. Remaining: staging Karafiel CFDI proof, DLQ drill, G2 sign-off.            | [Commercial GA Execution](COMMERCIAL_GA_EXECUTION.md)                   |
-| TD-1011 | Janua commercial readiness   | High     | Active   | Janua billing secrets were present with zero length in production proof; Janua-routed billing must not be claimed live.                                                                              | [Stability Wrap-Up](STABILITY_WRAP_UP_2026-05-20.md)                    |
-| TD-1012 | Public repo security hygiene | High     | Active   | ~48%: P0 + A6 + DEPLOYMENT redaction + PR checklist. AGENTS diet (P2) remains.                                                                                                                       | [Public Repo Security Remediation](PUBLIC_REPO_SECURITY_REMEDIATION.md) |
-| TD-1013 | MADFAM operator prod slice   | High     | Active   | ~65%: ledger + budget metadata + admin MADFAM Import UI. Belvo + prod PlatformConfig seed remain.                                                                                                    | [Full Remediation Plan](FULL_REMEDIATION_PLAN_G4_AND_OPERATOR_SLICE.md) |
-| TD-1014 | Production catalog sync ops  | High     | Active   | GitHub Production environment lacks `DATABASE_URL`/Stripe secrets; live catalog drift (e.g. missing `voxa`) until `sync-catalog.ts` runs. Weekly drift workflow + hardened operator runbook shipped. | [Catalog Truth](CATALOG_TRUTH_2026-05-20.md)                            |
+| ID      | Area                          | Severity | Status    | Current impact                                                                                                                                                                                       | Primary reference                                                       |
+| ------- | ----------------------------- | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| TD-1002 | Staging activation            | Medium   | Active    | Staging API/web/admin smoke is green; remaining debt is repeated proof and Enclii-owned namespace-aware route apply.                                                                                 | [Deployment Guide](DEPLOYMENT.md)                                       |
+| TD-1003 | Production rollout truth      | High     | Active    | `production-rollout-proof.js` proves ArgoCD live digests, but Enclii `prod` records still do not own public rollout truth.                                                                           | [Stability Wrap-Up](STABILITY_WRAP_UP_2026-05-20.md)                    |
+| TD-1004 | Enclii adapter coverage       | Medium   | Active    | Migration repair, policy waiver apply, staging tunnel route apply, and queue remediation adapters are not fully wired.                                                                               | [Stability Wrap-Up](STABILITY_WRAP_UP_2026-05-20.md)                    |
+| TD-1005 | Provider health semantics     | Medium   | Active    | Plaid/Bitso/Banxico intentional unconfigured states need explicit operational classification.                                                                                                        | [Credential Onboarding](CREDENTIAL_ONBOARDING.md)                       |
+| TD-1006 | React 18 global pin           | Low      | Deferred  | Root pnpm overrides keep web/admin on React 18 until Expo/mobile can move safely.                                                                                                                    | [package.json](../package.json)                                         |
+| TD-1007 | Mobile test depth             | Low      | Active    | Mobile still has a small foundation test set relative to app surface area.                                                                                                                           | [Mobile Guide](MOBILE.md)                                               |
+| TD-1008 | Historical docs cleanup       | Low      | Active    | Phase summaries archived under `docs/reports/historical/`; GA banners on guides; OpenAPI export script verified locally. Long-term: generate `API.md` sections from OpenAPI.                         | [Documentation Audit](DOCUMENTATION_AUDIT_2026-05-22.md)                |
+| TD-1009 | Billing router unification    | Medium   | Active    | Fee-aware routing + schedule maintenance shipped in source. Remaining: production staging smoke proof and close legacy bypass audit.                                                                 | [Commercial GA Execution](COMMERCIAL_GA_EXECUTION.md)                   |
+| TD-1010 | Internal POS completeness     | Medium   | Active    | Charge, refund, timeline, reconciliation, route override, fee schedule admin, SDK, and golden probe CI are source-landed. Remaining: staging Karafiel CFDI proof, DLQ drill, G2 sign-off.            | [Commercial GA Execution](COMMERCIAL_GA_EXECUTION.md)                   |
+| TD-1011 | Janua commercial readiness    | High     | Active    | Janua billing secrets were present with zero length in production proof; Janua-routed billing must not be claimed live.                                                                              | [Stability Wrap-Up](STABILITY_WRAP_UP_2026-05-20.md)                    |
+| TD-1012 | Public repo security hygiene  | High     | Active    | ~48%: P0 + A6 + DEPLOYMENT redaction + PR checklist. AGENTS diet (P2) remains.                                                                                                                       | [Public Repo Security Remediation](PUBLIC_REPO_SECURITY_REMEDIATION.md) |
+| TD-1013 | MADFAM operator prod slice    | High     | Active    | ~65%: ledger + budget metadata + admin MADFAM Import UI. Belvo + prod PlatformConfig seed remain.                                                                                                    | [Full Remediation Plan](FULL_REMEDIATION_PLAN_G4_AND_OPERATOR_SLICE.md) |
+| TD-1014 | Production catalog sync ops   | High     | Active    | GitHub Production environment lacks `DATABASE_URL`/Stripe secrets; live catalog drift (e.g. missing `voxa`) until `sync-catalog.ts` runs. Weekly drift workflow + hardened operator runbook shipped. | [Catalog Truth](CATALOG_TRUTH_2026-05-20.md)                            |
+| TD-1015 | Prod public surface URL drift | High     | Mitigated | Staging-built web images on prod hostnames leaked `staging.dhan.am` links/CSP. Hostname-aware runtime resolution + prod web/admin rebuild on promote + preflight surface checks.                     | `apps/web/src/lib/routing/public-surface.ts`                            |
 
 ## Remediation Notes
 
@@ -217,6 +218,24 @@ Lockbox (`DATABASE_URL`, `STRIPE_SECRET_KEY`, `STRIPE_MX_SECRET_KEY`), then:
 Production API now sets `DHANAM_PUBLIC_CATALOG_SOURCE=db` so public catalog and
 checkout share one reconciled store. Image-only `catalog.yaml` updates without
 DB sync will not surface new products (e.g. `voxa`).
+
+### TD-1015: Prod Public Surface URL Drift
+
+Root cause: `promote-to-prod` reused staging web/admin digests whose
+`NEXT_PUBLIC_*` values are baked at build time with staging hostnames.
+
+Mitigations shipped:
+
+1. `resolvePublicAppUrl()` / `resolvePublicApiUrl()` derive tier from the
+   request hostname and override mismatched build-time URLs.
+2. Runtime CSP in middleware uses the resolved API origin.
+3. `promote-to-prod.yml` rebuilds web/admin with production build-args; only
+   API may reuse the staging digest.
+4. `scripts/production-preflight.sh` fails if prod HTML references
+   `staging.dhan.am` or CSP still allows `staging-api.dhan.am`.
+
+Close this by promoting web with the updated workflow and confirming
+`./scripts/production-preflight.sh` is green on `dhan.am` / `app.dhan.am`.
 
 ## Recently Closed Debt
 

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:b088d6ab62532422ea9c1ad06c04da99161345abb73b2677b51f580173ec1502
+    digest: sha256:8659b4942dce938c775814eeb30f300c4f6df1847d2c1f5d8708dd2f793c4449
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/scripts/production-preflight.sh
+++ b/scripts/production-preflight.sh
@@ -60,6 +60,31 @@ check_redirect() {
   echo "REDIR OK   $url -> $location"
 }
 
+check_prod_public_surface() {
+  local url="$1"
+  local html
+  local csp
+
+  html="$(curl -LsS --max-time 20 "$url" || true)"
+  if [[ -z "$html" ]]; then
+    echo "SURFACE FAIL $url empty response body"
+    return 1
+  fi
+
+  if echo "$html" | grep -q 'staging\.dhan\.am'; then
+    echo "SURFACE FAIL $url HTML references staging.dhan.am"
+    return 1
+  fi
+
+  csp="$(curl -sSI --max-time 20 "$url" | awk 'BEGIN{IGNORECASE=1} /^content-security-policy:/ {sub(/^content-security-policy:[[:space:]]*/i, ""); sub(/\r$/, ""); print; exit}')"
+  if [[ -n "$csp" && "$csp" == *staging-api.dhan.am* ]]; then
+    echo "SURFACE FAIL $url CSP connect-src still allows staging-api.dhan.am"
+    return 1
+  fi
+
+  echo "SURFACE OK $url"
+}
+
 prod_hosts=(dhan.am www.dhan.am app.dhan.am admin.dhan.am api.dhan.am)
 for host in "${prod_hosts[@]}"; do
   check_dns "$host"
@@ -70,6 +95,8 @@ check_http "https://app.dhan.am/api/health"
 check_http "https://admin.dhan.am/api/health"
 check_http "https://dhan.am/"
 check_redirect "https://www.dhan.am/" "https://dhan.am/"
+check_prod_public_surface "https://dhan.am/es"
+check_prod_public_surface "https://app.dhan.am/login"
 
 if [[ "$include_staging" == true ]]; then
   staging_hosts=(staging.dhan.am staging-api.dhan.am staging-admin.dhan.am)


### PR DESCRIPTION
## Summary
- Resolve app/API/admin URLs from request hostname so prod marketing domains never leak staging links or CSP targets.
- Set Content-Security-Policy at runtime in middleware from the resolved API origin.
- Rebuild web/admin with production `NEXT_PUBLIC_*` build-args during `promote-to-prod`; only API may reuse staging digests.
- Extend `production-preflight.sh` to fail when prod HTML/CSP still reference staging hostnames.

## Test plan
- [x] `pnpm test --testPathPatterns="public-surface|middleware|client"` in apps/web
- [x] Pre-push hook (format, typecheck, lint, build, tests)
- [ ] After merge: dispatch **Promote staging -> prod** for `web`
- [ ] `./scripts/production-preflight.sh` green on `dhan.am` / `app.dhan.am`
- [ ] Try Live Demo on `dhan.am` routes to `app.dhan.am`, not staging


Made with [Cursor](https://cursor.com)