### PR TITLE
docs: mark Phase 0 secret store mitigated

### DIFF
--- a/docs/MONETIZATION_PATH_READINESS.md
+++ b/docs/MONETIZATION_PATH_READINESS.md
@@ -1,6 +1,6 @@
 # Monetization-Path Readiness — Dhanam
 
-**Last Updated:** 2026-06-14  
+**Last Updated:** 2026-06-16  
 **Agent entrypoint:** [`MONETIZATION_SESSION.md`](MONETIZATION_SESSION.md) — read that
 file first for session routing and the private ops boundary.
 
@@ -40,6 +40,14 @@ are Phase 1, not the first transaction.
 - **Prisma `SubscriptionTier` comments corrected** to match catalog truth
   (essentials 4.99/79, pro 14.99/299, premium 29.99/599). Comment-only; no migration.
 
+## Shipped 2026-06-16 (platform ops — private record)
+
+- **Phase 0 secret store restored** — `dhanam-secrets` sync green, `dhanam-api`
+  **2/2**, `/health/full` healthy. Operator detail (Vault paths, break-glass steps):
+  `internal-devops/runbooks/2026-06-16-dhanam-secrets-recovery-session.md`.
+- **No dhanam repo change required** for Phase 0; durable Enclii ExternalSecret
+  manifests land in `enclii/infra/k8s/base/external-secrets/vault-secrets/`.
+
 ## Shipped 2026-06-14 (this repo)
 
 - **Production checkout funnel** — public, catalog-driven `/pricing` page + a
@@ -53,24 +61,21 @@ are Phase 1, not the first transaction.
 - **API hardened** — `strictNullChecks` enabled with 46 null-safety fixes (#525)
   and the TypeScript 6 upgrade on top (#526).
 
-> **Immediate gate (operational, not code):** a production secret-store
-> degradation is currently blocking new deploys, the catalog sync, and the
-> payment path (`dhanam-api` is serving on a single pod). Remediation and the
-> sequenced first-peso cutover are tracked privately in `internal-devops`:
-> `runbooks/MONETIZATION_OPS_SESSION.md` (ops entrypoint),
-> `runbooks/2026-06-13-dhanam-secrets-degradation-incident.md`, and
-> `runbooks/2026-06-14-dhanam-first-peso-cutover.md`. Unblocking is Vault/ESO +
-> Stripe-MX/BBVA provisioning — no repo change clears it.
+> **Immediate gate (operational, not code):** Phase 0 secret store **MITIGATED**
+> (2026-06-16). **Phase 1** is now the binding gate: Stripe MX KYC + BBVA payout,
+> then catalog sync and `FEATURE_STRIPE_MXN_LIVE`. Private sequencing:
+> `internal-devops/runbooks/2026-06-14-dhanam-first-peso-cutover.md` and
+> `runbooks/2026-06-16-dhanam-secrets-recovery-session.md`.
 
 ## Gates Dhanam owns (G0–G9)
 
-| Gate                     | Status | Dhanam action to close                                                                                  |
-| ------------------------ | ------ | ------------------------------------------------------------------------------------------------------- |
-| G0 Catalog truth         | Ready  | Keep `catalog.yaml` the single source; re-run `sync-catalog.ts` after the Free tier                     |
-| G1 Pricing evidence      | Ready  | Apply Tulana proposals (see `tulana/docs/dhanam-pricing-readiness-2026-06-13.md`)                       |
-| G5 Live checkout         | OPEN   | UI shipped (#522); flip `FEATURE_STRIPE_MXN_LIVE` after Stripe MX live + secret restore (runbook below) |
-| G6 Payment + ledger      | OPEN   | Prove one idempotent `BillingEvent` per payment, no duplicate revenue                                   |
-| G7 Entitlement + fan-out | OPEN   | Activate paid tier/credits + signed product webhook; close Karafiel CFDI staging proof (TD-1010)        |
+| Gate                     | Status | Dhanam action to close                                                                                       |
+| ------------------------ | ------ | ------------------------------------------------------------------------------------------------------------ |
+| G0 Catalog truth         | Ready  | Keep `catalog.yaml` the single source; re-run `sync-catalog.ts` after the Free tier                          |
+| G1 Pricing evidence      | Ready  | Apply Tulana proposals (see `tulana/docs/dhanam-pricing-readiness-2026-06-13.md`)                            |
+| G5 Live checkout         | OPEN   | UI shipped (#522); flip `FEATURE_STRIPE_MXN_LIVE` after Stripe MX live (Phase 0 secrets **done** 2026-06-16) |
+| G6 Payment + ledger      | OPEN   | Prove one idempotent `BillingEvent` per payment, no duplicate revenue                                        |
+| G7 Entitlement + fan-out | OPEN   | Activate paid tier/credits + signed product webhook; close Karafiel CFDI staging proof (TD-1010)             |
 
 (G2–G4 Selva/PhyndCRM, G8 BBVA, G9 Converge are owned outside this repo.)
 

--- a/docs/MONETIZATION_SESSION.md
+++ b/docs/MONETIZATION_SESSION.md
@@ -1,6 +1,6 @@
 # Monetization Session — Agent Entrypoint
 
-**Last Updated:** 2026-06-14  
+**Last Updated:** 2026-06-16  
 **Scope:** Open **dhanam alone** for monetization engineering. This file is the
 single in-repo routing index — read it before GA/stability docs unless the task
 is explicitly stability-only.
@@ -68,17 +68,18 @@ Routine production cutover, Vault/ESO remediation, and cross-repo sequencing liv
 in **`internal-devops`**. Open that repo (alone or beside dhanam) when the session
 touches Phase 0 platform blockers or operator cutover — not for app feature work.
 
-| Aspect                             | Canonical private path                                                       |
-| ---------------------------------- | ---------------------------------------------------------------------------- |
-| **Private ops session entrypoint** | `internal-devops/runbooks/MONETIZATION_OPS_SESSION.md`                       |
-| Cross-repo first-peso sequencing   | `internal-devops/roadmaps/2026-06-13-first-pesos-execution-roadmap.md`       |
-| Operator cutover (Phases 0–5)      | `internal-devops/runbooks/2026-06-14-dhanam-first-peso-cutover.md`           |
-| Secret-store degradation (OPEN)    | `internal-devops/runbooks/2026-06-13-dhanam-secrets-degradation-incident.md` |
-| Full ecosystem money architecture  | `internal-devops/ecosystem/monetization-architecture-2026-04-26.md`          |
+| Aspect                               | Canonical private path                                                                       |
+| ------------------------------------ | -------------------------------------------------------------------------------------------- |
+| **Private ops session entrypoint**   | `internal-devops/runbooks/MONETIZATION_OPS_SESSION.md`                                       |
+| Cross-repo first-peso sequencing     | `internal-devops/roadmaps/2026-06-13-first-pesos-execution-roadmap.md`                       |
+| Operator cutover (Phases 0–5)        | `internal-devops/runbooks/2026-06-14-dhanam-first-peso-cutover.md`                           |
+| Secret-store degradation             | `internal-devops/runbooks/2026-06-13-dhanam-secrets-degradation-incident.md` (**MITIGATED**) |
+| Phase 0 recovery record (2026-06-16) | `internal-devops/runbooks/2026-06-16-dhanam-secrets-recovery-session.md`                     |
+| Full ecosystem money architecture    | `internal-devops/ecosystem/monetization-architecture-2026-04-26.md`                          |
 
-**Phase 0 gate (2026-06-14):** `vault-store` ClusterSecretStore validation failure
-blocks full `dhanam-secrets` sync, new deploys, catalog sync, and live checkout.
-No dhanam repo change clears this — fix Vault/ESO first (private runbook above).
+**Phase 0 gate (2026-06-16):** Secret store **restored** — `dhanam-api` 2/2,
+`/health/full` green. **Phase 1** (Stripe MX KYC + BBVA payout) is the next gate.
+Private detail: `internal-devops/runbooks/2026-06-16-dhanam-secrets-recovery-session.md`.
 
 ## Adjacent repos (pull in only when needed)
 

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -247,18 +247,19 @@ Fixes shipped:
 
 ### TD-1016: Vault Extended Secret Backfill
 
-**Status:** Active
+**Status:** MITIGATED (2026-06-16) — cluster sync green; optional keys deferred
 
-The git-managed `dhanam-secrets` ExternalSecret is **deferred from kustomization**
-because `vault-store` cannot read `secret/dhanam` (`SecretSyncedError`). Until
-Enclii Lockbox backfill restores Vault read access:
+`vault-store` reads `secret/dhanam` again after Vault rebuild + Path B ES trim.
+Enclii canonical manifests: `enclii/infra/k8s/base/external-secrets/vault-secrets/dhanam-secrets.yaml`
 
-- `dhanam-ecosystem-service-auth` (platform ES) continues merging into
-  `dhanam-secrets`.
-- Retained secret keys from the last good sync remain in the cluster.
-- `external-secret.yaml` (core) and `external-secret-extended.yaml` (integration
-  keys) stay in-repo as the target contract; re-add to `kustomization.yaml` after
-  Vault proof.
+- `dhanam-secrets-extended.yaml` (Merge into same K8s Secret). Private record:
+  `internal-devops/runbooks/2026-06-16-dhanam-secrets-recovery-session.md`.
+
+Remaining:
+
+- Dhanam repo `external-secret*.yaml` still deferred from kustomization (Enclii owns ES).
+- Optional keys (R2, Cloudflare, Sentry) via `dhanam/app-infra` intake when needed.
+- Deprecate SendGrid/SMTP after platform Resend cutover.
 
 ## Recently Closed Debt
 

--- a/llms.txt
+++ b/llms.txt
@@ -15,9 +15,10 @@ When the goal is first revenue, checkout, billing, catalog, or entitlements:
 - `apps/api/src/modules/billing/README.md` — billing module (checkout, ledger, webhooks).
 - `docs/TECH_DEBT.md` — active debt (TD-1009, TD-1010, TD-1014).
 
-Phase 0 platform blockers (Vault/`dhanam-secrets`, operator cutover) are tracked in
-`internal-devops` — see paths in `docs/MONETIZATION_SESSION.md`. Open that repo
-when ops remediation is in scope; stay in dhanam for product/engineering work.
+Phase 0 platform blockers **MITIGATED 2026-06-16** — see
+`internal-devops/runbooks/2026-06-16-dhanam-secrets-recovery-session.md`.
+Phase 1 (Stripe MX + BBVA) is the next gate. Open `internal-devops` for operator
+cutover; stay in dhanam for product/engineering work.
 
 ## General read order
 


### PR DESCRIPTION
## Summary
- Update monetization session docs to reflect Phase 0 MITIGATED (2026-06-16)
- TD-1016 marked mitigated; Phase 1 Stripe/BBVA is the next gate

## Test plan
- [x] Docs only — pre-commit typecheck passed

Made with [Cursor](https://cursor.com)