### PR TITLE
fix(k8s): defer FX CronJob blocking prod sync

### DIFF
--- a/infra/k8s/production/kustomization.yaml
+++ b/infra/k8s/production/kustomization.yaml
@@ -6,7 +6,10 @@ resources:
 - api-deployment.yaml
 - admin-deployment.yaml
 - web-deployment.yaml
-- fx-spot-refresh-cronjob.yaml
+# Deferred: fx-spot-refresh CronJob blocks Argo sync (Kyverno GHCR pull for
+# signature verify on private api image). Re-enable after ghcr-credentials or
+# PolicyException ordering is proven — see TD-1003 / #506 follow-up.
+# - fx-spot-refresh-cronjob.yaml
 - kyverno-policy-exception.yaml
 - external-secret.yaml
 - external-secret-janua.yaml


### PR DESCRIPTION
Unblocks dhanam-web rollout to prod digest 808f430f. CronJob re-enable tracked in TD-1003.

Made with [Cursor](https://cursor.com)