### PR TITLE
feat(billing): route global checkout and catalog sync via MX Stripe account

### DIFF
--- a/.github/workflows/sync-catalog-prod.yml
+++ b/.github/workflows/sync-catalog-prod.yml
@@ -71,9 +71,12 @@ jobs:
           STRIPE_MX_SECRET_KEY: ${{ secrets.STRIPE_MX_SECRET_KEY }}
         run: |
           set -euo pipefail
+          # MX-only model: the Mexico Stripe account settles to BBVA (MXN) and
+          # presents USD/other currencies for global sales. Required: DATABASE_URL
+          # + STRIPE_MX_SECRET_KEY. STRIPE_SECRET_KEY (a separate global account)
+          # is OPTIONAL — only set it once a dedicated global Stripe entity exists.
           missing=()
           [ -z "${DATABASE_URL:-}" ] && missing+=("DATABASE_URL")
-          [ -z "${STRIPE_SECRET_KEY:-}" ] && missing+=("STRIPE_SECRET_KEY")
           [ -z "${STRIPE_MX_SECRET_KEY:-}" ] && missing+=("STRIPE_MX_SECRET_KEY")
           if [ "${#missing[@]}" -gt 0 ]; then
             echo "ERROR: GitHub Production environment is missing secrets: ${missing[*]}"
@@ -81,12 +84,17 @@ jobs:
             echo "Operator fallback: scripts/sync-catalog-prod.md → internal-devops runbook."
             exit 1
           fi
+          if [ -z "${STRIPE_SECRET_KEY:-}" ]; then
+            echo "NOTE: STRIPE_SECRET_KEY (global account) not set — running MX-only. USD prices are created on the MX account (multi-currency presentment)."
+          fi
           echo "::add-mask::$DATABASE_URL"
-          echo "::add-mask::$STRIPE_SECRET_KEY"
           echo "::add-mask::$STRIPE_MX_SECRET_KEY"
           echo "DATABASE_URL=$DATABASE_URL" >> "$GITHUB_ENV"
-          echo "STRIPE_SECRET_KEY=$STRIPE_SECRET_KEY" >> "$GITHUB_ENV"
           echo "STRIPE_MX_SECRET_KEY=$STRIPE_MX_SECRET_KEY" >> "$GITHUB_ENV"
+          if [ -n "${STRIPE_SECRET_KEY:-}" ]; then
+            echo "::add-mask::$STRIPE_SECRET_KEY"
+            echo "STRIPE_SECRET_KEY=$STRIPE_SECRET_KEY" >> "$GITHUB_ENV"
+          fi
 
       - name: Run catalog sync (dry-run)
         if: inputs.dry_run == true

--- a/apps/api/src/modules/billing/gateways/__tests__/payment-gateway.registry.spec.ts
+++ b/apps/api/src/modules/billing/gateways/__tests__/payment-gateway.registry.spec.ts
@@ -1,0 +1,48 @@
+import type { PaymentGatewayPort } from '../payment-gateway.port';
+import type { PaymentGatewayId } from '../payment-gateway.types';
+import { PaymentGatewayRegistry } from '../payment-gateway.registry';
+
+function gateway(id: PaymentGatewayId, configured: boolean): PaymentGatewayPort {
+  return { id, isConfigured: () => configured } as unknown as PaymentGatewayPort;
+}
+
+function makeRegistry(
+  configured: Partial<Record<PaymentGatewayId, boolean>>
+): PaymentGatewayRegistry {
+  return new PaymentGatewayRegistry(
+    gateway('stripe_mx', configured.stripe_mx ?? false),
+    gateway('paddle', configured.paddle ?? false),
+    gateway('conekta', configured.conekta ?? false),
+    gateway('janua', configured.janua ?? false),
+    gateway('legacy_stripe', configured.legacy_stripe ?? false)
+  );
+}
+
+describe('PaymentGatewayRegistry.resolveHybridCheckoutGateway', () => {
+  it('routes Mexico to stripe_mx when configured', () => {
+    expect(makeRegistry({ stripe_mx: true }).resolveHybridCheckoutGateway('MX')).toBe('stripe_mx');
+  });
+
+  it('prefers Paddle (MoR) for international when configured', () => {
+    const registry = makeRegistry({ stripe_mx: true, paddle: true });
+    expect(registry.resolveHybridCheckoutGateway('US')).toBe('paddle');
+    expect(registry.resolveHybridCheckoutGateway('DE')).toBe('paddle');
+  });
+
+  it('falls back international to stripe_mx when Paddle is not configured', () => {
+    const registry = makeRegistry({ stripe_mx: true });
+    expect(registry.resolveHybridCheckoutGateway('US')).toBe('stripe_mx');
+    expect(registry.resolveHybridCheckoutGateway('CO')).toBe('stripe_mx');
+  });
+
+  it('returns null when no hybrid gateway is configured', () => {
+    const registry = makeRegistry({});
+    expect(registry.resolveHybridCheckoutGateway('US')).toBeNull();
+    expect(registry.resolveHybridCheckoutGateway('MX')).toBeNull();
+  });
+
+  it('isHybridCheckoutAvailable reflects resolution', () => {
+    expect(makeRegistry({ stripe_mx: true }).isHybridCheckoutAvailable('US')).toBe(true);
+    expect(makeRegistry({}).isHybridCheckoutAvailable('US')).toBe(false);
+  });
+});

--- a/apps/api/src/modules/billing/gateways/payment-gateway.registry.ts
+++ b/apps/api/src/modules/billing/gateways/payment-gateway.registry.ts
@@ -68,8 +68,17 @@ export class PaymentGatewayRegistry {
     if (normalized === 'MX' && this.isConfigured('stripe_mx')) {
       return 'stripe_mx';
     }
-    if (normalized !== 'MX' && this.isConfigured('paddle')) {
-      return 'paddle';
+    if (normalized !== 'MX') {
+      // International: prefer Paddle (Merchant of Record) once configured; until
+      // then fall back to the Mexico Stripe account (multi-currency presentment,
+      // settles MXN→BBVA) so global card sales work on a single account. This
+      // auto-switches to Paddle MoR when it is provisioned — no further change.
+      if (this.isConfigured('paddle')) {
+        return 'paddle';
+      }
+      if (this.isConfigured('stripe_mx')) {
+        return 'stripe_mx';
+      }
     }
     return null;
   }

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:00956d6d93dfbd8def5e4389e24745261987a0c81897ebfc33ff0d421ebfa336
+    digest: sha256:bb02bb5cc6654b80833a01d9977d56e91da88faf09e2b783bc6d3f364fbe626b
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:18a7c9418f08d304d16dee444197aba05a177ef1d74e43b503fc094b58c63eb0
+    digest: sha256:00956d6d93dfbd8def5e4389e24745261987a0c81897ebfc33ff0d421ebfa336
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/scripts/sync-catalog.ts
+++ b/scripts/sync-catalog.ts
@@ -127,7 +127,11 @@ function log(step: string, msg: string): void {
 
 function getStripeForCurrency(currency: string): Stripe | null {
   if (currency.toUpperCase() === 'MXN') return stripeMx;
-  return stripeGlobal;
+  // Non-MXN (USD, etc.): use the dedicated global account when configured,
+  // otherwise fall back to the MX account. The Mexico account settles to MXN
+  // (BBVA) but can present USD/other currencies — single-account, multi-currency
+  // global selling. Drop the fallback once a dedicated global Stripe entity exists.
+  return stripeGlobal ?? stripeMx;
 }
 
 async function findStripeProduct(stripe: Stripe, slug: string): Promise<Stripe.Product | null> {


### PR DESCRIPTION
## Summary
Enables global selling on the **single Mexico Stripe account** (settles MXN→BBVA, presents USD/other currencies) — deferring a separate global/US Stripe entity.
- `sync-catalog.ts`: non-MXN prices fall back to the MX account when no dedicated global account is configured.
- `sync-catalog-prod` workflow: require only `STRIPE_MX_SECRET_KEY` (global `STRIPE_SECRET_KEY` optional).
- gateway registry: international checkout falls back to **Stripe MX** until **Paddle (MoR)** is configured, then auto-prefers Paddle.

## Validation
Pre-commit lint/typecheck/affected-tests passed locally. No live checkout fires until the Step-4 `FEATURE_STRIPE_MXN_LIVE` flip.
