### PR TITLE
fix(k8s): broaden Kyverno exception for prod web rollout

### DIFF
--- a/infra/k8s/production/kyverno-policy-exception.yaml
+++ b/infra/k8s/production/kyverno-policy-exception.yaml
@@ -21,12 +21,15 @@ spec:
   exceptions:
     - policyName: verify-image-signatures
       ruleNames:
+        - check-signature
         - autogen-check-signature
   match:
     any:
       - resources:
           kinds:
+            - Deployment
             - Pod
+            - ReplicaSet
           namespaces:
             - dhanam
           names:


### PR DESCRIPTION
Match Deployment/ReplicaSet and both signature rules so ArgoCD can apply prod web digest 808f430f.

Made with [Cursor](https://cursor.com)