### PR TITLE
ci(catalog): run prod catalog sync on in-cluster ARC runner

### DIFF
--- a/.github/workflows/sync-catalog-prod.yml
+++ b/.github/workflows/sync-catalog-prod.yml
@@ -34,7 +34,11 @@ concurrency:
 jobs:
   sync:
     name: sync-catalog.ts
-    runs-on: ubuntu-latest
+    # The prod DB is only reachable in-cluster (postgres.data.svc.cluster.local),
+    # so run on the self-hosted ARC runner when bootstrapped; GitHub-hosted
+    # runners cannot resolve cluster DNS. Falls back to ubuntu-latest pre-ARC
+    # (dry-run still works there; live sync requires the in-cluster runner).
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     environment: Production
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Prod Postgres is in-cluster only; GitHub-hosted runners get EAI_AGAIN. Route to self-hosted madfam-runners-blue when ARC bootstrapped (matches commercial-ga-proof). arc-runner-egress already permits cluster + Stripe + npm egress.

Made with [Cursor](https://cursor.com)