### PR TITLE
fix(k8s): Kyverno exception for catalog-sync CronJob

### DIFF
--- a/infra/k8s/production/kyverno-policy-exception.yaml
+++ b/infra/k8s/production/kyverno-policy-exception.yaml
@@ -42,3 +42,14 @@ spec:
             - dhanam-web*
             - dhanam-admin*
             - dhanam-fx-spot-refresh*
+            - dhanam-catalog-sync
+            - dhanam-catalog-sync*
+      - resources:
+          kinds:
+            - CronJob
+            - Job
+          namespaces:
+            - dhanam
+          selector:
+            matchLabels:
+              app: dhanam-catalog-sync


### PR DESCRIPTION
## Summary
- Extend PolicyException to match `dhanam-catalog-sync` CronJob by name and label
- Unblocks Argo sync for suspended on-demand catalog sync job

## Test plan
- [ ] Argo `dhanam-services` syncs to Healthy

Made with [Cursor](https://cursor.com)