### PR TITLE
feat: ecosystem marquee banner v0.1.3

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,7 +18,7 @@
     "@dhanam/ui": "workspace:*",
     "@hookform/resolvers": "^5.4.0",
     "@janua/react-sdk": "0.1.3",
-    "@madfam/ecosystem-banner": "0.1.2",
+    "@madfam/ecosystem-banner": "0.1.3",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/apps/web/src/components/ecosystem-banner-client.tsx
+++ b/apps/web/src/components/ecosystem-banner-client.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { EcosystemBanner } from '@dhanam/ui';
+import { EcosystemBanner } from '@madfam/ecosystem-banner';
 
 export function EcosystemBannerClient() {
-  return <EcosystemBanner />;
+  return <EcosystemBanner testId="ecosystem-banner" />;
 }

--- a/apps/web/src/components/landing/footer.tsx
+++ b/apps/web/src/components/landing/footer.tsx
@@ -42,19 +42,6 @@ export function Footer() {
               Status
             </a>
           </div>
-          <div className="flex items-center justify-center gap-3 pt-1 text-xs text-muted-foreground">
-            <a href="https://karafiel.mx" className="hover:text-foreground transition-colors">
-              Karafiel
-            </a>
-            <span aria-hidden="true">&middot;</span>
-            <a href="https://forgesight.quest" className="hover:text-foreground transition-colors">
-              Forgesight
-            </a>
-            <span aria-hidden="true">&middot;</span>
-            <a href="https://selva.town" className="hover:text-foreground transition-colors">
-              Selva
-            </a>
-          </div>
         </div>
 
         <div className="flex items-center gap-6">

--- a/infra/k8s/overlays/preview/kustomization.yaml
+++ b/infra/k8s/overlays/preview/kustomization.yaml
@@ -73,7 +73,7 @@ replicas:
 # is API-focused).
 images:
   - name: ghcr.io/madfam-org/dhanam/api
-    digest: sha256:acbabb63339f6bc4a1827cf4071a1ae109b8ae9f74bbabb871fc3a8a62619283
+    digest: sha256:cd86d7202239eb67b8afaaa5e547910ab305efc8212fa532c6ac745ba118c0ee
   - name: ghcr.io/madfam-org/dhanam/web
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: ghcr.io/madfam-org/dhanam/admin

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -645,7 +645,7 @@ importers:
         version: link:../../packages/config
       '@testing-library/react-native':
         specifier: ^13.3.3
-        version: 13.3.3(jest@30.2.0(@types/node@20.11.0))(react-native@0.83.1(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1))(react-test-renderer@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 13.3.3(jest@30.2.0(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3)))(react-native@0.83.1(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1))(react-test-renderer@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
@@ -666,10 +666,10 @@ importers:
         version: 17.5.0
       jest:
         specifier: ^30.2.0
-        version: 30.2.0(@types/node@20.11.0)
+        version: 30.2.0(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3))
       jest-expo:
         specifier: ~51.0.2
-        version: 51.0.2(@babel/core@7.29.0)(jest@30.2.0(@types/node@20.11.0))(react@18.3.1)
+        version: 51.0.2(@babel/core@7.29.0)(jest@30.2.0(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3)))(react@18.3.1)
       react-test-renderer:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
@@ -692,8 +692,8 @@ importers:
         specifier: 0.1.3
         version: 0.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(axios@1.16.1)(immer@11.1.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@4.2.3)(use-sync-external-store@1.6.0(react@18.3.1))
       '@madfam/ecosystem-banner':
-        specifier: 0.1.2
-        version: 0.1.2(react@18.3.1)
+        specifier: 0.1.3
+        version: 0.1.3(react@18.3.1)
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -856,7 +856,7 @@ importers:
         version: 15.1.6(eslint@9.39.0(jiti@2.7.0))(typescript@5.9.3)
       jest:
         specifier: ^30.2.0
-        version: 30.2.0(@types/node@25.6.0)
+        version: 30.2.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^30.2.0
         version: 30.2.0
@@ -887,10 +887,10 @@ importers:
         version: 20.11.0
       jest:
         specifier: ^30.2.0
-        version: 30.2.0(@types/node@20.11.0)
+        version: 30.2.0(@types/node@20.11.0)(ts-node@10.9.2(@types/node@20.11.0)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.5
-        version: 29.4.5(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.2.0(@babel/core@7.29.7))(esbuild@0.27.7)(jest-util@30.4.1)(jest@30.2.0(@types/node@20.11.0))(typescript@5.9.3)
+        version: 29.4.5(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.2.0(@babel/core@7.29.7))(esbuild@0.27.7)(jest-util@30.4.1)(jest@30.2.0(@types/node@20.11.0)(ts-node@10.9.2(@types/node@20.11.0)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.9.0)
@@ -988,10 +988,10 @@ importers:
         version: 20.11.0
       jest:
         specifier: ^30.2.0
-        version: 30.2.0(@types/node@20.11.0)
+        version: 30.2.0(@types/node@20.11.0)(ts-node@10.9.2(@types/node@20.11.0)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.5
-        version: 29.4.5(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.2.0(@babel/core@7.29.7))(esbuild@0.27.7)(jest-util@30.4.1)(jest@30.2.0(@types/node@20.11.0))(typescript@5.9.3)
+        version: 29.4.5(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.2.0(@babel/core@7.29.7))(esbuild@0.27.7)(jest-util@30.4.1)(jest@30.2.0(@types/node@20.11.0)(ts-node@10.9.2(@types/node@20.11.0)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.9.0)
@@ -1025,13 +1025,13 @@ importers:
         version: 18.3.28
       jest:
         specifier: ^30.2.0
-        version: 30.2.0(@types/node@20.11.0)
+        version: 30.2.0(@types/node@20.11.0)(ts-node@10.9.2(@types/node@20.11.0)(typescript@5.9.3))
       react:
         specifier: 18.3.1
         version: 18.3.1
       ts-jest:
         specifier: ^29.4.5
-        version: 29.4.5(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.2.0(@babel/core@7.29.7))(esbuild@0.27.7)(jest-util@30.4.1)(jest@30.2.0(@types/node@20.11.0))(typescript@5.9.3)
+        version: 29.4.5(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.2.0(@babel/core@7.29.7))(esbuild@0.27.7)(jest-util@30.4.1)(jest@30.2.0(@types/node@20.11.0)(ts-node@10.9.2(@types/node@20.11.0)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.9.0)
@@ -1056,10 +1056,10 @@ importers:
         version: 20.11.0
       jest:
         specifier: ^30.2.0
-        version: 30.2.0(@types/node@20.11.0)
+        version: 30.2.0(@types/node@20.11.0)(ts-node@10.9.2(@types/node@20.11.0)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.1.1
-        version: 29.4.5(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.2.0(@babel/core@7.29.7))(esbuild@0.27.7)(jest-util@30.4.1)(jest@30.2.0(@types/node@20.11.0))(typescript@5.9.3)
+        version: 29.4.5(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.2.0(@babel/core@7.29.7))(esbuild@0.27.7)(jest-util@30.4.1)(jest@30.2.0(@types/node@20.11.0)(ts-node@10.9.2(@types/node@20.11.0)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.9.0)
@@ -3282,8 +3282,8 @@ packages:
     resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
     engines: {node: '>=8'}
 
-  '@madfam/ecosystem-banner@0.1.2':
-    resolution: {integrity: sha512-Z586GOYhN72KY4TKlhPpeLVzyKpBNgz7i/sGqYpw5HmeNBgGo6iOcbohOyGMOhPHMc5+BdbUDI1NjOIiDwOFNg==}
+  '@madfam/ecosystem-banner@0.1.3':
+    resolution: {integrity: sha512-B69AS9clicnAfR8/MqK/yoOAo+NVvNcLVPSu8EKsaAiZ9SanvgzC/cc6IkVEHv1vqsGLHUTT9IMK8OqVeLfODw==}
     peerDependencies:
       react: 18.3.1
 
@@ -14951,7 +14951,7 @@ snapshots:
       jest-util: 30.2.0
       slash: 3.0.0
 
-  '@jest/core@30.2.0':
+  '@jest/core@30.2.0(ts-node@10.9.2(@types/node@20.11.0)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 30.2.0
       '@jest/pattern': 30.0.1
@@ -14966,7 +14966,7 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.2.0
-      jest-config: 30.2.0(@types/node@25.6.0)
+      jest-config: 30.2.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@20.11.0)(typescript@5.9.3))
       jest-haste-map: 30.2.0
       jest-message-util: 30.2.0
       jest-regex-util: 30.0.1
@@ -14987,7 +14987,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@30.2.0(ts-node@10.9.2(@types/node@20.11.0)(typescript@5.9.3))':
+  '@jest/core@30.2.0(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 30.2.0
       '@jest/pattern': 30.0.1
@@ -15002,7 +15002,7 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.2.0
-      jest-config: 30.2.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@20.11.0)(typescript@5.9.3))
+      jest-config: 30.2.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3))
       jest-haste-map: 30.2.0
       jest-message-util: 30.2.0
       jest-regex-util: 30.0.1
@@ -15418,7 +15418,7 @@ snapshots:
 
   '@lukeed/ms@2.0.2': {}
 
-  '@madfam/ecosystem-banner@0.1.2(react@18.3.1)':
+  '@madfam/ecosystem-banner@0.1.3(react@18.3.1)':
     dependencies:
       react: 18.3.1
 
@@ -17806,7 +17806,7 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react-native@13.3.3(jest@30.2.0(@types/node@20.11.0))(react-native@0.83.1(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1))(react-test-renderer@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@testing-library/react-native@13.3.3(jest@30.2.0(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3)))(react-native@0.83.1(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1))(react-test-renderer@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       jest-matcher-utils: 30.4.1
       picocolors: 1.1.1
@@ -17816,7 +17816,7 @@ snapshots:
       react-test-renderer: 18.3.1(react@18.3.1)
       redent: 3.0.0
     optionalDependencies:
-      jest: 30.2.0(@types/node@20.11.0)
+      jest: 30.2.0(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3))
 
   '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -21811,25 +21811,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.2.0(@types/node@20.11.0):
-    dependencies:
-      '@jest/core': 30.2.0
-      '@jest/test-result': 30.2.0
-      '@jest/types': 30.2.0
-      chalk: 4.1.2
-      exit-x: 0.2.2
-      import-local: 3.2.0
-      jest-config: 30.2.0(@types/node@20.11.0)
-      jest-util: 30.2.0
-      jest-validate: 30.2.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
   jest-cli@30.2.0(@types/node@20.11.0)(ts-node@10.9.2(@types/node@20.11.0)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 30.2.0(ts-node@10.9.2(@types/node@20.11.0)(typescript@5.9.3))
@@ -21849,15 +21830,15 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.2.0(@types/node@25.6.0):
+  jest-cli@30.2.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 30.2.0
+      '@jest/core': 30.2.0(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3))
       '@jest/test-result': 30.2.0
       '@jest/types': 30.2.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.2.0(@types/node@25.6.0)
+      jest-config: 30.2.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3))
       jest-util: 30.2.0
       jest-validate: 30.2.0
       yargs: 17.7.2
@@ -21906,38 +21887,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.2.0(@types/node@20.11.0):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.2.0
-      '@jest/types': 30.2.0
-      babel-jest: 30.2.0(@babel/core@7.29.7)
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      deepmerge: 4.3.1
-      glob: 13.0.6
-      graceful-fs: 4.2.11
-      jest-circus: 30.2.0
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.2.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.2.0
-      jest-runner: 30.2.0
-      jest-util: 30.2.0
-      jest-validate: 30.2.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 30.2.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 20.11.0
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
   jest-config@30.2.0(@types/node@20.11.0)(ts-node@10.9.2(@types/node@20.11.0)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.7
@@ -21971,38 +21920,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.2.0(@types/node@25.6.0):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.2.0
-      '@jest/types': 30.2.0
-      babel-jest: 30.2.0(@babel/core@7.29.7)
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      deepmerge: 4.3.1
-      glob: 13.0.6
-      graceful-fs: 4.2.11
-      jest-circus: 30.2.0
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.2.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.2.0
-      jest-runner: 30.2.0
-      jest-util: 30.2.0
-      jest-validate: 30.2.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 30.2.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 25.6.0
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
   jest-config@30.2.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@20.11.0)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.7
@@ -22032,6 +21949,39 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
       ts-node: 10.9.2(@types/node@20.11.0)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@30.2.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.2.0
+      '@jest/types': 30.2.0
+      babel-jest: 30.2.0(@babel/core@7.29.7)
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      deepmerge: 4.3.1
+      glob: 13.0.6
+      graceful-fs: 4.2.11
+      jest-circus: 30.2.0
+      jest-docblock: 30.2.0
+      jest-environment-node: 30.2.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.2.0
+      jest-runner: 30.2.0
+      jest-util: 30.2.0
+      jest-validate: 30.2.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 30.2.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.6.0
+      ts-node: 10.9.2(@types/node@25.6.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -22207,7 +22157,7 @@ snapshots:
       jest-util: 30.2.0
       jest-validate: 30.2.0
 
-  jest-expo@51.0.2(@babel/core@7.29.0)(jest@30.2.0(@types/node@20.11.0))(react@18.3.1):
+  jest-expo@51.0.2(@babel/core@7.29.0)(jest@30.2.0(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3)))(react@18.3.1):
     dependencies:
       '@expo/config': 9.0.4
       '@expo/json-file': 8.3.3
@@ -22216,7 +22166,7 @@ snapshots:
       find-up: 5.0.0
       jest-environment-jsdom: 29.7.0
       jest-watch-select-projects: 2.0.0
-      jest-watch-typeahead: 2.2.1(jest@30.2.0(@types/node@20.11.0))
+      jest-watch-typeahead: 2.2.1(jest@30.2.0(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3)))
       json5: 2.2.3
       lodash: 4.18.1
       react-test-renderer: 18.2.0(react@18.3.1)
@@ -22545,11 +22495,11 @@ snapshots:
       chalk: 3.0.0
       prompts: 2.4.2
 
-  jest-watch-typeahead@2.2.1(jest@30.2.0(@types/node@20.11.0)):
+  jest-watch-typeahead@2.2.1(jest@30.2.0(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3))):
     dependencies:
       ansi-escapes: 6.2.1
       chalk: 4.1.2
-      jest: 30.2.0(@types/node@20.11.0)
+      jest: 30.2.0(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3))
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -22607,19 +22557,6 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.2.0(@types/node@20.11.0):
-    dependencies:
-      '@jest/core': 30.2.0
-      '@jest/types': 30.2.0
-      import-local: 3.2.0
-      jest-cli: 30.2.0(@types/node@20.11.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
   jest@30.2.0(@types/node@20.11.0)(ts-node@10.9.2(@types/node@20.11.0)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 30.2.0(ts-node@10.9.2(@types/node@20.11.0)(typescript@5.9.3))
@@ -22633,12 +22570,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@30.2.0(@types/node@25.6.0):
+  jest@30.2.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 30.2.0
+      '@jest/core': 30.2.0(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3))
       '@jest/types': 30.2.0
       import-local: 3.2.0
-      jest-cli: 30.2.0(@types/node@25.6.0)
+      jest-cli: 30.2.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -25779,12 +25716,12 @@ snapshots:
       babel-jest: 30.2.0(@babel/core@7.29.7)
       jest-util: 30.4.1
 
-  ts-jest@29.4.5(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.2.0(@babel/core@7.29.7))(esbuild@0.27.7)(jest-util@30.4.1)(jest@30.2.0(@types/node@20.11.0))(typescript@5.9.3):
+  ts-jest@29.4.5(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.2.0(@babel/core@7.29.7))(esbuild@0.27.7)(jest-util@30.4.1)(jest@30.2.0(@types/node@20.11.0)(ts-node@10.9.2(@types/node@20.11.0)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.2.0(@types/node@20.11.0)
+      jest: 30.2.0(@types/node@20.11.0)(ts-node@10.9.2(@types/node@20.11.0)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -25838,6 +25775,25 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 20.11.0
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 9.0.0
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
+
+  ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 25.6.0
       acorn: 8.16.0
       acorn-walk: 8.3.5
       arg: 4.1.3


### PR DESCRIPTION
## Summary
- Adopt `@madfam/ecosystem-banner` v0.1.3 continuous horizontal marquee (NYSE-style ticker)
- Mount `<EcosystemBanner />` on root layout with `pb-8` body padding
- Remove cross-platform ecosystem links from product footer (discovery via banner only)

## Test plan
- [ ] `pnpm build` / app build passes
- [ ] Landing shows bottom marquee with all 13 platforms
- [ ] Footer shows only platform + MADFAM company links

Part of ecosystem banner remediation — see `internal-devops/ecosystem/ecosystem-banner-footer-audit-2026-06-15.md`.

Made with [Cursor](https://cursor.com)