### PR TITLE
chore(deps): hold Stripe major in Dependabot until upstream fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,6 +66,18 @@ updates:
     labels:
       - "dependencies"
       - "api"
+    ignore:
+      # Stripe 22.x breaks the API typecheck via the upstream stripe-node#2683
+      # issue (Stripe.* namespace types under CommonJS + tsc). Hold on the
+      # supported 20.x line until the upstream fix lands or we schedule a
+      # dedicated module-resolution (ESM) migration, then bump deliberately.
+      - dependency-name: "stripe"
+        update-types: ["version-update:semver-major"]
+    groups:
+      api-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   # Web workspace
   - package-ecosystem: "npm"


### PR DESCRIPTION
Adds a Dependabot `ignore` for `stripe` semver-major in `/apps/api` (broken by upstream stripe-node#2683 under CommonJS+tsc; we run the supported 20.x) and groups API minor/patch updates to reduce PR churn. Config-only.

Made with [Cursor](https://cursor.com)