### PR TITLE
fix(k8s): Kyverno PolicyException API version for prod sync

### DIFF
--- a/infra/k8s/production/kyverno-policy-exception.yaml
+++ b/infra/k8s/production/kyverno-policy-exception.yaml
@@ -9,7 +9,7 @@
 # Operator note: prefer cosign-signed digests from deploy-staging / prod-rebuild
 # jobs; this exception does not disable signature verification cluster-wide.
 
-apiVersion: kyverno.io/v2
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: dhanam-gitops-rollout-signature


### PR DESCRIPTION
## Summary
- Change `PolicyException` from `kyverno.io/v2` to `kyverno.io/v2beta1` to match the cluster CRD
- Unblocks ArgoCD `dhanam-services` sync (was failing with SyncError on PolicyException v2)

## Test plan
- [ ] Merge and `enclii ops apps sync dhanam-services --apply`
- [ ] `./scripts/production-preflight.sh` passes surface checks


Made with [Cursor](https://cursor.com)