### PR TITLE
docs(monetization): add self-guiding session entrypoint for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,11 @@ redirect and should not become the source of truth again.
 - `README.md`
 - `ECOSYSTEM.md`
 - `docs/`
-- `docs/STABILITY_WRAP_UP_2026-05-20.md`
-- `docs/GA_REMEDIATION_ROADMAP.md`
+- **Monetization sessions:** `docs/MONETIZATION_SESSION.md` →
+  `docs/MONETIZATION_PATH_READINESS.md` →
+  `docs/FIRST_PESOS_COMMERCIAL_GA_MONETIZATION_2026-06-01.md`
+- **Stability / GA (non-revenue):** `docs/GA_REMEDIATION_ROADMAP.md`,
+  `docs/STABILITY_WRAP_UP_2026-05-20.md`
 - `infra/`
 - `.github/workflows/`
 
@@ -87,6 +90,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Pricing & PMF Anchoring
 
+- **Monetization sessions:** start at [`docs/MONETIZATION_SESSION.md`](docs/MONETIZATION_SESSION.md) →
+  [`docs/MONETIZATION_PATH_READINESS.md`](docs/MONETIZATION_PATH_READINESS.md).
 - **Pricing source-of-truth**: `internal-devops/decisions/2026-04-25-tulana-ecosystem-pricing.md`. Dhanam Consumer tiers (Tulana v0.1 recommended, MXN/mo): Free $0 / Copilot Pro 199 / Family Plus 499 / Teams (B2B) 1,499. Plus Dhanam B2B Platform Billing tiers: Starter $0+3.5% / Scale 499+2.5% / Enterprise 2,999+1.5%. Confidence: low — needs validation with real users.
 - **Note**: Dhanam IS the billing platform for the MADFAM ecosystem — it consumes PMF data from Tulana but its own pricing is anchored by Tulana too (no self-anchoring).
 - **PMF measurement**: per RFC 0013, NPS + Sean Ellis + retention via `@madfam/pmf-widget` → Tulana `/v1/pmf/*` endpoints. Composite PMF Score informs price moves + sunset decisions.

--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ Comprehensive documentation is available in the [`docs/`](docs/) directory:
 
 This project provides machine-readable context files for LLM agents:
 
+- [`docs/MONETIZATION_SESSION.md`](docs/MONETIZATION_SESSION.md) — **Monetization session entrypoint** (first revenue, checkout, billing)
 - [`llms.txt`](llms.txt) — Concise project overview with documentation links ([llmstxt.org spec](https://llmstxt.org/))
 - [`llms-full.txt`](llms-full.txt) — Expanded version with inlined critical content
 - [`AGENTS.md`](AGENTS.md) — Canonical agent operating instructions

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -7,6 +7,12 @@ open `docs/INDEX.md`.
 
 ## Primary Entry Points
 
+- [Monetization Session](MONETIZATION_SESSION.md) - **agent entrypoint** for first
+  revenue, checkout, billing, catalog, and entitlement work
+- [Monetization Path Readiness](MONETIZATION_PATH_READINESS.md) - current gate
+  table, shipped work, ranked open tasks
+- [First Pesos Commercial GA](FIRST_PESOS_COMMERCIAL_GA_MONETIZATION_2026-06-01.md) -
+  G0–G9 framework and first-peso proof bar
 - [Repository README](../README.md) - product overview and quick start
 - [Development Guide](DEVELOPMENT.md) - local setup, ports, commands, tests
 - [GA Remediation Roadmap](GA_REMEDIATION_ROADMAP.md) - full stability and GA program

--- a/docs/MONETIZATION_PATH_READINESS.md
+++ b/docs/MONETIZATION_PATH_READINESS.md
@@ -1,6 +1,9 @@
 # Monetization-Path Readiness — Dhanam
 
-**Last Updated:** 2026-06-14
+**Last Updated:** 2026-06-14  
+**Agent entrypoint:** [`MONETIZATION_SESSION.md`](MONETIZATION_SESSION.md) — read that
+file first for session routing and the private ops boundary.
+
 **Scope:** Dhanam's execution slice toward first MXN revenue. Pairs with
 `docs/FIRST_PESOS_COMMERCIAL_GA_MONETIZATION_2026-06-01.md` (the G0–G9 gate
 framework) and the cross-repo sequence in
@@ -54,19 +57,20 @@ are Phase 1, not the first transaction.
 > degradation is currently blocking new deploys, the catalog sync, and the
 > payment path (`dhanam-api` is serving on a single pod). Remediation and the
 > sequenced first-peso cutover are tracked privately in `internal-devops`:
-> `runbooks/2026-06-13-dhanam-secrets-degradation-incident.md` and
+> `runbooks/MONETIZATION_OPS_SESSION.md` (ops entrypoint),
+> `runbooks/2026-06-13-dhanam-secrets-degradation-incident.md`, and
 > `runbooks/2026-06-14-dhanam-first-peso-cutover.md`. Unblocking is Vault/ESO +
 > Stripe-MX/BBVA provisioning — no repo change clears it.
 
 ## Gates Dhanam owns (G0–G9)
 
-| Gate                     | Status | Dhanam action to close                                                                           |
-| ------------------------ | ------ | ------------------------------------------------------------------------------------------------ |
-| G0 Catalog truth         | Ready  | Keep `catalog.yaml` the single source; re-run `sync-catalog.ts` after the Free tier              |
-| G1 Pricing evidence      | Ready  | Apply Tulana proposals (see `tulana/docs/dhanam-pricing-readiness-2026-06-13.md`)                |
+| Gate                     | Status | Dhanam action to close                                                                                  |
+| ------------------------ | ------ | ------------------------------------------------------------------------------------------------------- |
+| G0 Catalog truth         | Ready  | Keep `catalog.yaml` the single source; re-run `sync-catalog.ts` after the Free tier                     |
+| G1 Pricing evidence      | Ready  | Apply Tulana proposals (see `tulana/docs/dhanam-pricing-readiness-2026-06-13.md`)                       |
 | G5 Live checkout         | OPEN   | UI shipped (#522); flip `FEATURE_STRIPE_MXN_LIVE` after Stripe MX live + secret restore (runbook below) |
-| G6 Payment + ledger      | OPEN   | Prove one idempotent `BillingEvent` per payment, no duplicate revenue                            |
-| G7 Entitlement + fan-out | OPEN   | Activate paid tier/credits + signed product webhook; close Karafiel CFDI staging proof (TD-1010) |
+| G6 Payment + ledger      | OPEN   | Prove one idempotent `BillingEvent` per payment, no duplicate revenue                                   |
+| G7 Entitlement + fan-out | OPEN   | Activate paid tier/credits + signed product webhook; close Karafiel CFDI staging proof (TD-1010)        |
 
 (G2–G4 Selva/PhyndCRM, G8 BBVA, G9 Converge are owned outside this repo.)
 

--- a/docs/MONETIZATION_SESSION.md
+++ b/docs/MONETIZATION_SESSION.md
@@ -1,0 +1,106 @@
+# Monetization Session — Agent Entrypoint
+
+**Last Updated:** 2026-06-14  
+**Scope:** Open **dhanam alone** for monetization engineering. This file is the
+single in-repo routing index — read it before GA/stability docs unless the task
+is explicitly stability-only.
+
+## Position
+
+Dhanam is the ecosystem **cash register**: sole Stripe-key holder, catalog/checkout/
+ledger/entitlement authority, and billing rails every product sells through. Code
+readiness is **high**; first-revenue readiness is **medium-low** because binding
+constraints are operational (secret store, Stripe MX live, BBVA payout), not missing
+CRUD.
+
+The fastest meaningful first peso is a **high-ticket B2B SKU on Dhanam rails**
+(`karafiel__contador`, MXN 1,299/mo), not the low-ticket consumer tiers.
+
+## Read order (monetization sessions)
+
+1. **`AGENTS.md`** — operating doctrine, side-effect guards, Janua/Enclii contracts.
+2. **This file** — session routing and repo vs private ops boundary.
+3. **[MONETIZATION_PATH_READINESS.md](MONETIZATION_PATH_READINESS.md)** — current
+   gate table (G0–G9 slice Dhanam owns), shipped work, ranked open tasks.
+4. **[FIRST_PESOS_COMMERCIAL_GA_MONETIZATION_2026-06-01.md](FIRST_PESOS_COMMERCIAL_GA_MONETIZATION_2026-06-01.md)** —
+   full G0–G9 framework and first-peso proof requirements.
+5. Task-specific runbooks and modules (below).
+
+For stability-only work (unrelated to revenue), use
+[GA_REMEDIATION_ROADMAP.md](GA_REMEDIATION_ROADMAP.md) instead of this index.
+
+## In-repo execution map
+
+| Task                               | Start here                                                                                                                                               |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Gate status + ranked backlog       | [MONETIZATION_PATH_READINESS.md](MONETIZATION_PATH_READINESS.md)                                                                                         |
+| G0–G9 framework + proof bar        | [FIRST_PESOS_COMMERCIAL_GA_MONETIZATION_2026-06-01.md](FIRST_PESOS_COMMERCIAL_GA_MONETIZATION_2026-06-01.md)                                             |
+| Flip live MXN checkout             | [runbooks/STRIPE_MXN_LIVE_FLIP.md](runbooks/STRIPE_MXN_LIVE_FLIP.md)                                                                                     |
+| Staging commercial smoke (WS1–WS6) | [COMMERCIAL_GA_EXECUTION.md](COMMERCIAL_GA_EXECUTION.md)                                                                                                 |
+| Catalog authoring + sync           | [`catalog.yaml`](../catalog.yaml), [`scripts/sync-catalog.ts`](../scripts/sync-catalog.ts), [CATALOG_TRUTH_2026-05-20.md](CATALOG_TRUTH_2026-05-20.md)   |
+| Billing API + webhooks             | [apps/api/src/modules/billing/README.md](../apps/api/src/modules/billing/README.md), [packages/billing-sdk/README.md](../packages/billing-sdk/README.md) |
+| Production checkout UI             | `apps/web` — `/pricing`, `/register`, billing checkout routes                                                                                            |
+| Active monetization debt           | [TECH_DEBT.md](TECH_DEBT.md) — TD-1009, TD-1010, TD-1014                                                                                                 |
+| Tulana SKU handoff                 | [TULANA_SKU_AND_CATALOG_HANDOFF_2026-05-29.md](TULANA_SKU_AND_CATALOG_HANDOFF_2026-05-29.md)                                                             |
+| DLQ / replay drill                 | [runbooks/COMMERCIAL_DLQ_DRILL.md](runbooks/COMMERCIAL_DLQ_DRILL.md)                                                                                     |
+| Break-glass (Enclii gap)           | [runbooks/BREAK_GLASS.md](runbooks/BREAK_GLASS.md)                                                                                                       |
+
+## Code anchors
+
+```
+catalog.yaml                          # SKU source of truth (authoring)
+scripts/sync-catalog.ts               # Stripe + DB catalog sync
+apps/api/src/modules/billing/         # Checkout, ledger, webhooks, entitlements
+apps/web/src/app/                     # Public pricing + register funnel
+packages/billing-sdk/                 # Ecosystem billing client
+infra/k8s/production/                 # Deploy manifests (ExternalSecret commented — see ops)
+```
+
+Verify catalog edits:
+
+```sh
+npx tsx scripts/sync-catalog.ts --dry-run
+```
+
+## Private ops boundary (not in this repo)
+
+Routine production cutover, Vault/ESO remediation, and cross-repo sequencing live
+in **`internal-devops`**. Open that repo (alone or beside dhanam) when the session
+touches Phase 0 platform blockers or operator cutover — not for app feature work.
+
+| Aspect                             | Canonical private path                                                       |
+| ---------------------------------- | ---------------------------------------------------------------------------- |
+| **Private ops session entrypoint** | `internal-devops/runbooks/MONETIZATION_OPS_SESSION.md`                       |
+| Cross-repo first-peso sequencing   | `internal-devops/roadmaps/2026-06-13-first-pesos-execution-roadmap.md`       |
+| Operator cutover (Phases 0–5)      | `internal-devops/runbooks/2026-06-14-dhanam-first-peso-cutover.md`           |
+| Secret-store degradation (OPEN)    | `internal-devops/runbooks/2026-06-13-dhanam-secrets-degradation-incident.md` |
+| Full ecosystem money architecture  | `internal-devops/ecosystem/monetization-architecture-2026-04-26.md`          |
+
+**Phase 0 gate (2026-06-14):** `vault-store` ClusterSecretStore validation failure
+blocks full `dhanam-secrets` sync, new deploys, catalog sync, and live checkout.
+No dhanam repo change clears this — fix Vault/ESO first (private runbook above).
+
+## Adjacent repos (pull in only when needed)
+
+| Repo                | When                                                         |
+| ------------------- | ------------------------------------------------------------ |
+| `internal-devops`   | Vault/secrets restore, first-peso cutover, Stripe MX KYC ops |
+| `tulana`            | G1 pricing evidence finalization                             |
+| `karafiel`          | TD-1010 CFDI staging proof                                   |
+| `solarpunk-foundry` | `@madfam/webhook-attribution` shared contract                |
+| `enclii`            | Platform GA, Postgres HA — not first-peso product work       |
+| `janua`             | Auth/OAuth only — never holds money                          |
+
+## Session routing (quick)
+
+| You are…                                           | Primary repo                                  |
+| -------------------------------------------------- | --------------------------------------------- |
+| Shipping checkout, billing, catalog, entitlements  | **dhanam** (this file)                        |
+| Fixing Vault / restoring secrets / running cutover | **internal-devops** + dhanam for verification |
+| Finalizing SKU prices                              | **tulana** → apply in dhanam `catalog.yaml`   |
+
+## Related public docs
+
+- [docs/README.md](README.md) — full documentation map
+- [llms.txt](../llms.txt) — compact LLM index (monetization-first)
+- [llms-full.txt](../llms-full.txt) — durable agent context map

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,29 @@
 # Dhanam Documentation
 
-Last updated: 2026-05-29
+Last updated: 2026-06-14
 
 This is the canonical human and agent documentation map for Dhanam. Prefer this
 file over older phase summaries when choosing what to read first.
+
+## Monetization and First Peso
+
+For revenue, checkout, billing, catalog, or entitlement work, start here — not the
+GA/stability section below.
+
+| Document                                                                          | Use                                                                                 |
+| --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| [Monetization Session](MONETIZATION_SESSION.md)                                   | **Agent entrypoint** — read order, code anchors, private ops boundary               |
+| [Monetization Path Readiness](MONETIZATION_PATH_READINESS.md)                     | Current gate table (G0–G9 slice), shipped work, ranked open tasks                   |
+| [First Pesos Commercial GA](FIRST_PESOS_COMMERCIAL_GA_MONETIZATION_2026-06-01.md) | Full G0–G9 framework and first-peso proof bar                                       |
+| [Stripe MXN Live Flip](runbooks/STRIPE_MXN_LIVE_FLIP.md)                          | Operator runbook to enable live MXN checkout                                        |
+| [Catalog Truth 2026-05-20](CATALOG_TRUTH_2026-05-20.md)                           | Product catalog drift gate and production sync truth                                |
+| [Tulana SKU and Catalog Handoff](TULANA_SKU_AND_CATALOG_HANDOFF_2026-05-29.md)    | Tulana readiness, billing catalogue mirror, and Selva-approved price apply contract |
+| [Commercial GA Execution](COMMERCIAL_GA_EXECUTION.md)                             | G2 runbook: WS1–WS6 staging smoke, proof gates, GitHub secrets/vars                 |
+| [Billing module](../apps/api/src/modules/billing/README.md)                       | Checkout, ledger, webhooks, entitlements (NestJS)                                   |
+| [Billing SDK](../packages/billing-sdk/README.md)                                  | Ecosystem billing client                                                            |
+
+Private operator sequencing and Phase 0 blockers (Vault/`dhanam-secrets`, cutover)
+live in `internal-devops` — paths listed in [Monetization Session](MONETIZATION_SESSION.md).
 
 ## Start Here
 
@@ -143,9 +163,9 @@ Full guide index: [guides/README.md](guides/README.md).
 | [llms-full.txt](../llms-full.txt)                   | Expanded LLM context map            |
 | [agent-manifest.json](../tools/agent-manifest.json) | Machine-readable repo metadata      |
 
-For agents: read `AGENTS.md`, this index,
-[Documentation Audit 2026-05-22](DOCUMENTATION_AUDIT_2026-05-22.md), and the
-specific app/module docs for the files you are touching.
+For agents: read `AGENTS.md`, [Monetization Session](MONETIZATION_SESSION.md) for
+revenue work (or this index for stability work), and the specific app/module docs
+for the files you are touching.
 
 ## Historical Reports
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,6 +1,6 @@
 # Dhanam Full LLM Context
 
-Generated: 2026-05-22
+Generated: 2026-06-14
 
 ## Purpose
 
@@ -8,6 +8,20 @@ This file gives LLM agents a stable, tool-agnostic map for working in this
 repository without depending on vendor-specific instruction files.
 
 ## Canonical instruction order
+
+### Monetization sessions (first revenue, checkout, billing, catalog)
+
+1. `AGENTS.md`
+2. `docs/MONETIZATION_SESSION.md` — single entrypoint; repo vs private ops routing
+3. `docs/MONETIZATION_PATH_READINESS.md` — current gate table and ranked tasks
+4. `docs/FIRST_PESOS_COMMERCIAL_GA_MONETIZATION_2026-06-01.md` — G0–G9 framework
+5. Task-specific runbooks (`docs/runbooks/STRIPE_MXN_LIVE_FLIP.md`, etc.) and
+   billing modules (`apps/api/src/modules/billing/`, `catalog.yaml`,
+   `scripts/sync-catalog.ts`)
+6. `internal-devops` (separate repo) only for Phase 0 ops — paths in
+   `docs/MONETIZATION_SESSION.md`
+
+### General / stability sessions
 
 1. `AGENTS.md`
 2. `README.md` if present
@@ -21,7 +35,7 @@ repository without depending on vendor-specific instruction files.
 10. `ECOSYSTEM.md` if present
 11. App and module docs: `apps/*/README.md`, `apps/api/src/modules/README.md`
 12. Relevant files under `docs/`, `infra/`, `.github/workflows/`, and source
-   directories for the specific task
+    directories for the specific task
 
 ## Agent compatibility
 
@@ -45,6 +59,9 @@ gap or incident link.
 
 - `README.md`
 - `docs/README.md`
+- `docs/MONETIZATION_SESSION.md`
+- `docs/MONETIZATION_PATH_READINESS.md`
+- `docs/FIRST_PESOS_COMMERCIAL_GA_MONETIZATION_2026-06-01.md`
 - `docs/GA_REMEDIATION_ROADMAP.md`
 - `docs/ROADMAP.md`
 - `docs/STABILITY_AUDIT_2026-05-19.md`

--- a/llms.txt
+++ b/llms.txt
@@ -2,13 +2,29 @@
 
 Compact LLM context index for this repository.
 
-## Read first
+## Monetization session (read first)
+
+When the goal is first revenue, checkout, billing, catalog, or entitlements:
 
 - `AGENTS.md` — canonical agent operating instructions.
+- `docs/MONETIZATION_SESSION.md` — **single monetization entrypoint**; repo vs private ops routing.
+- `docs/MONETIZATION_PATH_READINESS.md` — current G0–G9 slice, gate table, ranked open tasks.
+- `docs/FIRST_PESOS_COMMERCIAL_GA_MONETIZATION_2026-06-01.md` — full first-peso gate framework.
+- `docs/runbooks/STRIPE_MXN_LIVE_FLIP.md` — live MXN flip (after secret restore + Stripe MX live).
+- `catalog.yaml` + `scripts/sync-catalog.ts` — SKU source of truth and Stripe/DB sync.
+- `apps/api/src/modules/billing/README.md` — billing module (checkout, ledger, webhooks).
+- `docs/TECH_DEBT.md` — active debt (TD-1009, TD-1010, TD-1014).
+
+Phase 0 platform blockers (Vault/`dhanam-secrets`, operator cutover) are tracked in
+`internal-devops` — see paths in `docs/MONETIZATION_SESSION.md`. Open that repo
+when ops remediation is in scope; stay in dhanam for product/engineering work.
+
+## General read order
+
 - `README.md` — human/product overview when present.
 - `docs/README.md` — canonical documentation map.
 - `docs/GA_REMEDIATION_ROADMAP.md` — full GA program (stability + commercial +
-  consumer); canonical implementation plan.
+  consumer); use for stability-only sessions.
 - `docs/COMMERCIAL_GA_EXECUTION.md` — G2 commercial GA runbook (WS1–WS6) and
   staging commercial smoke configuration.
 - `docs/ROADMAP.md` — stability priorities P0–P8 and milestones M1–M7.

--- a/tools/agent-manifest.json
+++ b/tools/agent-manifest.json
@@ -3,7 +3,7 @@
   "name": "dhanam",
   "version": "0.1.0",
   "description": "Dhanam - MADFAM billing ledger boundary and LATAM-first personal finance app",
-  "lastUpdated": "2026-05-22",
+  "lastUpdated": "2026-06-14",
 
   "domains": {
     "production": {
@@ -141,6 +141,10 @@
     "llmsTxt": "llms.txt",
     "llmsFullTxt": "llms-full.txt",
     "docsIndex": "docs/README.md",
+    "monetizationSession": "docs/MONETIZATION_SESSION.md",
+    "monetizationPathReadiness": "docs/MONETIZATION_PATH_READINESS.md",
+    "firstPesosCommercialGa": "docs/FIRST_PESOS_COMMERCIAL_GA_MONETIZATION_2026-06-01.md",
+    "stripeMxnLiveFlip": "docs/runbooks/STRIPE_MXN_LIVE_FLIP.md",
     "roadmap": "docs/ROADMAP.md",
     "gaRemediationRoadmap": "docs/GA_REMEDIATION_ROADMAP.md",
     "stabilityAudit": "docs/STABILITY_AUDIT_2026-05-19.md",


### PR DESCRIPTION
## Summary
- Add `docs/MONETIZATION_SESSION.md` as the single in-repo agent entrypoint for monetization work
- Prioritize monetization docs in `llms.txt`, `AGENTS.md`, `docs/README.md`, and `agent-manifest.json`
- Cross-link to `internal-devops/runbooks/MONETIZATION_OPS_SESSION.md` for private ops boundary

## Test plan
- [x] Doc link checker passes locally
- [x] Pre-push hooks (format, typecheck, lint, test, build) passed on push

Made with [Cursor](https://cursor.com)