### PR TITLE
feat(web): phase F landing conversion polish

### DIFF
--- a/apps/web/src/components/landing/final-cta.tsx
+++ b/apps/web/src/components/landing/final-cta.tsx
@@ -16,7 +16,8 @@ export function FinalCta({ onLiveDemoClick, onSignUpClick }: FinalCtaProps) {
     <section className="container mx-auto px-6 py-16">
       <div className="max-w-3xl mx-auto text-center bg-primary/5 rounded-2xl p-12 border border-primary/10">
         <h2 className="text-3xl md:text-4xl font-bold mb-4">{t('cta.title')}</h2>
-        <p className="text-lg text-muted-foreground mb-8">{t('cta.subtitle')}</p>
+        <p className="text-lg text-muted-foreground mb-4">{t('cta.subtitle')}</p>
+        <p className="text-sm font-medium text-primary mb-8">{t('cta.urgencyNote')}</p>
         <div className="flex flex-col sm:flex-row gap-4 justify-center">
           <Button size="lg" onClick={() => onSignUpClick()} className="gap-2">
             {t('cta.button')}

--- a/apps/web/src/components/landing/landing-nav.tsx
+++ b/apps/web/src/components/landing/landing-nav.tsx
@@ -92,7 +92,7 @@ export function LandingNav({ locale }: LandingNavProps) {
             <a href={`${appUrl}/login`}>
               <Button variant="ghost">{t('nav.login')}</Button>
             </a>
-            <a href={`${appUrl}/register`}>
+            <a href={`${appUrl}/register?plan=copilot_pro`}>
               <Button>{t('nav.getStarted')}</Button>
             </a>
           </div>
@@ -140,7 +140,7 @@ export function LandingNav({ locale }: LandingNavProps) {
                 {t('nav.login')}
               </Button>
             </a>
-            <a href={`${appUrl}/register`} className="w-full">
+            <a href={`${appUrl}/register?plan=copilot_pro`} className="w-full">
               <Button className="w-full">{t('nav.getStarted')}</Button>
             </a>
           </div>

--- a/apps/web/src/components/landing/pricing.tsx
+++ b/apps/web/src/components/landing/pricing.tsx
@@ -29,6 +29,7 @@ export function Pricing({ onSignUpClick }: PricingProps) {
   const { t } = useTranslation('landing');
   const [pricing, setPricing] = useState<PricingResponse | null>(null);
   const [geoCountry, setGeoCountry] = useState<string | undefined>();
+  const [billingPeriod, setBillingPeriod] = useState<'monthly' | 'annual'>('monthly');
 
   useEffect(() => {
     // Try to detect country from cookie or default to MX (LATAM-first; MXN is the
@@ -87,6 +88,21 @@ export function Pricing({ onSignUpClick }: PricingProps) {
     ? Math.round((recommendedTier.promoPrice ?? recommendedTier.monthlyPrice) * 100)
     : undefined;
 
+  const resolveDisplayPrice = (monthlyAmount: number) => {
+    if (billingPeriod === 'annual' && monthlyAmount > 0) {
+      return {
+        amount: monthlyAmount * 10,
+        suffix: '/yr',
+        equivalent: monthlyAmount * 10,
+      };
+    }
+    return { amount: monthlyAmount, suffix: '/mo', equivalent: null as number | null };
+  };
+
+  const showCoffeeAnchor =
+    (geoCountry === 'MX' || tiers.some((tier) => tier.currency === 'MXN')) &&
+    tiers.some((tier) => tier.id === 'copilot_pro' || tier.id === 'pro');
+
   return (
     <section className="container mx-auto px-6 py-16" id="pricing">
       <div className="max-w-6xl mx-auto">
@@ -106,6 +122,37 @@ export function Pricing({ onSignUpClick }: PricingProps) {
             Indicative pricing in MXN per month, anchored to the Tulana v0.1 ecosystem
             recommendation and subject to validation with real users.
           </p>
+
+          <div className="mt-6 inline-flex items-center rounded-full border bg-muted/40 p-1">
+            <button
+              type="button"
+              onClick={() => setBillingPeriod('monthly')}
+              className={`rounded-full px-4 py-2 text-sm font-medium transition-colors ${
+                billingPeriod === 'monthly'
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {t('pricing.billingMonthly')}
+            </button>
+            <button
+              type="button"
+              onClick={() => setBillingPeriod('annual')}
+              className={`rounded-full px-4 py-2 text-sm font-medium transition-colors ${
+                billingPeriod === 'annual'
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {t('pricing.billingAnnual')}
+            </button>
+          </div>
+          {billingPeriod === 'annual' && (
+            <p className="mt-2 text-xs font-medium text-success">{t('pricing.annualSave')}</p>
+          )}
+          {showCoffeeAnchor && billingPeriod === 'monthly' && (
+            <p className="mt-3 text-sm text-muted-foreground">{t('pricing.coffeeAnchor')}</p>
+          )}
         </div>
 
         <div className="grid md:grid-cols-3 gap-6">
@@ -116,6 +163,8 @@ export function Pricing({ onSignUpClick }: PricingProps) {
             // 'family_plus' is the highest consumer tier; 'premium' kept for back-compat.
             const isPremium = tier.id === 'family_plus' || tier.id === 'premium';
             const isFree = tier.monthlyPrice === 0 || tier.id === 'free';
+            const baseMonthly = tier.promoPrice ?? tier.monthlyPrice;
+            const display = resolveDisplayPrice(baseMonthly);
 
             return (
               <div
@@ -139,7 +188,7 @@ export function Pricing({ onSignUpClick }: PricingProps) {
                 )}
                 <h3 className="text-xl font-bold mb-2">{tier.name}</h3>
                 <div className="mb-4">
-                  {tier.promoPrice !== null ? (
+                  {tier.promoPrice !== null && billingPeriod === 'monthly' ? (
                     <>
                       <p className="text-3xl font-bold">
                         {formatPrice(tier.promoPrice, tier.currency)}
@@ -154,10 +203,21 @@ export function Pricing({ onSignUpClick }: PricingProps) {
                       </p>
                     </>
                   ) : (
-                    <p className="text-3xl font-bold">
-                      {formatPrice(tier.monthlyPrice, tier.currency)}
-                      <span className="text-sm font-normal text-muted-foreground">/mo</span>
-                    </p>
+                    <>
+                      <p className="text-3xl font-bold">
+                        {formatPrice(display.amount, tier.currency)}
+                        <span className="text-sm font-normal text-muted-foreground">
+                          {display.suffix}
+                        </span>
+                      </p>
+                      {billingPeriod === 'annual' &&
+                        display.equivalent !== null &&
+                        baseMonthly > 0 && (
+                          <p className="text-xs text-muted-foreground">
+                            {formatPrice(display.amount / 12, tier.currency)}/mo billed annually
+                          </p>
+                        )}
+                    </>
                   )}
                 </div>
                 <ul className="space-y-2 text-sm mb-6">

--- a/packages/shared/src/i18n/en/landing.ts
+++ b/packages/shared/src/i18n/en/landing.ts
@@ -228,6 +228,10 @@ export const landing = {
   pricing: {
     title: 'Plans for Every Stage',
     subtitle: 'Start free, grow into the tools you need',
+    billingMonthly: 'Monthly',
+    billingAnnual: 'Annual',
+    annualSave: 'Save ~17% · 2 months free',
+    coffeeAnchor: 'Copilot Pro from ~MX$50/week — less than two specialty coffees.',
     mostPopular: 'Most Popular',
     bestValue: 'Best Value',
     cancelAnytime: 'Cancel anytime',
@@ -401,6 +405,8 @@ export const landing = {
     title: 'Your Financial Life, Unified.',
     subtitle:
       "Whether you're Maria managing 5 accounts or Diego tracking 7 DeFi networks — start in 30 seconds.",
+    urgencyNote:
+      'Live demo sessions expire after 1 hour — explore the full product now, no signup.',
     button: 'Create Free Account',
     buttonSecondary: 'Try Live Demo',
   },

--- a/packages/shared/src/i18n/es/landing.ts
+++ b/packages/shared/src/i18n/es/landing.ts
@@ -229,6 +229,10 @@ export const landing = {
   pricing: {
     title: 'Planes para Cada Etapa',
     subtitle: 'Comienza gratis, crece con las herramientas que necesitas',
+    billingMonthly: 'Mensual',
+    billingAnnual: 'Anual',
+    annualSave: 'Ahorra ~17% · 2 meses gratis',
+    coffeeAnchor: 'Copilot Pro desde ~MX$50/semana — menos que dos cafés de especialidad.',
     mostPopular: 'Más Popular',
     bestValue: 'Mejor Valor',
     cancelAnytime: 'Cancela cuando quieras',
@@ -402,6 +406,8 @@ export const landing = {
     title: 'Tu Vida Financiera, Unificada.',
     subtitle:
       'Ya seas María administrando 5 cuentas o Diego rastreando 7 redes DeFi — comienza en 30 segundos.',
+    urgencyNote:
+      'Las sesiones demo expiran en 1 hora — explora el producto completo ahora, sin registro.',
     button: 'Crear Cuenta Gratis',
     buttonSecondary: 'Probar Demo en Vivo',
   },

--- a/packages/shared/src/i18n/pt-BR/landing.ts
+++ b/packages/shared/src/i18n/pt-BR/landing.ts
@@ -228,6 +228,10 @@ export const landing = {
   pricing: {
     title: 'Planos para Cada Etapa',
     subtitle: 'Comece grátis, cresça com as ferramentas que você precisa',
+    billingMonthly: 'Mensal',
+    billingAnnual: 'Anual',
+    annualSave: 'Economize ~17% · 2 meses grátis',
+    coffeeAnchor: 'Copilot Pro a partir de ~MX$50/semana — menos que dois cafés especiais.',
     mostPopular: 'Mais Popular',
     bestValue: 'Melhor Custo-Benefício',
     cancelAnytime: 'Cancele quando quiser',
@@ -400,6 +404,7 @@ export const landing = {
     title: 'Sua Vida Financeira, Unificada.',
     subtitle:
       'Seja você a Maria gerenciando 5 contas ou o Diego rastreando 7 redes DeFi — comece em 30 segundos.',
+    urgencyNote: 'Sessões demo expiram em 1 hora — explore o produto completo agora, sem cadastro.',
     button: 'Criar Conta Grátis',
     buttonSecondary: 'Testar Demo ao Vivo',
   },


### PR DESCRIPTION
## Summary

- Monthly/annual billing toggle with ~17% annual savings display.
- MX coffee/week price anchor for Copilot Pro on monthly view.
- Demo session urgency copy on final CTA.
- Nav Get Started links include `?plan=copilot_pro`.

## Test plan

- [x] Landing integration tests (16/16)
- [x] Pre-push hook green


Made with [Cursor](https://cursor.com)