### PR TITLE
fix(k8s): force web pod rollout to prod digest

### DIFF
--- a/infra/k8s/production/web-deployment.yaml
+++ b/infra/k8s/production/web-deployment.yaml
@@ -30,6 +30,9 @@ spec:
       labels:
         app: dhanam-web
         component: frontend
+      annotations:
+        # Bumps pod template to roll out digest-pinned image after Argo sync.
+        enclii.dev/rollout-revision: "808f430f-prod-surface"
     spec:
       serviceAccountName: dhanam-web
       securityContext:


### PR DESCRIPTION
Rolls dhanam-web pods forward to digest 808f430f (prod NEXT_PUBLIC URLs).

Made with [Cursor](https://cursor.com)