### PR TITLE
feat(web): Phase C Dhanam landing product scroll story

### DIFF
--- a/apps/web/src/components/landing/features-grid.tsx
+++ b/apps/web/src/components/landing/features-grid.tsx
@@ -14,70 +14,87 @@ import {
   Users,
   FileText,
   Trophy,
+  ChevronDown,
+  ChevronUp,
 } from 'lucide-react';
+import { useState } from 'react';
 
 const featureConfig = [
-  { key: 'feature1' as const, icon: Landmark, color: 'blue' },
-  { key: 'feature2' as const, icon: Coins, color: 'purple' },
-  { key: 'feature3' as const, icon: Home, color: 'teal' },
-  { key: 'feature4' as const, icon: Gamepad2, color: 'pink' },
-  { key: 'feature5' as const, icon: Cpu, color: 'violet' },
-  { key: 'feature6' as const, icon: HeartPulse, color: 'red' },
-  { key: 'feature7' as const, icon: Search, color: 'amber' },
-  { key: 'feature8' as const, icon: Wallet, color: 'green' },
-  { key: 'feature9' as const, icon: TrendingUp, color: 'orange' },
-  { key: 'feature10' as const, icon: Users, color: 'cyan' },
-  { key: 'feature11' as const, icon: FileText, color: 'indigo' },
-  { key: 'feature12' as const, icon: Trophy, color: 'amber' },
+  { key: 'feature1' as const, icon: Landmark, tone: 'bg-info/15 text-info' },
+  { key: 'feature2' as const, icon: Coins, tone: 'bg-primary/15 text-primary' },
+  { key: 'feature3' as const, icon: Home, tone: 'bg-warning/15 text-warning' },
+  { key: 'feature4' as const, icon: Gamepad2, tone: 'bg-info/15 text-info' },
+  { key: 'feature5' as const, icon: Cpu, tone: 'bg-primary/15 text-primary' },
+  { key: 'feature6' as const, icon: HeartPulse, tone: 'bg-success/15 text-success' },
+  { key: 'feature7' as const, icon: Search, tone: 'bg-warning/15 text-warning' },
+  { key: 'feature8' as const, icon: Wallet, tone: 'bg-info/15 text-info' },
+  { key: 'feature9' as const, icon: TrendingUp, tone: 'bg-primary/15 text-primary' },
+  { key: 'feature10' as const, icon: Users, tone: 'bg-success/15 text-success' },
+  { key: 'feature11' as const, icon: FileText, tone: 'bg-warning/15 text-warning' },
+  { key: 'feature12' as const, icon: Trophy, tone: 'bg-primary/15 text-primary' },
 ] as const;
-
-const colorMap: Record<string, string> = {
-  blue: 'bg-blue-100 dark:bg-blue-900/50 text-blue-600',
-  purple: 'bg-purple-100 dark:bg-purple-900/50 text-purple-600',
-  teal: 'bg-teal-100 dark:bg-teal-900/50 text-teal-600',
-  pink: 'bg-pink-100 dark:bg-pink-900/50 text-pink-600',
-  violet: 'bg-violet-100 dark:bg-violet-900/50 text-violet-600',
-  amber: 'bg-amber-100 dark:bg-amber-900/50 text-amber-600',
-  cyan: 'bg-cyan-100 dark:bg-cyan-900/50 text-cyan-600',
-  orange: 'bg-orange-100 dark:bg-orange-900/50 text-orange-600',
-  green: 'bg-green-100 dark:bg-green-900/50 text-green-600',
-  red: 'bg-red-100 dark:bg-red-900/50 text-red-600',
-  indigo: 'bg-indigo-100 dark:bg-indigo-900/50 text-indigo-600',
-};
 
 export function FeaturesGrid() {
   const { t } = useTranslation('landing');
+  const [expanded, setExpanded] = useState(false);
 
   return (
     <section className="container mx-auto px-6 py-16">
-      <div className="text-center mb-12">
+      <div className="text-center mb-8">
         <h2 className="text-3xl font-bold mb-4">{t('features.title')}</h2>
-        <p className="text-muted-foreground">{t('features.subtitle')}</p>
+        <p className="text-muted-foreground max-w-2xl mx-auto">{t('features.subtitle')}</p>
       </div>
 
-      <div className="max-w-6xl mx-auto">
-        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {featureConfig.map((feature) => {
-            const Icon = feature.icon;
-            return (
-              <div
-                key={feature.key}
-                className="rounded-lg border bg-card p-6 hover:shadow-lg transition-shadow"
-              >
-                <div
-                  className={`h-12 w-12 rounded-lg flex items-center justify-center mb-4 ${colorMap[feature.color]}`}
-                >
-                  <Icon className="h-6 w-6" />
-                </div>
-                <h4 className="text-lg font-semibold mb-2">{t(`features.${feature.key}.title`)}</h4>
-                <p className="text-sm text-muted-foreground">
-                  {t(`features.${feature.key}.description`)}
-                </p>
-              </div>
-            );
-          })}
+      {!expanded ? (
+        <div className="text-center">
+          <button
+            type="button"
+            onClick={() => setExpanded(true)}
+            className="inline-flex items-center gap-2 rounded-lg border border-border bg-card px-6 py-3 text-sm font-medium transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+          >
+            {t('features.showAll')}
+            <ChevronDown className="h-4 w-4" aria-hidden />
+          </button>
         </div>
-      </div>
+      ) : (
+        <>
+          <div className="max-w-6xl mx-auto">
+            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {featureConfig.map((feature) => {
+                const Icon = feature.icon;
+                return (
+                  <div
+                    key={feature.key}
+                    className="rounded-lg border bg-card p-6 hover:shadow-lg transition-shadow"
+                  >
+                    <div
+                      className={`h-12 w-12 rounded-lg flex items-center justify-center mb-4 ${feature.tone}`}
+                    >
+                      <Icon className="h-6 w-6" />
+                    </div>
+                    <h4 className="text-lg font-semibold mb-2">
+                      {t(`features.${feature.key}.title`)}
+                    </h4>
+                    <p className="text-sm text-muted-foreground">
+                      {t(`features.${feature.key}.description`)}
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+          <div className="mt-8 text-center">
+            <button
+              type="button"
+              onClick={() => setExpanded(false)}
+              className="inline-flex items-center gap-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {t('features.hideAll')}
+              <ChevronUp className="h-4 w-4" aria-hidden />
+            </button>
+          </div>
+        </>
+      )}
     </section>
   );
 }

--- a/apps/web/src/components/landing/landing-nav.tsx
+++ b/apps/web/src/components/landing/landing-nav.tsx
@@ -33,7 +33,7 @@ export function LandingNav({ locale }: LandingNavProps) {
   }, []);
 
   const navLinks = [
-    { href: '#personas', label: t('nav.features') },
+    { href: '#features', label: t('nav.features') },
     { href: '#pricing', label: t('nav.pricing') },
     { href: '#landing-hero', label: t('nav.demo') },
   ];

--- a/apps/web/src/components/landing/landing-page-client.tsx
+++ b/apps/web/src/components/landing/landing-page-client.tsx
@@ -13,6 +13,7 @@ import { PersonaCards } from '@/components/landing/persona-cards';
 import { PlatformDepth } from '@/components/landing/platform-depth';
 import { Pricing } from '@/components/landing/pricing';
 import { ProblemSolution } from '@/components/landing/problem-solution';
+import { ProductStorySection } from '@/components/landing/product-story-section';
 import { SecurityTrust } from '@/components/landing/security-trust';
 import { SocialProof } from '@/components/landing/social-proof';
 import { useAnalytics } from '@/hooks/useAnalytics';
@@ -85,6 +86,7 @@ export function LandingPageClient({
         <div id="personas">
           <PersonaCards />
         </div>
+        <ProductStorySection />
         <ProblemSolution />
         <HowItWorks />
         <SecurityTrust />

--- a/apps/web/src/components/landing/problem-solution.tsx
+++ b/apps/web/src/components/landing/problem-solution.tsx
@@ -1,10 +1,13 @@
 'use client';
 
 import { useTranslation } from '@dhanam/shared';
-import { AlertTriangle, CheckCircle } from 'lucide-react';
+import { CheckCircle, X } from 'lucide-react';
+
+const comparisonRows = ['row1', 'row2', 'row3'] as const;
 
 export function ProblemSolution() {
   const { t } = useTranslation('landing');
+
   return (
     <section className="container mx-auto px-6 py-16 bg-muted/30">
       <div className="max-w-4xl mx-auto">
@@ -14,35 +17,36 @@ export function ProblemSolution() {
           <span className="text-primary">{t('problemSolution.titleHighlight')}</span>
         </h2>
 
-        <div className="grid md:grid-cols-2 gap-6">
-          <div className="rounded-lg border border-red-200 dark:border-red-900/50 bg-card p-6">
-            <div className="flex items-center gap-2 text-red-600 mb-4">
-              <AlertTriangle className="h-5 w-5" />
-              <h3 className="font-semibold">{t('problemSolution.budgetTrackers')}</h3>
-            </div>
-            <ul className="space-y-2 text-sm text-muted-foreground">
-              {([1, 2, 3, 4, 5, 6, 7, 8] as const).map((n) => (
-                <li key={n} className="flex gap-2">
-                  <span className="text-red-600">&#10007;</span> {t(`problemSolution.problem${n}`)}
-                </li>
-              ))}
-            </ul>
+        <div className="overflow-hidden rounded-xl border bg-card">
+          <div className="grid grid-cols-[1fr_auto_1fr] gap-4 border-b bg-muted/40 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground md:px-6">
+            <span>{t('problemSolution.budgetTrackers')}</span>
+            <span className="sr-only">versus</span>
+            <span className="text-right text-primary">Dhanam</span>
           </div>
 
-          <div className="rounded-lg border border-green-200 dark:border-green-900/50 bg-card p-6">
-            <div className="flex items-center gap-2 text-green-600 mb-4">
-              <CheckCircle className="h-5 w-5" />
-              <h3 className="font-semibold">Dhanam</h3>
-            </div>
-            <ul className="space-y-2 text-sm">
-              {([1, 2, 3, 4, 5, 6, 7, 8] as const).map((n) => (
-                <li key={n} className="flex gap-2">
-                  <CheckCircle className="h-4 w-4 text-green-600 shrink-0 mt-0.5" />{' '}
-                  {t(`problemSolution.solution${n}`)}
-                </li>
-              ))}
-            </ul>
-          </div>
+          <ul className="divide-y">
+            {comparisonRows.map((row) => (
+              <li
+                key={row}
+                className="grid grid-cols-1 gap-3 px-4 py-4 md:grid-cols-[1fr_auto_1fr] md:items-center md:gap-4 md:px-6"
+              >
+                <div className="flex gap-2 text-sm text-muted-foreground">
+                  <X className="h-4 w-4 shrink-0 text-destructive mt-0.5" aria-hidden />
+                  <span>{t(`problemSolution.${row}Problem`)}</span>
+                </div>
+                <span
+                  className="hidden text-xs font-medium uppercase tracking-wide text-muted-foreground md:block"
+                  aria-hidden
+                >
+                  vs
+                </span>
+                <div className="flex gap-2 text-sm md:justify-end">
+                  <CheckCircle className="h-4 w-4 shrink-0 text-success mt-0.5" aria-hidden />
+                  <span>{t(`problemSolution.${row}Solution`)}</span>
+                </div>
+              </li>
+            ))}
+          </ul>
         </div>
       </div>
     </section>

--- a/apps/web/src/components/landing/product-chapter-preview.tsx
+++ b/apps/web/src/components/landing/product-chapter-preview.tsx
@@ -1,0 +1,176 @@
+type ChapterPreviewVariant =
+  | 'netWorth'
+  | 'spending'
+  | 'planning'
+  | 'household'
+  | 'estate'
+  | 'depth';
+
+const variantLabels: Record<ChapterPreviewVariant, string> = {
+  netWorth: 'Net worth',
+  spending: 'Spending',
+  planning: 'Plan',
+  household: 'Household',
+  estate: 'Life Beat',
+  depth: 'Platform',
+};
+
+function PreviewChrome({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="relative mx-auto w-full max-w-md" aria-hidden role="presentation">
+      <div className="absolute -inset-3 rounded-2xl bg-primary/5 blur-xl" />
+      <div className="relative overflow-hidden rounded-xl border border-border/80 bg-card shadow-lg">
+        <div className="flex items-center gap-2 border-b bg-muted/40 px-3 py-2">
+          <span className="h-2 w-2 rounded-full bg-destructive/70" />
+          <span className="h-2 w-2 rounded-full bg-warning/80" />
+          <span className="h-2 w-2 rounded-full bg-success/80" />
+          <span className="ml-1 text-[10px] font-medium text-muted-foreground">
+            Dhanam · {label}
+          </span>
+        </div>
+        <div className="bg-gradient-to-b from-card to-muted/20 p-4">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+function NetWorthPreview() {
+  return (
+    <PreviewChrome label={variantLabels.netWorth}>
+      <p className="text-[10px] uppercase tracking-wide text-muted-foreground">Total net worth</p>
+      <p className="text-2xl font-bold tracking-tight">$1,284,520</p>
+      <div className="mt-3 grid grid-cols-3 gap-1.5">
+        {[
+          { label: 'Bank', pct: '62%', tone: 'bg-info/15 text-info' },
+          { label: 'DeFi', pct: '24%', tone: 'bg-primary/15 text-primary' },
+          { label: 'Home', pct: '14%', tone: 'bg-warning/15 text-warning' },
+        ].map((item) => (
+          <div key={item.label} className={`rounded-md px-1 py-2 text-center ${item.tone}`}>
+            <p className="text-[9px] uppercase opacity-80">{item.label}</p>
+            <p className="text-sm font-semibold">{item.pct}</p>
+          </div>
+        ))}
+      </div>
+    </PreviewChrome>
+  );
+}
+
+function SpendingPreview() {
+  return (
+    <PreviewChrome label={variantLabels.spending}>
+      <div className="space-y-2">
+        {[
+          { merchant: 'Superama', cat: 'Groceries · AI', amt: '-$842' },
+          { merchant: 'Netflix', cat: 'Subscriptions · Recurring', amt: '-$299' },
+          { merchant: 'SPEI · Rent', cat: 'Housing · Rule matched', amt: '-$12,500' },
+        ].map((row) => (
+          <div
+            key={row.merchant}
+            className="flex items-center justify-between rounded-lg border bg-background/80 px-2.5 py-2 text-[11px]"
+          >
+            <div>
+              <p className="font-medium text-foreground">{row.merchant}</p>
+              <p className="text-muted-foreground">{row.cat}</p>
+            </div>
+            <span className="font-semibold text-expense">{row.amt}</span>
+          </div>
+        ))}
+      </div>
+    </PreviewChrome>
+  );
+}
+
+function PlanningPreview() {
+  return (
+    <PreviewChrome label={variantLabels.planning}>
+      <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+        Retirement at 55 · probability
+      </p>
+      <p className="text-2xl font-bold text-success">78%</p>
+      <div className="mt-3 h-16 rounded-lg border bg-background/80 p-2">
+        <div className="flex h-full items-end gap-0.5">
+          {[32, 48, 55, 62, 71, 78, 74, 68, 82, 78].map((h, i) => (
+            <div key={i} className="flex-1 rounded-sm bg-primary/30" style={{ height: `${h}%` }} />
+          ))}
+        </div>
+      </div>
+      <p className="mt-2 text-[10px] text-muted-foreground">
+        10,000 Monte Carlo paths · 12 stress tests
+      </p>
+    </PreviewChrome>
+  );
+}
+
+function HouseholdPreview() {
+  return (
+    <PreviewChrome label={variantLabels.household}>
+      <div className="flex gap-2">
+        {[
+          { label: 'Yours', amt: '$42,180', tone: 'border-info/40 bg-info/10' },
+          { label: 'Mine', amt: '$38,920', tone: 'border-primary/40 bg-primary/10' },
+          { label: 'Ours', amt: '$1.2M', tone: 'border-warning/40 bg-warning/10' },
+        ].map((item) => (
+          <div key={item.label} className={`flex-1 rounded-lg border p-2 ${item.tone}`}>
+            <p className="text-[9px] uppercase tracking-wide text-muted-foreground">{item.label}</p>
+            <p className="text-sm font-semibold">{item.amt}</p>
+          </div>
+        ))}
+      </div>
+    </PreviewChrome>
+  );
+}
+
+function EstatePreview() {
+  return (
+    <PreviewChrome label={variantLabels.estate}>
+      <div className="space-y-2">
+        <div className="rounded-lg border border-success/30 bg-success/5 px-3 py-2">
+          <p className="text-[10px] font-medium text-success">Life Beat active</p>
+          <p className="text-[11px] text-muted-foreground">
+            Executor access · last check-in 3 days ago
+          </p>
+        </div>
+        <div className="rounded-lg border bg-background/80 px-3 py-2 text-[11px]">
+          <p className="font-medium">Digital will · 4 documents</p>
+          <p className="text-muted-foreground">Encrypted vault · beneficiary verified</p>
+        </div>
+      </div>
+    </PreviewChrome>
+  );
+}
+
+function DepthPreview() {
+  return (
+    <PreviewChrome label={variantLabels.depth}>
+      <div className="grid grid-cols-2 gap-2">
+        {[
+          { label: 'DeFi', sub: '7 networks', tone: 'text-primary' },
+          { label: 'Collectibles', sub: '7 categories', tone: 'text-warning' },
+          { label: 'Cashflow', sub: '60-day forecast', tone: 'text-info' },
+          { label: 'ESG', sub: 'Crypto scores', tone: 'text-success' },
+        ].map((item) => (
+          <div key={item.label} className="rounded-lg border bg-background/80 px-2 py-2">
+            <p className={`text-xs font-semibold ${item.tone}`}>{item.label}</p>
+            <p className="text-[10px] text-muted-foreground">{item.sub}</p>
+          </div>
+        ))}
+      </div>
+    </PreviewChrome>
+  );
+}
+
+const previewMap: Record<ChapterPreviewVariant, () => React.ReactElement> = {
+  netWorth: NetWorthPreview,
+  spending: SpendingPreview,
+  planning: PlanningPreview,
+  household: HouseholdPreview,
+  estate: EstatePreview,
+  depth: DepthPreview,
+};
+
+export function ProductChapterPreview({ variant }: { variant: ChapterPreviewVariant }) {
+  const Preview = previewMap[variant];
+  return <Preview />;
+}
+
+export type { ChapterPreviewVariant };

--- a/apps/web/src/components/landing/product-story-section.tsx
+++ b/apps/web/src/components/landing/product-story-section.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useTranslation } from '@dhanam/shared';
+import { motion, useReducedMotion } from 'framer-motion';
+
+import {
+  ProductChapterPreview,
+  type ChapterPreviewVariant,
+} from '@/components/landing/product-chapter-preview';
+
+const chapters: { key: string; preview: ChapterPreviewVariant }[] = [
+  { key: 'chapter1', preview: 'netWorth' },
+  { key: 'chapter2', preview: 'spending' },
+  { key: 'chapter3', preview: 'planning' },
+  { key: 'chapter4', preview: 'household' },
+  { key: 'chapter5', preview: 'estate' },
+  { key: 'chapter6', preview: 'depth' },
+];
+
+function StoryChapter({
+  chapterKey,
+  preview,
+  index,
+}: {
+  chapterKey: string;
+  preview: ChapterPreviewVariant;
+  index: number;
+}) {
+  const { t } = useTranslation('landing');
+  const reducedMotion = useReducedMotion();
+  const reversed = index % 2 === 1;
+
+  const motionProps = reducedMotion
+    ? {}
+    : {
+        initial: { opacity: 0, y: 28 },
+        whileInView: { opacity: 1, y: 0 },
+        viewport: { once: true, margin: '-60px' },
+        transition: { duration: 0.55, ease: [0.22, 1, 0.36, 1] as const },
+      };
+
+  return (
+    <motion.article
+      {...motionProps}
+      className="grid items-center gap-10 lg:grid-cols-2 lg:gap-16"
+      aria-labelledby={`${chapterKey}-title`}
+    >
+      <div className={reversed ? 'lg:order-2' : 'lg:order-1'}>
+        <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-primary">
+          {t(`productStory.${chapterKey}.eyebrow`)}
+        </p>
+        <h3 id={`${chapterKey}-title`} className="text-2xl font-bold tracking-tight md:text-3xl">
+          {t(`productStory.${chapterKey}.title`)}
+        </h3>
+        <p className="mt-4 text-base text-muted-foreground md:text-lg">
+          {t(`productStory.${chapterKey}.description`)}
+        </p>
+      </div>
+      <div className={reversed ? 'lg:order-1' : 'lg:order-2'}>
+        <ProductChapterPreview variant={preview} />
+      </div>
+    </motion.article>
+  );
+}
+
+export function ProductStorySection() {
+  const { t } = useTranslation('landing');
+  const reducedMotion = useReducedMotion();
+
+  const headerMotion = reducedMotion
+    ? {}
+    : {
+        initial: { opacity: 0, y: 20 },
+        whileInView: { opacity: 1, y: 0 },
+        viewport: { once: true },
+        transition: { duration: 0.45 },
+      };
+
+  return (
+    <section
+      id="features"
+      className="container mx-auto px-6 py-16 md:py-24"
+      aria-labelledby="product-story-title"
+    >
+      <motion.div {...headerMotion} className="mx-auto mb-16 max-w-2xl text-center">
+        <h2 id="product-story-title" className="text-3xl font-bold tracking-tight md:text-4xl">
+          {t('productStory.title')}
+        </h2>
+        <p className="mt-4 text-muted-foreground md:text-lg">{t('productStory.subtitle')}</p>
+      </motion.div>
+
+      <div className="mx-auto max-w-5xl space-y-20 md:space-y-28">
+        {chapters.map((chapter, index) => (
+          <StoryChapter
+            key={chapter.key}
+            chapterKey={chapter.key}
+            preview={chapter.preview}
+            index={index}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/test/integration/landing-demo-flow.test.tsx
+++ b/apps/web/test/integration/landing-demo-flow.test.tsx
@@ -206,6 +206,7 @@ describe('Landing Page Demo Flow', () => {
     it('should render features grid', () => {
       renderLanding();
 
+      fireEvent.click(screen.getByRole('button', { name: /See all features/i }));
       expect(screen.getByText(/Multi-Provider Banking/i)).toBeInTheDocument();
       expect(screen.getByText(/DeFi & Web3/i)).toBeInTheDocument();
     });

--- a/apps/web/test/setup.ts
+++ b/apps/web/test/setup.ts
@@ -1,5 +1,27 @@
 import '@testing-library/jest-dom';
 
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root: Element | Document | null = null;
+  readonly rootMargin = '';
+  readonly thresholds: ReadonlyArray<number> = [];
+
+  constructor(private callback: IntersectionObserverCallback) {}
+
+  observe = (target: Element) => {
+    this.callback([{ isIntersecting: true, target } as IntersectionObserverEntry], this);
+  };
+
+  unobserve = jest.fn();
+  disconnect = jest.fn();
+  takeRecords = () => [];
+}
+
+Object.defineProperty(window, 'IntersectionObserver', {
+  writable: true,
+  configurable: true,
+  value: MockIntersectionObserver,
+});
+
 // Mock Next.js router
 jest.mock('next/router', () => ({
   useRouter: () => ({

--- a/packages/shared/src/i18n/en/landing.ts
+++ b/packages/shared/src/i18n/en/landing.ts
@@ -23,6 +23,46 @@ export const landing = {
     encryption: 'AES-256 encrypted',
     readOnly: 'Read-only bank access',
   },
+  productStory: {
+    title: 'One platform for every chapter of your financial life',
+    subtitle: 'From today’s balances to tomorrow’s probabilities — see it in Dhanam.',
+    chapter1: {
+      eyebrow: 'See everything',
+      title: 'Your full net worth — banks, crypto, property, and more',
+      description:
+        'Connect Belvo, Plaid, Bitso, Zapper, and manual assets. One dashboard shows what you own, where it lives, and how it moves.',
+    },
+    chapter2: {
+      eyebrow: 'Understand spending',
+      title: 'AI categorization that learns from your corrections',
+      description:
+        'Recurring bills, SPEI transfers, and subscription drift surface automatically. Review once — Dhanam remembers.',
+    },
+    chapter3: {
+      eyebrow: 'Plan with confidence',
+      title: 'Probabilistic planning, not static spreadsheets',
+      description:
+        'Run 10,000 Monte Carlo paths and 12 historical stress scenarios. Know the odds of hitting your goals — not just a best guess.',
+    },
+    chapter4: {
+      eyebrow: 'Grow together',
+      title: 'Yours, mine, and ours — without extra seats',
+      description:
+        'Household spaces with shared and private views. Couples and families stay aligned without juggling separate apps.',
+    },
+    chapter5: {
+      eyebrow: 'Protect what matters',
+      title: 'Estate planning with Life Beat',
+      description:
+        'Digital wills, encrypted document vault, and executor access that activates when it needs to — because planning is part of wealth.',
+    },
+    chapter6: {
+      eyebrow: 'Go deeper',
+      title: 'DeFi, collectibles, cashflow, and ESG — when you are ready',
+      description:
+        'Seven DeFi networks, collectible valuations, 60-day forecasts, and crypto ESG scores. Depth without switching tools.',
+    },
+  },
   personaCards: {
     title: 'Choose Your Adventure',
     subtitle: 'Explore Dhanam through a financial life like yours',
@@ -54,6 +94,8 @@ export const landing = {
   features: {
     title: 'Everything You Need to Manage Your Wealth',
     subtitle: 'Professional-grade tools for individuals and businesses',
+    showAll: 'See all features',
+    hideAll: 'Show less',
     feature1: {
       title: 'Multi-Provider Banking',
       description:
@@ -225,6 +267,12 @@ export const landing = {
     title: 'Traditional Apps Tell You Where Your Money Went.',
     titleHighlight: "Dhanam Tells You Where It's Going.",
     budgetTrackers: 'Budget Trackers',
+    row1Problem: 'Backward-looking only — no probability or stress tests',
+    row1Solution: 'Monte Carlo planning with 12 historical stress scenarios',
+    row2Problem: 'Banks only — no crypto, DeFi, collectibles, or property',
+    row2Solution: 'Unified wealth across banks, on-chain, real estate, and collectibles',
+    row3Problem: 'No household separation or estate continuity',
+    row3Solution: 'Yours / Mine / Ours spaces plus Life Beat estate planning',
     problem1: 'Static projections',
     problem2: 'No probability',
     problem3: "Can't stress test",

--- a/packages/shared/src/i18n/es/landing.ts
+++ b/packages/shared/src/i18n/es/landing.ts
@@ -23,6 +23,46 @@ export const landing = {
     encryption: 'Cifrado AES-256',
     readOnly: 'Acceso bancario de solo lectura',
   },
+  productStory: {
+    title: 'Una plataforma para cada capítulo de tu vida financiera',
+    subtitle: 'Desde los saldos de hoy hasta las probabilidades de mañana — en Dhanam.',
+    chapter1: {
+      eyebrow: 'Ver todo',
+      title: 'Tu patrimonio neto completo — bancos, cripto, propiedad y más',
+      description:
+        'Conecta Belvo, Plaid, Bitso, Zapper y activos manuales. Un panel muestra lo que tienes, dónde está y cómo se mueve.',
+    },
+    chapter2: {
+      eyebrow: 'Entender el gasto',
+      title: 'Categorización con IA que aprende de tus correcciones',
+      description:
+        'Facturas recurrentes, transferencias SPEI y suscripciones aparecen solas. Revisa una vez — Dhanam recuerda.',
+    },
+    chapter3: {
+      eyebrow: 'Planear con confianza',
+      title: 'Planificación probabilística, no hojas estáticas',
+      description:
+        'Ejecuta 10,000 rutas Monte Carlo y 12 escenarios de estrés históricos. Conoce las probabilidades de tus metas.',
+    },
+    chapter4: {
+      eyebrow: 'Crecer juntos',
+      title: 'Tuyo, mío y nuestro — sin asientos extra',
+      description:
+        'Espacios de hogar con vistas compartidas y privadas. Parejas y familias alineadas sin apps separadas.',
+    },
+    chapter5: {
+      eyebrow: 'Proteger lo importante',
+      title: 'Planificación patrimonial con Life Beat',
+      description:
+        'Testamentos digitales, bóveda cifrada y acceso de ejecutores cuando haga falta — porque planificar es parte del patrimonio.',
+    },
+    chapter6: {
+      eyebrow: 'Profundizar',
+      title: 'DeFi, coleccionables, flujo de caja y ESG — cuando quieras',
+      description:
+        'Siete redes DeFi, valuaciones de coleccionables, pronósticos a 60 días y puntajes ESG cripto. Profundidad sin cambiar de herramienta.',
+    },
+  },
   personaCards: {
     title: 'Elige Tu Aventura',
     subtitle: 'Explora Dhanam a través de una vida financiera como la tuya',
@@ -54,6 +94,8 @@ export const landing = {
   features: {
     title: 'Todo lo Que Necesitas para Administrar Tu Patrimonio',
     subtitle: 'Herramientas profesionales para personas y negocios',
+    showAll: 'Ver todas las funciones',
+    hideAll: 'Mostrar menos',
     feature1: {
       title: 'Banca Multi-Proveedor',
       description:
@@ -227,6 +269,12 @@ export const landing = {
     title: 'Las Apps Tradicionales Te Dicen a Dónde Fue Tu Dinero.',
     titleHighlight: 'Dhanam Te Dice a Dónde Va.',
     budgetTrackers: 'Apps de Presupuesto',
+    row1Problem: 'Solo miran al pasado — sin probabilidad ni pruebas de estrés',
+    row1Solution: 'Planificación Monte Carlo con 12 escenarios de estrés históricos',
+    row2Problem: 'Solo bancos — sin cripto, DeFi, coleccionables ni propiedad',
+    row2Solution: 'Patrimonio unificado: bancos, on-chain, bienes raíces y coleccionables',
+    row3Problem: 'Sin separación de hogar ni continuidad patrimonial',
+    row3Solution: 'Espacios Tuyo / Mío / Nuestro más planificación Life Beat',
     problem1: 'Proyecciones estáticas',
     problem2: 'Sin probabilidad',
     problem3: 'No se pueden hacer pruebas de estrés',

--- a/packages/shared/src/i18n/pt-BR/landing.ts
+++ b/packages/shared/src/i18n/pt-BR/landing.ts
@@ -23,6 +23,46 @@ export const landing = {
     encryption: 'Criptografia AES-256',
     readOnly: 'Acesso bancário somente leitura',
   },
+  productStory: {
+    title: 'Uma plataforma para cada capítulo da sua vida financeira',
+    subtitle: 'Dos saldos de hoje às probabilidades de amanhã — no Dhanam.',
+    chapter1: {
+      eyebrow: 'Ver tudo',
+      title: 'Seu patrimônio líquido completo — bancos, cripto, imóveis e mais',
+      description:
+        'Conecte Belvo, Plaid, Bitso, Zapper e ativos manuais. Um painel mostra o que você tem, onde está e como se move.',
+    },
+    chapter2: {
+      eyebrow: 'Entender gastos',
+      title: 'Categorização com IA que aprende com suas correções',
+      description:
+        'Contas recorrentes, transferências e assinaturas aparecem automaticamente. Revise uma vez — o Dhanam lembra.',
+    },
+    chapter3: {
+      eyebrow: 'Planejar com confiança',
+      title: 'Planejamento probabilístico, não planilhas estáticas',
+      description:
+        'Execute 10.000 caminhos Monte Carlo e 12 cenários de estresse históricos. Saiba as chances de atingir suas metas.',
+    },
+    chapter4: {
+      eyebrow: 'Crescer juntos',
+      title: 'Seu, meu e nosso — sem assentos extras',
+      description:
+        'Espaços familiares com visões compartilhadas e privadas. Casais e famílias alinhados sem apps separados.',
+    },
+    chapter5: {
+      eyebrow: 'Proteger o que importa',
+      title: 'Planejamento patrimonial com Life Beat',
+      description:
+        'Testamentos digitais, cofre criptografado e acesso de executores quando necessário — planejar faz parte do patrimônio.',
+    },
+    chapter6: {
+      eyebrow: 'Ir mais fundo',
+      title: 'DeFi, colecionáveis, fluxo de caixa e ESG — quando quiser',
+      description:
+        'Sete redes DeFi, avaliações de colecionáveis, previsões de 60 dias e scores ESG cripto. Profundidade sem trocar de ferramenta.',
+    },
+  },
   personaCards: {
     title: 'Escolha Sua Aventura',
     subtitle: 'Explore o Dhanam através de uma vida financeira como a sua',
@@ -54,6 +94,8 @@ export const landing = {
   features: {
     title: 'Tudo o Que Você Precisa para Gerenciar Seu Patrimônio',
     subtitle: 'Ferramentas profissionais para pessoas e negócios',
+    showAll: 'Ver todos os recursos',
+    hideAll: 'Mostrar menos',
     feature1: {
       title: 'Banco Multi-Provedor',
       description:
@@ -225,6 +267,12 @@ export const landing = {
     title: 'Os Apps Tradicionais Dizem Para Onde Seu Dinheiro Foi.',
     titleHighlight: 'O Dhanam Diz Para Onde Ele Vai.',
     budgetTrackers: 'Apps de Orçamento',
+    row1Problem: 'Só olham para o passado — sem probabilidade nem testes de estresse',
+    row1Solution: 'Planejamento Monte Carlo com 12 cenários históricos de estresse',
+    row2Problem: 'Só bancos — sem cripto, DeFi, colecionáveis ou imóveis',
+    row2Solution: 'Patrimônio unificado: bancos, on-chain, imóveis e colecionáveis',
+    row3Problem: 'Sem separação familiar nem continuidade patrimonial',
+    row3Solution: 'Espaços Seu / Meu / Nosso mais planejamento Life Beat',
     problem1: 'Projeções estáticas',
     problem2: 'Sem probabilidade',
     problem3: 'Não dá para fazer testes de estresse',


### PR DESCRIPTION
## Summary

- Adds `ProductStorySection` with six alternating chapters (net worth, spending, planning, household, estate, depth) and CSS dashboard mocks per chapter.
- Collapses `FeaturesGrid` behind "See all features"; compresses `ProblemSolution` to a 3-row comparison table.
- Migrates feature icon tiles to semantic design tokens; nav Features anchor points to `#features`.
- i18n for EN/ES/PT-BR; Jest `IntersectionObserver` mock for framer-motion scroll reveals.

## Test plan

- [x] Landing integration tests (15/15)
- [x] Pre-push hook (typecheck, lint, test, build)


Made with [Cursor](https://cursor.com)