### PR TITLE
feat(web): phase D persona cards with avatars and analytics

### DIFF
--- a/apps/web/src/components/landing/landing-page-client.tsx
+++ b/apps/web/src/components/landing/landing-page-client.tsx
@@ -84,7 +84,7 @@ export function LandingPageClient({
         </section>
 
         <div id="personas">
-          <PersonaCards />
+          <PersonaCards locale={locale} />
         </div>
         <ProductStorySection />
         <ProblemSolution />

--- a/apps/web/src/components/landing/persona-avatar.tsx
+++ b/apps/web/src/components/landing/persona-avatar.tsx
@@ -1,0 +1,62 @@
+import type { LandingPersonaKey } from '@/components/landing/persona-config';
+
+const avatarStyles: Record<LandingPersonaKey, { bg: string; accent: string; silhouette: string }> =
+  {
+    maria: {
+      bg: 'from-info/20 to-info/5',
+      accent: 'bg-info',
+      silhouette:
+        'M28 52c0-8 6-14 14-14s14 6 14 14v6H28v-6z M42 24a10 10 0 1 1 0 20 10 10 0 0 1 0-20z',
+    },
+    carlos: {
+      bg: 'from-success/20 to-success/5',
+      accent: 'bg-success',
+      silhouette:
+        'M26 54c0-7 7-12 16-12s16 5 16 12v4H26v-4z M42 22a11 11 0 1 1 0 22 11 11 0 0 1 0-22z M34 38h16v4H34z',
+    },
+    diego: {
+      bg: 'from-warning/25 to-primary/10',
+      accent: 'bg-warning',
+      silhouette:
+        'M24 56c0-8 8-14 18-14s18 6 18 14v2H24v-2z M42 20a12 12 0 1 1 0 24 12 12 0 0 1 0-24z M36 34l12 8-4 2-8-10z',
+    },
+    patricia: {
+      bg: 'from-primary/20 to-muted/30',
+      accent: 'bg-primary',
+      silhouette:
+        'M27 55c0-9 7-15 15-15s15 6 15 15v5H27v-5z M42 21a10 10 0 1 1 0 20 10 10 0 0 1 0-20z M38 40c4 2 8 2 12 0',
+    },
+    sofia: {
+      bg: 'from-info/15 to-warning/10',
+      accent: 'bg-info',
+      silhouette:
+        'M25 56c0-8 9-14 17-14s17 6 17 14v2H25v-2z M42 19a11 11 0 1 1 0 22 11 11 0 0 1 0-22z M30 36h24M36 32l6-4 6 4',
+    },
+    roberto: {
+      bg: 'from-success/15 to-info/10',
+      accent: 'bg-success',
+      silhouette:
+        'M26 54c0-7 8-13 16-13s16 6 16 13v6H26v-6z M42 22a10 10 0 1 1 0 20 10 10 0 0 1 0-20z M34 42h16v3H34z',
+    },
+  };
+
+interface PersonaAvatarProps {
+  persona: LandingPersonaKey;
+  className?: string;
+}
+
+export function PersonaAvatar({ persona, className = '' }: PersonaAvatarProps) {
+  const style = avatarStyles[persona];
+
+  return (
+    <div
+      className={`relative h-16 w-16 shrink-0 overflow-hidden rounded-2xl border border-border/60 bg-gradient-to-br shadow-sm ${style.bg} ${className}`}
+      aria-hidden
+    >
+      <span className={`absolute left-3 top-3 h-2 w-2 rounded-full ${style.accent} opacity-80`} />
+      <svg viewBox="0 0 84 84" className="absolute inset-0 h-full w-full" role="presentation">
+        <path d={style.silhouette} className="fill-foreground/75" />
+      </svg>
+    </div>
+  );
+}

--- a/apps/web/src/components/landing/persona-cards.tsx
+++ b/apps/web/src/components/landing/persona-cards.tsx
@@ -1,54 +1,94 @@
 'use client';
 
+import type { LandingLocale } from '@dhanam/shared';
 import { useTranslation } from '@dhanam/shared';
 import { Button } from '@dhanam/ui';
 import { ArrowRight } from 'lucide-react';
 
+import { PersonaAvatar } from '@/components/landing/persona-avatar';
+import {
+  landingPersonas,
+  resolveDemoPersonaKey,
+  type LandingPersonaKey,
+} from '@/components/landing/persona-config';
+import { ProductChapterPreview } from '@/components/landing/product-chapter-preview';
+import { useAnalytics } from '@/hooks/useAnalytics';
 import { usePublicAppUrl } from '@/hooks/usePublicSurface';
 import { buildAppDemoLaunchUrl } from '@/lib/demo/launch-demo';
 
-const personas = [
-  { key: 'maria' as const, emoji: '🧑‍💼' },
-  { key: 'carlos' as const, emoji: '🏪' },
-  { key: 'diego' as const, emoji: '🎮' },
-  { key: 'patricia' as const, emoji: '💎' },
-] as const;
+interface PersonaCardsProps {
+  locale: LandingLocale;
+}
 
-export function PersonaCards() {
+export function PersonaCards({ locale }: PersonaCardsProps) {
   const { t } = useTranslation('landing');
+  const analytics = useAnalytics();
   const appUrl = usePublicAppUrl();
 
+  const handlePersonaClick = (persona: LandingPersonaKey) => {
+    analytics.track('persona_card_clicked', { persona, locale });
+  };
+
   return (
-    <section className="container mx-auto px-6 py-16">
-      <div className="text-center mb-12">
-        <h2 className="text-3xl font-bold mb-4">{t('personaCards.title')}</h2>
-        <p className="text-muted-foreground">{t('personaCards.subtitle')}</p>
+    <section
+      className="container mx-auto px-6 py-16 md:py-24"
+      aria-labelledby="persona-cards-title"
+    >
+      <div className="mb-12 mx-auto max-w-2xl text-center">
+        <h2 id="persona-cards-title" className="mb-4 text-3xl font-bold tracking-tight md:text-4xl">
+          {t('personaCards.title')}
+        </h2>
+        <p className="text-muted-foreground md:text-lg">{t('personaCards.subtitle')}</p>
       </div>
 
-      <div className="max-w-5xl mx-auto grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
-        {personas.map((persona) => (
-          <div
-            key={persona.key}
-            className="rounded-lg border bg-card p-6 hover:shadow-lg transition-shadow flex flex-col"
-          >
-            <div className="text-3xl mb-3">{persona.emoji}</div>
-            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
-              {t(`personaCards.${persona.key}.archetype`)}
-            </p>
-            <p className="text-sm text-red-600 dark:text-red-400 mb-2">
-              {t(`personaCards.${persona.key}.pain`)}
-            </p>
-            <p className="text-sm font-medium mb-4 flex-1">
-              {t(`personaCards.${persona.key}.superpower`)}
-            </p>
-            <a href={buildAppDemoLaunchUrl(appUrl, persona.key)}>
-              <Button variant="outline" className="w-full gap-2" size="sm">
-                {t(`personaCards.${persona.key}.cta`)}
-                <ArrowRight className="h-3 w-3" />
-              </Button>
-            </a>
-          </div>
-        ))}
+      <div className="mx-auto grid max-w-6xl gap-5 sm:grid-cols-2 lg:grid-cols-3">
+        {landingPersonas.map((persona) => {
+          const demoKey = resolveDemoPersonaKey(persona.key);
+          const href = buildAppDemoLaunchUrl(appUrl, demoKey);
+
+          return (
+            <article
+              key={persona.key}
+              className="group relative flex flex-col overflow-hidden rounded-xl border bg-card p-5 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-primary/30 hover:shadow-lg motion-reduce:hover:translate-y-0"
+            >
+              <div className="mb-4 flex items-start gap-3">
+                <PersonaAvatar persona={persona.key} />
+                <div className="min-w-0 pt-1">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-primary">
+                    {t(`personaCards.${persona.key}.archetype`)}
+                  </p>
+                  <p className="mt-1 text-sm text-destructive/90 dark:text-destructive/80">
+                    {t(`personaCards.${persona.key}.pain`)}
+                  </p>
+                </div>
+              </div>
+
+              <p className="mb-5 flex-1 text-sm font-medium leading-relaxed">
+                {t(`personaCards.${persona.key}.superpower`)}
+              </p>
+
+              <a
+                href={href}
+                onClick={() => handlePersonaClick(persona.key)}
+                className="relative z-10 mt-auto"
+              >
+                <Button variant="outline" className="w-full gap-2" size="sm">
+                  {t(`personaCards.${persona.key}.cta`)}
+                  <ArrowRight className="h-3 w-3" aria-hidden />
+                </Button>
+              </a>
+
+              <div
+                className="pointer-events-none absolute inset-x-0 bottom-0 top-16 flex items-end justify-center bg-gradient-to-t from-card via-card/95 to-transparent p-3 opacity-0 transition-opacity duration-300 group-hover:opacity-100 group-focus-within:opacity-100 motion-reduce:group-hover:opacity-100"
+                aria-hidden
+              >
+                <div className="w-full max-w-[220px] origin-bottom scale-[0.72]">
+                  <ProductChapterPreview variant={persona.preview} />
+                </div>
+              </div>
+            </article>
+          );
+        })}
       </div>
     </section>
   );

--- a/apps/web/src/components/landing/persona-config.test.ts
+++ b/apps/web/src/components/landing/persona-config.test.ts
@@ -1,0 +1,13 @@
+import { resolveDemoPersonaKey } from '@/components/landing/persona-config';
+
+describe('resolveDemoPersonaKey', () => {
+  it('maps landing-only personas to live demo keys', () => {
+    expect(resolveDemoPersonaKey('sofia')).toBe('patricia');
+    expect(resolveDemoPersonaKey('roberto')).toBe('carlos');
+  });
+
+  it('passes through core demo personas', () => {
+    expect(resolveDemoPersonaKey('maria')).toBe('maria');
+    expect(resolveDemoPersonaKey('diego')).toBe('diego');
+  });
+});

--- a/apps/web/src/components/landing/persona-config.ts
+++ b/apps/web/src/components/landing/persona-config.ts
@@ -1,0 +1,23 @@
+import type { ChapterPreviewVariant } from '@/components/landing/product-chapter-preview';
+
+export type LandingPersonaKey = 'maria' | 'carlos' | 'diego' | 'patricia' | 'sofia' | 'roberto';
+
+export type DemoApiPersonaKey = 'maria' | 'carlos' | 'diego' | 'patricia';
+
+export function resolveDemoPersonaKey(persona: LandingPersonaKey): DemoApiPersonaKey {
+  if (persona === 'sofia') return 'patricia';
+  if (persona === 'roberto') return 'carlos';
+  return persona;
+}
+
+export const landingPersonas: {
+  key: LandingPersonaKey;
+  preview: ChapterPreviewVariant;
+}[] = [
+  { key: 'maria', preview: 'spending' },
+  { key: 'carlos', preview: 'household' },
+  { key: 'diego', preview: 'depth' },
+  { key: 'patricia', preview: 'planning' },
+  { key: 'sofia', preview: 'netWorth' },
+  { key: 'roberto', preview: 'spending' },
+];

--- a/apps/web/test/integration/landing-demo-flow.test.tsx
+++ b/apps/web/test/integration/landing-demo-flow.test.tsx
@@ -136,7 +136,9 @@ describe('Landing Page Demo Flow', () => {
     it('should render persona cards section', () => {
       renderLanding();
 
-      expect(screen.getByText(/Choose Your Adventure/i)).toBeInTheDocument();
+      expect(screen.getByText(/Which financial life sounds like yours/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Explore as Sofia/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Explore as Roberto/i })).toBeInTheDocument();
     });
 
     it('should render security trust section', () => {
@@ -166,6 +168,17 @@ describe('Landing Page Demo Flow', () => {
       fireEvent.click(demoButtons[0]!);
 
       expect(mockRedirectToAppDemo).toHaveBeenCalledWith('https://app.dhan.am');
+    });
+
+    it('should track persona_card_clicked when a persona CTA is clicked', () => {
+      renderLanding();
+
+      fireEvent.click(screen.getByRole('button', { name: /Explore as Maria/i }));
+
+      expect(mockAnalytics.track).toHaveBeenCalledWith('persona_card_clicked', {
+        persona: 'maria',
+        locale: 'en',
+      });
     });
   });
 

--- a/packages/shared/src/i18n/en/landing.ts
+++ b/packages/shared/src/i18n/en/landing.ts
@@ -64,8 +64,9 @@ export const landing = {
     },
   },
   personaCards: {
-    title: 'Choose Your Adventure',
-    subtitle: 'Explore Dhanam through a financial life like yours',
+    title: 'Which financial life sounds like yours?',
+    subtitle:
+      'Explore Dhanam through a story like yours — switch personas anytime in the live demo.',
     maria: {
       archetype: 'Young Professional',
       pain: 'Juggling 5 apps and still lost',
@@ -89,6 +90,18 @@ export const landing = {
       pain: "Static projections don't show probability",
       superpower: '10,000 simulations. 12 stress tests. Real odds.',
       cta: 'Explore as Patricia',
+    },
+    sofia: {
+      archetype: 'Cross-Border Professional',
+      pain: 'MXN, USD, and EUR scattered across borders',
+      superpower: 'Multi-currency net worth, FX-aware budgets, one home base.',
+      cta: 'Explore as Sofia',
+    },
+    roberto: {
+      archetype: 'Freelancer & Creator',
+      pain: 'Irregular income makes every month a guess',
+      superpower: 'Separate business space, cashflow forecast, tax-ready categories.',
+      cta: 'Explore as Roberto',
     },
   },
   features: {

--- a/packages/shared/src/i18n/es/landing.ts
+++ b/packages/shared/src/i18n/es/landing.ts
@@ -64,8 +64,9 @@ export const landing = {
     },
   },
   personaCards: {
-    title: 'Elige Tu Aventura',
-    subtitle: 'Explora Dhanam a través de una vida financiera como la tuya',
+    title: '¿Qué vida financiera se parece a la tuya?',
+    subtitle:
+      'Explora Dhanam con una historia como la tuya — cambia de persona cuando quieras en el demo.',
     maria: {
       archetype: 'Joven Profesional',
       pain: 'Malabarismo con 5 apps y aún perdida',
@@ -89,6 +90,18 @@ export const landing = {
       pain: 'Las proyecciones estáticas no muestran probabilidad',
       superpower: '10,000 simulaciones. 12 pruebas de estrés. Probabilidades reales.',
       cta: 'Explorar como Patricia',
+    },
+    sofia: {
+      archetype: 'Profesional Transfronterizo',
+      pain: 'MXN, USD y EUR repartidos entre fronteras',
+      superpower: 'Patrimonio multi-moneda, presupuestos con FX, una sola base.',
+      cta: 'Explorar como Sofia',
+    },
+    roberto: {
+      archetype: 'Freelancer y Creador',
+      pain: 'Ingresos irregulares hacen de cada mes una incógnita',
+      superpower: 'Espacio de negocio separado, flujo de caja y categorías listas para impuestos.',
+      cta: 'Explorar como Roberto',
     },
   },
   features: {

--- a/packages/shared/src/i18n/pt-BR/landing.ts
+++ b/packages/shared/src/i18n/pt-BR/landing.ts
@@ -64,8 +64,9 @@ export const landing = {
     },
   },
   personaCards: {
-    title: 'Escolha Sua Aventura',
-    subtitle: 'Explore o Dhanam através de uma vida financeira como a sua',
+    title: 'Qual vida financeira parece com a sua?',
+    subtitle:
+      'Explore o Dhanam com uma história como a sua — troque de persona a qualquer momento no demo.',
     maria: {
       archetype: 'Jovem Profissional',
       pain: 'Fazendo malabarismo com 5 apps e ainda perdida',
@@ -89,6 +90,18 @@ export const landing = {
       pain: 'Projeções estáticas não mostram probabilidade',
       superpower: '10.000 simulações. 12 testes de estresse. Probabilidades reais.',
       cta: 'Explorar como Patricia',
+    },
+    sofia: {
+      archetype: 'Profissional Transfronteiriço',
+      pain: 'MXN, USD e EUR espalhados entre fronteiras',
+      superpower: 'Patrimônio multi-moeda, orçamentos com FX, uma base só.',
+      cta: 'Explorar como Sofia',
+    },
+    roberto: {
+      archetype: 'Freelancer e Criador',
+      pain: 'Renda irregular torna cada mês uma incógnita',
+      superpower: 'Espaço de negócio separado, fluxo de caixa e categorias prontas para impostos.',
+      cta: 'Explorar como Roberto',
     },
   },
   features: {


### PR DESCRIPTION
## Summary

- Upgrades `PersonaCards` with SVG avatars, hover product previews, and a 3×2 grid layout.
- Adds Sofia (cross-border) and Roberto (freelancer) personas with EN/ES/PT-BR copy.
- Maps landing-only personas to live demo keys (Sofia→Patricia, Roberto→Carlos).
- Fires `persona_card_clicked` PostHog events with `{ persona, locale }`.

## Test plan

- [x] Landing integration tests (16/16)
- [x] `persona-config.test.ts` (2/2)
- [x] Pre-push hook (typecheck, lint, test, build)


Made with [Cursor](https://cursor.com)