### PR TITLE
feat(catalog): in-cluster catalog-sync job + ship sync script in image

### DIFF
--- a/.github/workflows/sync-catalog-prod.yml
+++ b/.github/workflows/sync-catalog-prod.yml
@@ -34,7 +34,11 @@ concurrency:
 jobs:
   sync:
     name: sync-catalog.ts
-    runs-on: ubuntu-latest
+    # The prod DB is only reachable in-cluster (postgres.data.svc.cluster.local),
+    # so run on the self-hosted ARC runner when bootstrapped; GitHub-hosted
+    # runners cannot resolve cluster DNS. Falls back to ubuntu-latest pre-ARC
+    # (dry-run still works there; live sync requires the in-cluster runner).
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     environment: Production
     steps:
       - uses: actions/checkout@v4

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -90,6 +90,10 @@ COPY --from=builder --chown=nestjs:nodejs /app/apps/api/prisma ./apps/api/prisma
 COPY --from=builder --chown=nestjs:nodejs /app/apps/api/generated ./apps/api/generated
 COPY --from=builder --chown=nestjs:nodejs /app/apps/api/package.json ./apps/api/package.json
 COPY --from=builder --chown=nestjs:nodejs /app/catalog.yaml ./catalog.yaml
+# Ops script for the in-cluster catalog sync job (catalog-sync-job.yaml). It
+# reads /app/catalog.yaml and imports the generated Prisma client at
+# apps/api/generated; tsx (devDep) is already present in apps/api/node_modules.
+COPY --from=builder --chown=nestjs:nodejs /app/scripts/sync-catalog.ts ./scripts/sync-catalog.ts
 # prisma.config.ts needed for `prisma migrate deploy` in container
 COPY --from=builder --chown=nestjs:nodejs /app/apps/api/prisma.config.ts ./apps/api/prisma.config.ts
 

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:bb02bb5cc6654b80833a01d9977d56e91da88faf09e2b783bc6d3f364fbe626b
+    digest: sha256:f536607b77042bea8d1c3c1b5e0666f4b78cf4c203a9ce66d74ed49df16e1aef
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/infra/k8s/production/catalog-sync-job.yaml
+++ b/infra/k8s/production/catalog-sync-job.yaml
@@ -1,0 +1,117 @@
+# In-cluster catalog sync (on-demand).
+#
+# Why this exists: scripts/sync-catalog.ts writes to the production Postgres,
+# which is reachable ONLY from inside the cluster (postgres.data.svc.cluster.local)
+# and admits only its consumer namespaces. CI runners cannot reach it
+# (GitHub-hosted = no cluster DNS; arc-runners = blocked by the Postgres ingress
+# NetworkPolicy). Running here, in the dhanam namespace, the DB + billing secrets
+# resolve exactly as they do for dhanam-api.
+#
+# Suspended by design — it never runs on a schedule. An operator triggers it:
+#
+#   kubectl -n dhanam create job catalog-sync-$(date +%Y%m%d-%H%M) \
+#     --from=cronjob/dhanam-catalog-sync
+#   kubectl -n dhanam logs -f job/catalog-sync-<stamp>
+#
+# Prereq: dhanam-billing-secrets must hold the live STRIPE_MX_SECRET_KEY (Step 3A),
+# otherwise the sync writes DB rows but skips Stripe price creation.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: dhanam-catalog-sync
+  namespace: dhanam
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  labels:
+    app: dhanam-catalog-sync
+    app.kubernetes.io/component: ops-job
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/part-of: dhanam-billing
+spec:
+  # On-demand only: suspended, and a never-occurring schedule (Feb 31) as a guard.
+  suspend: true
+  schedule: "0 0 31 2 *"
+  timeZone: "Etc/UTC"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 86400
+      activeDeadlineSeconds: 600
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: dhanam-catalog-sync
+            app.kubernetes.io/component: ops-job
+            app.kubernetes.io/part-of: dhanam-billing
+        spec:
+          serviceAccountName: dhanam-api
+          restartPolicy: Never
+          imagePullSecrets:
+            - name: ghcr-credentials
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            fsGroup: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: sync
+              image: dhanam-api
+              imagePullPolicy: Always
+              workingDir: /app/apps/api
+              command:
+                - sh
+                - -lc
+                - |
+                  echo "[catalog-sync] running scripts/sync-catalog.ts in-cluster (live)"
+                  exec /app/apps/api/node_modules/.bin/tsx /app/scripts/sync-catalog.ts
+              env:
+                - name: NODE_ENV
+                  value: "production"
+                - name: TMPDIR
+                  value: /tmp
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: dhanam-secrets
+                      key: DATABASE_URL
+                # MXN prices (Mexico account, settles to BBVA). Required for Stripe
+                # price creation; if absent the sync does DB-only.
+                - name: STRIPE_MX_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: dhanam-billing-secrets
+                      key: STRIPE_MX_SECRET_KEY
+                # Optional global account; when unset, USD prices fall back to the
+                # MX account (single-account multi-currency).
+                - name: STRIPE_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: dhanam-billing-secrets
+                      key: STRIPE_SECRET_KEY
+                      optional: true
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+              securityContext:
+                privileged: false
+                allowPrivilegeEscalation: false
+                # tsx/esbuild needs a writable fs for transient compilation.
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: tmp
+              emptyDir: {}

--- a/infra/k8s/production/kustomization.yaml
+++ b/infra/k8s/production/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - admin-deployment.yaml
 - web-deployment.yaml
 - fx-spot-refresh-cronjob.yaml
+- catalog-sync-job.yaml
 - kyverno-policy-exception.yaml
 # Git-managed Vault ES deferred: vault-store cannot read secret/dhanam (TD-1016).
 # Platform ES dhanam-ecosystem-service-auth merges into dhanam-secrets instead.


### PR DESCRIPTION
Prod Postgres is in-cluster only; CI runners can't reach it (Postgres ingress netpol). Run the sync in the dhanam namespace instead. Ships scripts/sync-catalog.ts in the dhanam-api image (tsx/catalog.yaml/Prisma client already present) and adds a suspended on-demand `dhanam-catalog-sync` CronJob. Operator: `kubectl -n dhanam create job catalog-sync-$(date +%s) --from=cronjob/dhanam-catalog-sync` after Step 3A. Validated with kustomize build (image digest-pinned).

Made with [Cursor](https://cursor.com)