### PR TITLE
docs: session wrap-up and prod rollout incident (2026-06-15)

### DIFF
--- a/docs/LANDING_REMEDIATION.md
+++ b/docs/LANDING_REMEDIATION.md
@@ -2,8 +2,9 @@
 
 **Version:** 1.0  
 **Date:** 2026-06-15  
-**Status:** Approved for execution  
-**Owner:** Dhanam product / web (Aureo Labs, a MADFAM company)
+**Status:** Phases A–G shipped to production (2026-06-15); ES hero copy fix #568 live  
+**Owner:** Dhanam product / web (Aureo Labs, a MADFAM company)  
+**Session handoff:** [SESSION_WRAP_UP_2026-06-15.md](SESSION_WRAP_UP_2026-06-15.md)
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@ live in `internal-devops` — paths listed in [Monetization Session](MONETIZATIO
 | [Deployment Guide](DEPLOYMENT.md)                                              | Enclii-first deploy, staging, rollback, current rollout blockers                    |
 | [Stability Audit 2026-05-19](STABILITY_AUDIT_2026-05-19.md)                    | Current truth about production, staging, DNS, health, and remaining stability gaps  |
 | [Stability Wrap-Up 2026-05-20](STABILITY_WRAP_UP_2026-05-20.md)                | Concise final status from the latest production-stability push                      |
+| [Session Wrap-Up 2026-06-15](SESSION_WRAP_UP_2026-06-15.md)                    | **Latest handoff** — landing Phases A–G live, ES copy, deploy gaps, next picks      |
 | [Tech Debt Register](TECH_DEBT.md)                                             | Current technical debt, active stability gaps, and historical debt archive          |
 | [Documentation Audit 2026-05-22](DOCUMENTATION_AUDIT_2026-05-22.md)            | Latest corpus audit: coverage, interconnection, remediation backlog                 |
 | [Documentation Audit 2026-05-19](DOCUMENTATION_AUDIT_2026-05-19.md)            | Prior audit (historical context)                                                    |
@@ -51,20 +52,21 @@ live in `internal-devops` — paths listed in [Monetization Session](MONETIZATIO
 
 ## Architecture And Operations
 
-| Document                                                | Use                                                                               |
-| ------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| [Architecture Overview](architecture/ARCHITECTURE.md)   | Current system shape: Next.js, NestJS, Postgres, Redis, Enclii, Cloudflare Tunnel |
-| [Software Specification](architecture/SOFTWARE_SPEC.md) | Product and technical specification; some infrastructure sections are historical  |
-| [Infrastructure Guide](INFRASTRUCTURE.md)               | Monitoring, admin, and infrastructure notes                                       |
-| [Launch Operations](LAUNCH_OPERATIONS.md)               | Launch checklist and operator tasks                                               |
-| [Backup And Restore](BACKUP_RESTORE.md)                 | Backup and restore runbooks                                                       |
-| [Admin Dashboard](ADMIN_DASHBOARD.md)                   | Admin app features and routes                                                     |
-| [Sentry Setup](SENTRY_SETUP.md)                         | Error monitoring setup                                                            |
-| [Catalog Truth 2026-05-20](CATALOG_TRUTH_2026-05-20.md) | Product catalog drift gate and production sync truth                              |
-| [Credential Onboarding](CREDENTIAL_ONBOARDING.md)       | Provider credential activation runbook                                            |
-| [PP.2 Staging Audit](PP_2_STAGING_AUDIT.md)             | Staging pipeline gap analysis (RFC 0001)                                          |
-| [Break-glass runbook](runbooks/BREAK_GLASS.md)          | Documented raw-access procedures when Enclii adapters are missing                 |
-| [Compliance appendix](../claudedocs/README.md)          | SOC2 / SRE historical procedures                                                  |
+| Document                                                                                                 | Use                                                                               |
+| -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| [Architecture Overview](architecture/ARCHITECTURE.md)                                                    | Current system shape: Next.js, NestJS, Postgres, Redis, Enclii, Cloudflare Tunnel |
+| [Software Specification](architecture/SOFTWARE_SPEC.md)                                                  | Product and technical specification; some infrastructure sections are historical  |
+| [Infrastructure Guide](INFRASTRUCTURE.md)                                                                | Monitoring, admin, and infrastructure notes                                       |
+| [Launch Operations](LAUNCH_OPERATIONS.md)                                                                | Launch checklist and operator tasks                                               |
+| [Backup And Restore](BACKUP_RESTORE.md)                                                                  | Backup and restore runbooks                                                       |
+| [Admin Dashboard](ADMIN_DASHBOARD.md)                                                                    | Admin app features and routes                                                     |
+| [Sentry Setup](SENTRY_SETUP.md)                                                                          | Error monitoring setup                                                            |
+| [Catalog Truth 2026-05-20](CATALOG_TRUTH_2026-05-20.md)                                                  | Product catalog drift gate and production sync truth                              |
+| [Credential Onboarding](CREDENTIAL_ONBOARDING.md)                                                        | Provider credential activation runbook                                            |
+| [PP.2 Staging Audit](PP_2_STAGING_AUDIT.md)                                                              | Staging pipeline gap analysis (RFC 0001)                                          |
+| [Break-glass runbook](runbooks/BREAK_GLASS.md)                                                           | Documented raw-access procedures when Enclii adapters are missing                 |
+| [Incident: dhanam-web prod rollout 2026-06-15](runbooks/incidents/2026-06-15-dhanam-web-prod-rollout.md) | Stale Argo sync after promote; post-promote dispatch required                     |
+| [Compliance appendix](../claudedocs/README.md)                                                           | SOC2 / SRE historical procedures                                                  |
 
 Production operations are Enclii-first. Raw `kubectl`, `helm`, provider CLIs,
 SSH, `docker exec`, or direct container access are break-glass/bootstrap only;

--- a/docs/SESSION_WRAP_UP_2026-06-15.md
+++ b/docs/SESSION_WRAP_UP_2026-06-15.md
@@ -1,0 +1,184 @@
+# Session Wrap-Up — 2026-06-15
+
+**Repos touched:** `madfam-org/dhanam`, `madfam-org/janua`  
+**Operator focus:** Dhanam landing program execution, Spanish copy go-live, Janua website prod rollout closure  
+**Read next session with:** [LANDING_REMEDIATION.md](LANDING_REMEDIATION.md), [DEPLOYMENT.md](DEPLOYMENT.md), [runbooks/BREAK_GLASS.md](runbooks/BREAK_GLASS.md)
+
+---
+
+## Executive summary
+
+This session shipped the full **Dhanam landing remediation program (Phases A–G)** to production, fixed and deployed **Spanish hero copy** (PR #568), and closed **Janua website** production rollout (Tailwind v4 + Phase 2–3 UX).
+
+Both products hit the same operational pattern: **git and GHCR were correct before the cluster rolled**. Production required explicit **ArgoCD hard refresh** (Dhanam) or **GHCR credential rotation + rollout** (Janua).
+
+---
+
+## Dhanam — production state (verified 2026-06-15)
+
+| Surface      | URL                        | Status                                                |
+| ------------ | -------------------------- | ----------------------------------------------------- |
+| Landing (ES) | https://dhan.am/es         | Live — hero: **“Descubre hacia dónde va tu dinero…”** |
+| Landing (EN) | https://dhan.am/en         | Live — Phases A–G shipped                             |
+| App          | https://app.dhan.am        | Unchanged routing (auth/dashboard)                    |
+| API          | https://api.dhan.am/health | Healthy                                               |
+| Admin        | https://admin.dhan.am      | On prod manifest digests                              |
+
+**Git:** `main` @ `f5f4cee2` — `deploy(prod): promote 2356f6e`
+
+**Production digests** (`infra/k8s/production/kustomization.yaml`):
+
+| Service      | Digest                                                                    |
+| ------------ | ------------------------------------------------------------------------- |
+| dhanam-web   | `sha256:f57893bcb4098ef5957cd64c5dfe74c4ec669655999af88ee8a5dfe4c3a52c8b` |
+| dhanam-api   | `sha256:296485c1b24201994bfefc25428726d1ace9f0f2b2172b8d9011ed815e46aa27` |
+| dhanam-admin | `sha256:45b85897626332c3f5fd5331db7256b9938c99d7869da9ef84b14b0e995633e9` |
+
+**ArgoCD:** Application `dhanam-services` — `Healthy` / `Synced` on `main` @ `f5f4cee2`
+
+**Quick verify:**
+
+```bash
+curl -fsSL https://dhan.am/es | grep -o 'Descubre hacia dónde va tu dinero'
+curl -fsSL https://dhan.am/en | grep -o 'Know where your money'
+```
+
+---
+
+## Dhanam — landing program status
+
+Canonical plan: [LANDING_REMEDIATION.md](LANDING_REMEDIATION.md)  
+Design tokens: [LANDING_DESIGN_SYSTEM.md](LANDING_DESIGN_SYSTEM.md)
+
+| Phase    | Scope                          | PR   | Prod promote |
+| -------- | ------------------------------ | ---- | ------------ |
+| A        | Foundation, SSR, dedupe, OG    | #547 | Yes          |
+| B        | Hero, nav, tokens, trust strip | #547 | Yes          |
+| C        | Product scroll story           | #548 | Yes          |
+| D        | Persona cards + avatars        | #549 | Yes          |
+| E        | Social proof, trust, logos     | #550 | Yes          |
+| F        | Conversion / pricing polish    | #551 | Yes          |
+| G        | A11y, fonts, scroll analytics  | #552 | Yes          |
+| Copy fix | ES hero `Sabe` → `Descubre`    | #568 | Yes          |
+
+**Program status:** Phases A–G and ES hero copy are **live on production**. Remaining work is polish and proof, not core IA:
+
+- ES / PT copy review (native speaker pass on new strings)
+- Dashboard screenshots for scroll-story chapters (Phase C assets)
+- Partner SVG logos + testimonial consent (Phase E assets)
+- Visual regression baseline refresh after font swap (Phase G)
+- Staging web smoke gap (`staging.dhan.am` may lag prod — known RFC 0001 item)
+
+---
+
+## Dhanam — deploy timeline (2026-06-15, Spanish copy)
+
+1. **#568 merged** — `c60776fc` / merge `9c7f73b8` — i18n hero fix
+2. **Staging** — workflow `Deploy to Staging` run **27577241820** — SUCCESS
+3. **Promote** — workflow `Promote staging -> prod` run **27577545018** — web only — SUCCESS → commit `f5f4cee2`
+4. **Post-promote** — run **27577844509** (manual `workflow_dispatch`) — manifest proof + Enclii callback OK; **GHA kubectl unreachable**
+5. **Cluster reconcile** — hard refresh `dhanam-services` via local `KUBECONFIG=~/.kube/config-hetzner`; `dhanam-web` rolled to `f57893bc…`
+6. **Verified** — https://dhan.am/es serves **Descubre…**
+
+Incident write-up: [runbooks/incidents/2026-06-15-dhanam-web-prod-rollout.md](runbooks/incidents/2026-06-15-dhanam-web-prod-rollout.md)
+
+---
+
+## Janua — production state (verified 2026-06-15)
+
+**Git:** `main` @ `53e7867e` (clean)
+
+**Live:** https://janua.dev — styled marketing site with Phase 2–3 UX (Sora/DM Sans, brand tokens, legal pages, honest blog)
+
+**ArgoCD app name:** `janua-services` (not `janua`)
+
+**Incident + runbook:**
+
+- [janua/docs/runbooks/incidents/2026-06-15-janua-website-prod-rollout.md](../../janua/docs/runbooks/incidents/2026-06-15-janua-website-prod-rollout.md)
+- [janua/docs/runbooks/production-gitops-reconcile.md](../../janua/docs/runbooks/production-gitops-reconcile.md)
+
+**Merged this session (Janua):** #419 (Tailwind v4), #420–#422 (promote/sync hardening), #423 (Phase 2–3 UX), #424 (CI ECR mirrors)
+
+---
+
+## Known platform gaps (carry forward)
+
+| ID       | Gap                                                                                            | Impact                                            | Mitigation today                                                                           |
+| -------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| TD-1004  | `promote-to-prod` pushes via `GITHUB_TOKEN` do **not** trigger `prod-post-promote.yml` on push | Post-promote skipped; cluster may lag git         | **Always** dispatch `prod-post-promote.yml` after promote, or hard-refresh Argo            |
+| TD-1004  | `KUBECONFIG_PRODUCTION` unreachable from GitHub-hosted runners                                 | Argo refresh job in CI is no-op                   | Use local/ARC kubeconfig or Enclii `ops apps sync dhanam-services`                         |
+| TD-1004  | ArgoCD can report **Synced** while pods still run old digest                                   | False confidence after promote                    | Run `scripts/production-rollout-proof.js dhanam-services` or compare pod image to manifest |
+| RFC 0001 | Staging web/admin smoke incomplete                                                             | `staging.dhan.am` not authoritative for marketing | Use prod curl checks after promote                                                         |
+| Catalog  | `prod-post-promote` catalog drift gate fails (informational)                                   | Non-blocking                                      | Run catalog sync when Production env secrets configured                                    |
+
+---
+
+## Operator cheat sheet — next promote
+
+Pattern B manual gate (`min_soak_minutes: 30`, `require_smoke_pass: true`).
+
+```bash
+# 1. Confirm staging smoke run id from latest green "Deploy to Staging" on main
+gh run list --workflow deploy-staging.yml --branch main --limit 3
+
+# 2. Promote (component: all | api | web | admin)
+gh workflow run promote-to-prod.yml \
+  -f component=web \
+  -f staging_smoke_run_id=<RUN_ID> \
+  -f reason="..."
+
+# 3. REQUIRED: post-promote (GITHUB_TOKEN push does not auto-trigger this)
+gh workflow run prod-post-promote.yml \
+  -f reason="Reconcile after promote ..."
+
+# 4. If live site lags git, hard refresh Argo (break-glass)
+export KUBECONFIG=~/.kube/config-hetzner   # or operator kubeconfig
+kubectl -n argocd annotate application dhanam-services \
+  argocd.argoproj.io/refresh=hard --overwrite
+kubectl -n dhanam rollout status deployment/dhanam-web --timeout=300s
+
+# 5. Proof
+node scripts/production-rollout-proof.js dhanam-services
+curl -fsSL https://dhan.am/es | grep -o 'Descubre hacia'
+```
+
+---
+
+## Suggested next-session picks
+
+**Product / landing (Dhanam)**
+
+1. ES/PT copy review for all new landing strings (not just hero)
+2. Capture Phase C dashboard screenshots; wire into scroll story
+3. Phase E assets — partner logos, testimonials with consent
+4. Playwright visual regression baseline after Fraunces/DM Sans (Phase G)
+5. PMF widget re-enable when `@madfam/pmf-widget` publishes (see AGENTS.md)
+
+**Platform / stability**
+
+1. Fix post-promote trigger: use `workflow_run` on `promote-to-prod` completion, or PAT push, so reconcile is automatic
+2. Wire `ENCLII_ROLLOUT_PROOF_ENABLED=true` + Enclii CLI on ARC runners
+3. Staging web smoke in `deploy-staging.yml` for marketing routes
+4. Commercial GA G2 proof ([COMMERCIAL_GA_EXECUTION.md](COMMERCIAL_GA_EXECUTION.md))
+
+**Janua**
+
+1. Add `GHCR_PAT` / `madfam-bot` to janua repo for reliable GHCR pulls (see Janua incident follow-ups)
+2. Mirror Dhanam `prod-post-promote.yml` pattern on janua repo
+
+---
+
+## Files created or updated this session
+
+| File                                                            | Purpose                                |
+| --------------------------------------------------------------- | -------------------------------------- |
+| `docs/LANDING_REMEDIATION.md`                                   | Canonical landing program (phases A–G) |
+| `docs/LANDING_DESIGN_SYSTEM.md`                                 | Typography, tokens, components         |
+| `docs/SESSION_WRAP_UP_2026-06-15.md`                            | This handoff                           |
+| `docs/runbooks/incidents/2026-06-15-dhanam-web-prod-rollout.md` | Dhanam stale-Argo incident             |
+| `packages/shared/src/i18n/es/landing.ts`                        | ES hero copy (#568)                    |
+| `docs/README.md`, `docs/DEVELOPMENT.md`, `llms.txt`             | Index links to landing docs            |
+
+---
+
+**Documented:** 2026-06-15

--- a/docs/runbooks/BREAK_GLASS.md
+++ b/docs/runbooks/BREAK_GLASS.md
@@ -1,6 +1,6 @@
 # Break-Glass Operations Runbook
 
-Last updated: 2026-05-22
+Last updated: 2026-06-15
 
 Routine production operations are **Enclii-first**. Use Enclii web, API, or CLI
 before any raw infrastructure access.
@@ -86,12 +86,26 @@ adapter unavailable.
 ### ArgoCD hard refresh
 
 **When:** Promote workflow succeeded but live digests lag ArgoCD source
-( observed 2026-05-20 ).
+(observed 2026-05-20 and 2026-06-15).
 
-**Break-glass:** Hard refresh `dhanam-services` Application, then run:
+**Symptoms:** ArgoCD Application `dhanam-services` reports `Synced` while
+`dhanam-web` pods still reference an older `@sha256:…` digest; public HTML
+unchanged after `deploy(prod):` commit.
+
+**Required after every promote:** Dispatch `prod-post-promote.yml` manually.
+The promote job pushes with `GITHUB_TOKEN`, which **does not trigger**
+downstream workflows on push. See
+[incident 2026-06-15](../runbooks/incidents/2026-06-15-dhanam-web-prod-rollout.md).
+
+**Break-glass:** Hard refresh `dhanam-services` Application, wait for rollout,
+then run:
 
 ```bash
-./scripts/production-rollout-proof.js
+export KUBECONFIG=~/.kube/config-hetzner   # operator kubeconfig
+kubectl -n argocd annotate application dhanam-services \
+  argocd.argoproj.io/refresh=hard --overwrite
+kubectl -n dhanam rollout status deployment/dhanam-web --timeout=300s
+node scripts/production-rollout-proof.js dhanam-services
 ```
 
 **Goal:** Eliminate this step via Phase 1 rollout truth work

--- a/docs/runbooks/incidents/2026-06-15-dhanam-web-prod-rollout.md
+++ b/docs/runbooks/incidents/2026-06-15-dhanam-web-prod-rollout.md
@@ -1,0 +1,97 @@
+# Incident: dhanam-web prod rollout lag (2026-06-15)
+
+> **Status:** Resolved  
+> **Severity:** P2 (marketing copy not live after promote)  
+> **Change:** PR [#568](https://github.com/madfam-org/dhanam/pull/568) — Spanish hero `Sabe` → `Descubre`  
+> **Operator runbook:** [BREAK_GLASS.md](../BREAK_GLASS.md) — ArgoCD hard refresh
+
+---
+
+## Summary
+
+`promote-to-prod.yml` succeeded and updated `infra/k8s/production/kustomization.yaml`
+with web digest `sha256:f57893bcb4098ef5957cd64c5dfe74c4ec669655999af88ee8a5dfe4c3a52c8b`,
+but **https://dhan.am/es continued serving the old headline** (“Sabe hacia dónde va…”)
+until ArgoCD `dhanam-services` was hard-refreshed and `dhanam-web` rolled out.
+
+Git was correct; the cluster had not adopted the new digest despite ArgoCD reporting
+**Synced** on an older revision until refresh.
+
+---
+
+## User-visible impact
+
+- Spanish landing hero unchanged for ~15 minutes after prod promote
+- English and other landing content from Phases A–G were already live from earlier promotes
+
+---
+
+## Root cause (two layers)
+
+### Layer 1 — Post-promote workflow not auto-triggered
+
+The promote job commits and pushes to `main` using `GITHUB_TOKEN`. GitHub Actions
+**does not trigger downstream workflows** on pushes made by `GITHUB_TOKEN`.
+
+`prod-post-promote.yml` is designed to run on that push but was **skipped** for
+commit `f5f4cee2`. Manual `workflow_dispatch` (run **27577844509**) was required.
+
+### Layer 2 — ArgoCD stale sync + GHA cluster unreachable
+
+After manual post-promote:
+
+- Enclii lifecycle callback succeeded
+- `argocd-refresh-best-effort` job could not reach the cluster API from GitHub-hosted runners
+- ArgoCD Application `dhanam-services` showed **Synced** while `dhanam-web` pods still ran
+  digest `sha256:43bbc533…` (previous prod web)
+
+Hard refresh from operator kubeconfig (`~/.kube/config-hetzner`) moved Argo to revision
+`f5f4cee2` and triggered rollout to `sha256:f57893bc…`.
+
+---
+
+## Resolution timeline (2026-06-15 UTC)
+
+1. **21:21** — #568 merged; staging deploy run **27577241820** SUCCESS
+2. **21:27** — Promote run **27577545018** SUCCESS → `f5f4cee2`
+3. **21:33** — Manual post-promote run **27577844509** SUCCESS (Enclii callback; GHA kubectl skipped)
+4. **~21:35** — Hard refresh `dhanam-services`; `dhanam-web` rollout complete
+5. **~21:36** — https://dhan.am/es verified: **“Descubre hacia dónde va tu dinero…”**
+
+---
+
+## Verification (post-fix)
+
+```bash
+curl -fsSL https://dhan.am/es | grep -o 'Descubre hacia dónde va tu dinero'
+
+export KUBECONFIG=~/.kube/config-hetzner
+kubectl -n dhanam get deployment dhanam-web \
+  -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+# ghcr.io/madfam-org/dhanam/web@sha256:f57893bcb4098ef5957cd64c5dfe74c4ec669655999af88ee8a5dfe4c3a52c8b
+```
+
+---
+
+## Follow-up actions
+
+| Priority | Action                                                                                           | Owner    |
+| -------- | ------------------------------------------------------------------------------------------------ | -------- |
+| P1       | Trigger post-promote via `workflow_run` on promote completion, or use PAT for promote push       | Platform |
+| P2       | Document mandatory post-promote dispatch in [DEPLOYMENT.md](../../DEPLOYMENT.md) promote section | Platform |
+| P2       | Enable rollout proof on ARC (`ENCLII_ROLLOUT_PROOF_ENABLED`, Enclii CLI)                         | Platform |
+| P3       | Compare live pod digest in promote workflow summary (automated)                                  | Platform |
+
+---
+
+## Lessons learned
+
+1. **Promote ≠ live** — Always verify running pod digest vs manifest after Pattern B promote.
+2. **Argo Synced can lie** — Hard refresh when git revision advanced but pods did not roll.
+3. **GITHUB_TOKEN push gap** — Post-promote must be explicit until trigger is fixed.
+4. **Enclii-first** — Lifecycle callback alone did not roll pods; Argo refresh was still required.
+
+---
+
+**Documented:** 2026-06-15  
+**Session handoff:** [SESSION_WRAP_UP_2026-06-15.md](../../SESSION_WRAP_UP_2026-06-15.md)

--- a/llms.txt
+++ b/llms.txt
@@ -37,6 +37,7 @@ when ops remediation is in scope; stay in dhanam for product/engineering work.
 - `docs/DOCUMENTATION_AUDIT_2026-05-22.md` — latest documentation corpus audit.
 - `docs/runbooks/BREAK_GLASS.md` — break-glass procedures when Enclii adapters are missing.
 - `docs/api/README.md` — OpenAPI export and API reference index.
+- `docs/SESSION_WRAP_UP_2026-06-15.md` — latest session handoff (landing live, deploy ops, next picks).
 - `docs/LANDING_REMEDIATION.md` — Dhanam marketing landing (`dhan.am`) UX remediation program.
 - `docs/LANDING_DESIGN_SYSTEM.md` — landing typography, tokens, components (Dhanam product vs MADFAM company).
 - `ECOSYSTEM.md` — MADFAM ecosystem and Enclii deployment context when present.


### PR DESCRIPTION
## Summary
- Add `docs/SESSION_WRAP_UP_2026-06-15.md` — session handoff (landing Phases A–G live, ES copy, deploy ops, next picks)
- Add incident runbook for stale Argo sync after promote (#568 ES hero rollout)
- Update `BREAK_GLASS.md`, `LANDING_REMEDIATION.md`, `docs/README.md`, and `llms.txt`

## Test plan
- [x] Docs-only change; pre-commit hooks passed locally
- [ ] CI lint on PR

Made with [Cursor](https://cursor.com)