### PR TITLE
fix(web): Try Live Demo opens the persona picker (no auto-guest)

### DIFF
--- a/apps/web/src/app/[locale]/landing/page.tsx
+++ b/apps/web/src/app/[locale]/landing/page.tsx
@@ -43,7 +43,8 @@ export default function LocaleLandingPage() {
 
   const handleLiveDemoClick = () => {
     analytics.track('live_demo_clicked', { source: 'hero_cta', locale });
-    redirectToAppDemo(appUrl, 'guest');
+    // No forced persona — land on the picker so the visitor chooses their path.
+    redirectToAppDemo(appUrl);
   };
 
   const handleSignUpClick = (plan?: string) => {

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -37,7 +37,8 @@ function HomePageContent() {
 
   const handleLiveDemoClick = () => {
     analytics.track('live_demo_clicked', { source: 'hero_cta' });
-    redirectToAppDemo(resolvedAppUrl, 'guest');
+    // No forced persona — land on the picker so the visitor chooses their path.
+    redirectToAppDemo(resolvedAppUrl);
   };
 
   const handleSignUpClick = (plan?: string) => {

--- a/apps/web/src/lib/demo/launch-demo.test.ts
+++ b/apps/web/src/lib/demo/launch-demo.test.ts
@@ -12,4 +12,9 @@ describe('buildAppDemoLaunchUrl', () => {
       'https://app.dhan.am/demo?persona=maria'
     );
   });
+
+  it('points at the persona picker (no query) when persona is omitted', () => {
+    expect(buildAppDemoLaunchUrl('https://app.dhan.am')).toBe('https://app.dhan.am/demo');
+    expect(buildAppDemoLaunchUrl('https://app.dhan.am/')).toBe('https://app.dhan.am/demo');
+  });
 });

--- a/apps/web/src/lib/demo/launch-demo.ts
+++ b/apps/web/src/lib/demo/launch-demo.ts
@@ -1,14 +1,21 @@
 /**
  * Marketing-site demo CTA must start auth on app.dhan.am — localStorage and
  * API client state do not cross from dhan.am to app.dhan.am.
+ *
+ * When `persona` is omitted, the URL points at the demo persona picker so the
+ * visitor chooses their own path. When a specific persona is provided (e.g. a
+ * landing persona card), the picker auto-launches that persona.
  */
-export function buildAppDemoLaunchUrl(appUrl: string, persona = 'guest'): string {
+export function buildAppDemoLaunchUrl(appUrl: string, persona?: string): string {
   const base = appUrl.replace(/\/$/, '');
+  if (!persona) {
+    return `${base}/demo`;
+  }
   const params = new URLSearchParams({ persona });
   return `${base}/demo?${params.toString()}`;
 }
 
 /** Full-page navigation to app demo entrypoint (mockable in jsdom tests). */
-export function redirectToAppDemo(appUrl: string, persona = 'guest'): void {
+export function redirectToAppDemo(appUrl: string, persona?: string): void {
   window.location.href = buildAppDemoLaunchUrl(appUrl, persona);
 }

--- a/apps/web/test/integration/landing-demo-flow.test.tsx
+++ b/apps/web/test/integration/landing-demo-flow.test.tsx
@@ -148,7 +148,7 @@ describe('Landing Page Demo Flow', () => {
       const demoButtons = screen.getAllByRole('button', { name: /Try Live Demo/i });
       fireEvent.click(demoButtons[0]!);
 
-      expect(mockRedirectToAppDemo).toHaveBeenCalledWith('https://app.dhan.am', 'guest');
+      expect(mockRedirectToAppDemo).toHaveBeenCalledWith('https://app.dhan.am');
       expect(mockAuthApi.loginAsGuest).not.toHaveBeenCalled();
     });
 
@@ -239,7 +239,7 @@ describe('Landing Page Demo Flow', () => {
 
       fireEvent.click(demoButtons[1]!);
 
-      expect(mockRedirectToAppDemo).toHaveBeenCalledWith('https://app.dhan.am', 'guest');
+      expect(mockRedirectToAppDemo).toHaveBeenCalledWith('https://app.dhan.am');
     });
   });
 });


### PR DESCRIPTION
## Problem
On https://dhan.am/en, clicking **Try Live Demo** redirected to `app.dhan.am/demo?persona=guest`, and the `/demo` page **auto-launches any valid `?persona=` on mount** — so visitors were dropped straight into the guest dashboard, never seeing the 5-persona picker.

## Root cause
The generic CTA (`handleLiveDemoClick` in the root + locale landing pages) called `redirectToAppDemo(appUrl, 'guest')`, hard-coding `persona=guest`. The `/demo` page's mount effect then calls `handlePersonaClick('guest')` → instant login + `/dashboard`.

## Fix
- `buildAppDemoLaunchUrl` / `redirectToAppDemo`: `persona` is now optional; when omitted, the URL is just `/demo` (the picker).
- Both landing pages' "Try Live Demo" CTA now call `redirectToAppDemo(appUrl)` (no forced persona) → visitor lands on the picker and chooses their path.
- Landing **persona cards keep their intentional deep-link** (`?persona=maria`, etc.) → those still auto-launch the chosen persona.

## Test plan
- [x] `pnpm --filter @dhanam/web typecheck`
- [x] Unit test added: `buildAppDemoLaunchUrl` omits the query when no persona is given
- [ ] Manual: Try Live Demo → persona picker (not auto-dashboard); a persona card → still auto-launches that persona

Made with [Cursor](https://cursor.com)