### PR TITLE
fix(infra): defer git ExternalSecret until Vault read works

### DIFF
--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -39,7 +39,7 @@ For execution order and milestone targets, read the
 | TD-1013 | MADFAM operator prod slice     | High     | Active   | ~65%: ledger + budget metadata + admin MADFAM Import UI. Belvo + prod PlatformConfig seed remain.                                                                                                    | [Full Remediation Plan](FULL_REMEDIATION_PLAN_G4_AND_OPERATOR_SLICE.md) |
 | TD-1014 | Production catalog sync ops    | High     | Active   | GitHub Production environment lacks `DATABASE_URL`/Stripe secrets; live catalog drift (e.g. missing `voxa`) until `sync-catalog.ts` runs. Weekly drift workflow + hardened operator runbook shipped. | [Catalog Truth](CATALOG_TRUTH_2026-05-20.md)                            |
 | TD-1015 | Prod public surface URL drift  | High     | Closed   | Staging-built web on prod hostnames fixed via hostname-aware URLs, prod web rebuild on promote, PR #513 rollout, preflight green on `dhan.am` / `app.dhan.am`.                                       | `scripts/production-preflight.sh`                                       |
-| TD-1016 | Vault extended secret backfill | Medium   | Active   | `external-secret-extended.yaml` deferred until Lockbox populates integration keys (SMTP, Banxico, Metamap, Sentry, etc.). Core ES uses Merge policy.                                                 | `infra/k8s/production/external-secret-extended.yaml`                    |
+| TD-1016 | Vault extended secret backfill | High     | Active   | `vault-store` cannot read `secret/dhanam`; git ES removed from kustomization. Platform ES + retained keys interim. Re-enable after Lockbox backfill.                                                 | `infra/k8s/production/external-secret.yaml`                             |
 
 ## Remediation Notes
 
@@ -247,11 +247,18 @@ Fixes shipped:
 
 ### TD-1016: Vault Extended Secret Backfill
 
-The git-managed `dhanam-secrets` ExternalSecret now syncs a **core** property set
-with `creationPolicy: Merge` so missing optional Vault keys no longer fail GitOps.
-Integration keys live in `external-secret-extended.yaml` (not in kustomization)
-until Enclii Lockbox backfills `secret/dhanam` (SMTP, Banxico, Metamap, Sentry,
-Cotiza federation, etc.).
+**Status:** Active
+
+The git-managed `dhanam-secrets` ExternalSecret is **deferred from kustomization**
+because `vault-store` cannot read `secret/dhanam` (`SecretSyncedError`). Until
+Enclii Lockbox backfill restores Vault read access:
+
+- `dhanam-ecosystem-service-auth` (platform ES) continues merging into
+  `dhanam-secrets`.
+- Retained secret keys from the last good sync remain in the cluster.
+- `external-secret.yaml` (core) and `external-secret-extended.yaml` (integration
+  keys) stay in-repo as the target contract; re-add to `kustomization.yaml` after
+  Vault proof.
 
 ## Recently Closed Debt
 

--- a/infra/k8s/production/kustomization.yaml
+++ b/infra/k8s/production/kustomization.yaml
@@ -8,7 +8,9 @@ resources:
 - web-deployment.yaml
 - fx-spot-refresh-cronjob.yaml
 - kyverno-policy-exception.yaml
-- external-secret.yaml
+# Git-managed Vault ES deferred: vault-store cannot read secret/dhanam (TD-1016).
+# Platform ES dhanam-ecosystem-service-auth merges into dhanam-secrets instead.
+# - external-secret.yaml
 - external-secret-janua.yaml
 - network-policies.yaml
 - pdb.yaml


### PR DESCRIPTION
## Summary
- Remove failing git-managed `dhanam-secrets` ExternalSecret from prod kustomization (vault-store cannot read `secret/dhanam`).
- Platform ES `dhanam-ecosystem-service-auth` continues to merge into `dhanam-secrets`.
- Unblocks Argo sync stuck on ExternalSecret + dhanam-web OutOfSync.

## Test plan
- [ ] ArgoCD sync succeeds; health improves from Degraded
- [ ] `./scripts/production-preflight.sh` green


Made with [Cursor](https://cursor.com)