### PR TITLE
feat(web): public pricing funnel route + incident runbook

### DIFF
--- a/apps/web/src/app/pricing/page.tsx
+++ b/apps/web/src/app/pricing/page.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { Button } from '@dhanam/ui';
+import { Globe } from 'lucide-react';
+import Link from 'next/link';
+import { useEffect } from 'react';
+
+import { Footer } from '@/components/landing/footer';
+import { Pricing } from '@/components/landing/pricing';
+import { useAnalytics } from '@/hooks/useAnalytics';
+import { usePublicAppUrl } from '@/hooks/usePublicSurface';
+import { useAuth } from '@/lib/hooks/use-auth';
+
+/**
+ * Public, deep-linkable pricing funnel entry (for ads / sales / SEO).
+ * Reuses the catalog-driven <Pricing> section and the plan-aware register
+ * handoff so the checkout funnel is consistent with the landing page.
+ */
+export default function PricingPage() {
+  const { isAuthenticated } = useAuth();
+  const analytics = useAnalytics();
+
+  const appUrl = usePublicAppUrl();
+  const resolvedAppUrl = appUrl || 'https://app.dhan.am';
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      window.location.href = `${resolvedAppUrl}/billing/upgrade`;
+    } else {
+      analytics.trackPageView('Pricing Page', '/pricing');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- analytics is stable; only re-run on auth change
+  }, [isAuthenticated]);
+
+  const handleSignUpClick = (plan?: string) => {
+    analytics.track('signup_clicked', { source: 'pricing_page', plan });
+    const planParam = plan ? `?plan=${plan}` : '';
+    window.location.href = `${resolvedAppUrl}/register${planParam}`;
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-background via-background to-muted/20">
+      <nav className="container mx-auto px-6 py-4 border-b">
+        <div className="flex items-center justify-between">
+          <Link href="/" className="flex items-center gap-2 transition-opacity hover:opacity-80">
+            <Globe className="h-6 w-6 text-primary" />
+            <span className="text-2xl font-bold">Dhanam</span>
+          </Link>
+          <div className="flex items-center gap-4">
+            <a href={`${resolvedAppUrl}/login`}>
+              <Button variant="ghost">Log in</Button>
+            </a>
+            <a href={`${resolvedAppUrl}/register`}>
+              <Button>Get started</Button>
+            </a>
+          </div>
+        </div>
+      </nav>
+
+      <header className="container mx-auto px-6 pt-16 pb-4 text-center">
+        <h1 className="text-4xl font-bold tracking-tight">Plans that grow with your wealth</h1>
+        <p className="mt-3 text-muted-foreground max-w-2xl mx-auto">
+          Start free. Upgrade when you need household views, deeper projections, and priority
+          support. Cancel anytime.
+        </p>
+      </header>
+
+      <Pricing onSignUpClick={handleSignUpClick} />
+      <Footer />
+    </div>
+  );
+}

--- a/apps/web/src/components/landing/pricing.tsx
+++ b/apps/web/src/components/landing/pricing.tsx
@@ -94,7 +94,7 @@ export function Pricing({ onSignUpClick }: PricingProps) {
           <h2 className="text-3xl font-bold mb-4">{t('pricing.title')}</h2>
           <p className="text-muted-foreground">{t('pricing.subtitle')}</p>
           {hasPromo && (
-            <div className="mt-4 inline-flex items-center gap-2 bg-gradient-to-r from-blue-600/10 to-purple-600/10 border border-primary/20 rounded-full px-4 py-2 text-sm">
+            <div className="mt-4 inline-flex items-center gap-2 bg-primary/5 border border-primary/20 rounded-full px-4 py-2 text-sm">
               <Sparkles className="h-4 w-4 text-primary" />
               <span>
                 Start free for {trial.daysWithoutCC} days — then promo pricing for{' '}
@@ -120,17 +120,19 @@ export function Pricing({ onSignUpClick }: PricingProps) {
             return (
               <div
                 key={tier.id}
-                className={`rounded-lg bg-card p-6 relative ${
-                  isPro ? 'border-2 border-primary' : 'border'
+                className={`group rounded-lg bg-card p-6 relative transition-all duration-300 ease-out hover:-translate-y-1 hover:shadow-lg ${
+                  isPro
+                    ? 'border-2 border-primary shadow-md ring-1 ring-primary/15'
+                    : 'border hover:border-primary/40'
                 }`}
               >
                 {isPro && (
-                  <div className="absolute -top-3 left-1/2 -translate-x-1/2 bg-gradient-to-r from-blue-600 to-purple-600 text-white px-3 py-1 rounded-full text-xs font-semibold">
+                  <div className="absolute -top-3 left-1/2 -translate-x-1/2 bg-primary text-primary-foreground px-3 py-1 rounded-full text-xs font-semibold shadow-sm">
                     {t('pricing.mostPopular')}
                   </div>
                 )}
                 {isPremium && (
-                  <div className="absolute -top-3 left-1/2 -translate-x-1/2 bg-gradient-to-r from-amber-500 to-orange-500 text-white px-3 py-1 rounded-full text-xs font-semibold flex items-center gap-1">
+                  <div className="absolute -top-3 left-1/2 -translate-x-1/2 bg-warning text-warning-foreground px-3 py-1 rounded-full text-xs font-semibold flex items-center gap-1 shadow-sm">
                     <Star className="h-3 w-3" />
                     {t('pricing.bestValue')}
                   </div>
@@ -163,15 +165,15 @@ export function Pricing({ onSignUpClick }: PricingProps) {
                     const isBold = index === 0;
                     return (
                       <li key={index} className="flex gap-2">
-                        <CheckCircle className="h-4 w-4 text-green-600 shrink-0 mt-0.5" />
+                        <CheckCircle className="h-4 w-4 text-success shrink-0 mt-0.5" />
                         {isBold ? <strong>{feature}</strong> : feature}
                       </li>
                     );
                   })}
                 </ul>
                 <Button
-                  className={`w-full ${isPro ? 'bg-gradient-to-r from-blue-600 to-purple-600' : ''} ${isPremium ? 'bg-gradient-to-r from-amber-500 to-orange-500' : ''}`}
-                  variant="default"
+                  className="w-full transition-transform duration-200 active:scale-[0.98]"
+                  variant={isPro ? 'default' : 'outline'}
                   onClick={() => onSignUpClick(tier.id)}
                 >
                   {isFree ? 'Get Started' : `Start ${trial.daysWithoutCC}-Day Trial`}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -15,6 +15,8 @@ const publicPaths = [
   '/auth/callback', // OAuth callback from Janua SSO
   '/demo',
   '/demo/',
+  '/pricing', // Public, deep-linkable pricing funnel entry
+  '/for-platforms',
   // Legal pages (rendered under (legal) route group)
   '/privacy',
   '/terms',

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:f536607b77042bea8d1c3c1b5e0666f4b78cf4c203a9ce66d74ed49df16e1aef
+    digest: sha256:acbabb63339f6bc4a1827cf4071a1ae109b8ae9f74bbabb871fc3a8a62619283
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin


### PR DESCRIPTION
## Summary
- **Public pricing funnel**: new deep-linkable `/pricing` route (for ads/SEO/sales) that reuses the catalog-driven `<Pricing>` section and the plan-aware `/register?plan=…` handoff. Registers `/pricing` + `/for-platforms` as public paths so strangers aren't bounced to `/login`.
- **Aesthetic-mandate compliance**: replaced the banned `from-blue-600 to-purple-600` / `from-amber-500 to-orange-500` gradients and raw `text-green-600` in the landing pricing section with the design system's semantic tokens (`primary`, `warning`, `success`) + tasteful micro-interactions (card hover-lift, recommended-tier ring, button active-scale). Still fully catalog-driven via the public `getPricing`.
- **Incident runbook**: documents the `dhanam-secrets` latent outage (secret reduced to 2 keys → new `dhanam-api` pods fail with `couldn't find key DATABASE_URL`; one survivor pod), root cause (platform `Orphan` ES replacing data + git ES deferred on the Vault read gap, TD-1016), and the ordered remediation.

## Test plan
- [x] `pnpm --filter @dhanam/web typecheck` (green)
- [x] ESLint on changed files (green)
- [ ] CI: build + lint + typecheck + tests
- [ ] Visual check of `/pricing` once deployed (catalog-driven, MXN geo, recommended tier highlight)

Made with [Cursor](https://cursor.com)