### PR TITLE
fix(k8s): unblock dhanam-web rollout (drop unused secret refs)

### DIFF
--- a/infra/k8s/production/web-deployment.yaml
+++ b/infra/k8s/production/web-deployment.yaml
@@ -32,7 +32,7 @@ spec:
         component: frontend
       annotations:
         # Bumps pod template to roll out digest-pinned image after Argo sync.
-        enclii.dev/rollout-revision: "808f430f-prod-surface"
+        enclii.dev/rollout-revision: "808f430f-no-dead-secret-refs"
     spec:
       serviceAccountName: dhanam-web
       securityContext:
@@ -83,18 +83,9 @@ spec:
             # Janua OAuth API (Required for SSO button visibility)
             - name: NEXT_PUBLIC_JANUA_API_URL
               value: "https://auth.madfam.io"
-            - name: OIDC_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: dhanam-secrets
-                  key: OIDC_CLIENT_SECRET
-            - name: NEXTAUTH_URL
-              value: "https://app.dhan.am"
-            - name: NEXTAUTH_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: dhanam-secrets
-                  key: NEXTAUTH_SECRET
+            # Web auth is Janua PKCE (client-side). Server-side OIDC/NextAuth
+            # secrets live on dhanam-api only; do not mount dhanam-secrets keys
+            # here — ExternalSecret sync gaps must not block web rollouts.
 
             # =================================================================
             # Billing Frontend Configuration


### PR DESCRIPTION
## Summary
- Remove `OIDC_CLIENT_SECRET`, `NEXTAUTH_URL`, and `NEXTAUTH_SECRET` from prod `dhanam-web` — `apps/web` uses Janua client-side PKCE only and never reads these env vars.
- New web pods were stuck in `CreateContainerConfigError` because `dhanam-secrets` ExternalSecret sync is degraded and the keys are absent.
- Bump rollout annotation to roll forward on merge.

## Test plan
- [ ] ArgoCD sync `dhanam-services`
- [ ] `./scripts/production-preflight.sh` passes (no staging URLs on dhan.am)
- [ ] All `dhanam-web` pods on digest `808f430f`


Made with [Cursor](https://cursor.com)